### PR TITLE
add action http_post for simple webhooks

### DIFF
--- a/zentral/core/actions/backends/http_post.py
+++ b/zentral/core/actions/backends/http_post.py
@@ -1,0 +1,20 @@
+import json
+import requests
+from .base import BaseAction
+
+
+class Action(BaseAction):
+    def trigger(self, event, probe, action_config_d):
+        action_config_d = action_config_d or {}
+        url = self.config_d["url"]
+        auth = None
+        if "basic_auth" in self.config_d:
+            auth = (self.config_d["basic_auth"]["login"],
+                    self.config_d["basic_auth"]["password"])
+        headers = {'Accept': 'application/json'}
+        headers.update(self.config_d.get("headers", {}))
+        r = requests.post(url,
+                          auth=auth,
+                          headers=headers,
+                          data=json.dumps(event.serialize()))
+        r.raise_for_status()


### PR DESCRIPTION
#### base.json example
 ```json
   "requestbin": {
      "backend": "zentral.core.actions.backends.http_post",
      "url": "http://requestb.in/11bt1tq1",
      "basic_auth": {
          "login": "yo_login",
          "password": "yo_pass"
      },
      "headers": {"X-Booom": "kaboom"}
    }
```
#### probe example
```yaml
name: Inventory group change
metadata_filters:
  - type: inventory_group_update
actions:
  requestbin:
````

