### PR TITLE
osquery now uses plist (compliance queries)

### DIFF
--- a/tests/osquery/test_osquery_compliance_probe.py
+++ b/tests/osquery/test_osquery_compliance_probe.py
@@ -41,7 +41,7 @@ class OsqueryComplianceProbeTestCase(TestCase):
         cls.query_pfu_query = (
             "select username, filename, key, value from "
             "(select * from users where directory like '/Users/%') u, "
-            "preferences p, file f "
+            "plist p, file f "
             "WHERE ("
             "(p.path like u.directory || '/Library/Preferences/%onepassword4%') or "
             "(p.path like u.directory || '/Library/Preferences/%/%onepassword4%')"
@@ -65,7 +65,7 @@ class OsqueryComplianceProbeTestCase(TestCase):
         # probe global preference file
         cls.query_pfg_query = (
             "select filename, key, value from "
-            "preferences p, file f "
+            "plist p, file f "
             "WHERE ("
             "(p.path = '/Library/Preferences/Bluetooth')"
             ") and ("

--- a/zentral/contrib/osquery/probes/osquery_compliance.py
+++ b/zentral/contrib/osquery/probes/osquery_compliance.py
@@ -80,7 +80,7 @@ class PreferenceFile(object):
                 "select username, filename, key, value "
                 "from "
                 "(select * from users where directory like '/Users/%') u, "
-                "preferences p, "
+                "plist p, "
                 "file f "
                 "WHERE "
                 "({rel_path_tests}) and ({key_tests}) "
@@ -90,7 +90,7 @@ class PreferenceFile(object):
             query_template = (
                 "select filename, key, value "
                 "from "
-                "preferences p, file f "
+                "plist p, file f "
                 "WHERE "
                 "({rel_path_tests}) and ({key_tests}) "
                 "and f.path = p.path"


### PR DESCRIPTION
osquery> select filename, key, value from preferences p, file f WHERE ((p.path = '/Library/Preferences/com.apple.loginwindow.plist')) and f.path = p.path;
Error: no such column: p.path

preferences no longer has `path` key. osquery uses `plist` now