### PR TITLE
Update osquery enrollment package postinstall script to fix permissions on plist.

### DIFF
--- a/zentral/contrib/osquery/osx_package/build.tmpl/scripts/postinstall
+++ b/zentral/contrib/osquery/osx_package/build.tmpl/scripts/postinstall
@@ -7,4 +7,8 @@
 ## write zentral base url
 /usr/bin/defaults write /Library/Preferences/io.zentral.plist base_url "https://%TLS_HOSTNAME%"
 
+## Correct invalid permissions on "/Library/LaunchDaemons/com.facebook.osqueryd.plist".
+chown root:wheel "/Library/LaunchDaemons/com.facebook.osqueryd.plist"
+chmod 700 "/Library/LaunchDaemons/com.facebook.osqueryd.plist"
+
 exit 0


### PR DESCRIPTION
The current osquery enrollment package installs the "/Library/LaunchDaemons/com.facebook.osqueryd.plist" file with invalid permissions. This causes launchctl to fail to load "/Library/LaunchDaemons/com.facebook.osqueryd.plist" also causing the following error message in the system log: Caller specified a plist with bad ownership/permissions: path = /Library/LaunchDaemons/com.facebook.osqueryd.plist, caller = launchctl.89355.

I've added two lines of code to fix the permission issue.