### PR TITLE
update prometheus.yml to support prometheus 2

### DIFF
--- a/conf/start/docker/prometheus/Dockerfile
+++ b/conf/start/docker/prometheus/Dockerfile
@@ -1,7 +1,7 @@
 FROM    prom/prometheus
 ADD     prometheus.yml /etc/prometheus/
-CMD     [ "-config.file=/etc/prometheus/prometheus.yml", \
-          "-storage.local.path=/prometheus", \
-          "-web.console.libraries=/etc/prometheus/console_libraries", \
-          "-web.console.templates=/etc/prometheus/consoles", \
-          "-web.external-url=https://zentral/prometheus/" ]
+CMD     [ "--config.file=/etc/prometheus/prometheus.yml", \
+          "--storage.tsdb.path=/prometheus", \
+          "--web.console.libraries=/etc/prometheus/console_libraries", \
+          "--web.console.templates=/etc/prometheus/consoles", \
+          "--web.external-url=https://zentral/prometheus/" ]


### PR DESCRIPTION
Currently the docker-compose image does not pin the prometheus version.  The current `prometheus.yml` is not compatible with the prometheus version.  This PR fixes the problem and ensure that everything comes up when you execute the command `docker-compose up -d`.