### PR TITLE
Added machine owner to santa config

### DIFF
--- a/zentral/contrib/santa/osx_package/build.tmpl/root/var/db/santa/config.plist
+++ b/zentral/contrib/santa/osx_package/build.tmpl/root/var/db/santa/config.plist
@@ -6,6 +6,8 @@
 	<integer>%MODE%</integer>
 	<key>MachineID</key>
 	<string>%MACHINE_ID%</string>
+	<key>MachineOwner</key>
+	<string>%MACHINE_OWNER%</string>
 	<key>SyncBaseURL</key>
 	<string>https://%TLS_HOSTNAME%/santa/</string>
 </dict>

--- a/zentral/contrib/santa/osx_package/build.tmpl/scripts/postinstall
+++ b/zentral/contrib/santa/osx_package/build.tmpl/scripts/postinstall
@@ -4,9 +4,13 @@
 ## detect client device serial_number
 SERIAL_NUMBER=$(/usr/sbin/system_profiler SPHardwareDataType | awk '/Serial/ {print $4}')
 MACHINE_ID="%API_SECRET%\$SERIAL\$${SERIAL_NUMBER}"
+MACHINE_OWNER=$(/usr/bin/whoami)
 
 ## set machine_id
 /usr/bin/sed -i -e "s/%MACHINE_ID%/$MACHINE_ID/" /var/db/santa/config.plist
+
+## set machine_owner
+/usr/bin/sed -i -e "s/%MACHINE_OWNER%/$MACHINE_OWNER/" /var/db/santa/config.plist
 
 ## load com.google.santad.plist
 /bin/launchctl load -w "/Library/LaunchDaemons/com.google.santad.plist"  >/dev/null 2>&1


### PR DESCRIPTION
When performing ```santactl sync``` a MachineOwner is required in the config.plist for the sync to start.