### PR TITLE
add support for Docker containers

### DIFF
--- a/zentral/contrib/osquery/linux_script/template.sh
+++ b/zentral/contrib/osquery/linux_script/template.sh
@@ -10,6 +10,10 @@ get_do_instance_id () {
   curl -s --connect-timeout 2 http://169.254.169.254/metadata/v1/id
 }
 
+get_docker_instance_id () {
+  cat /proc/self/cgroup | grep "docker" | sed s/\\//\\n/g | tail -1 | cut -c-12
+}
+
 get_ec2_instance_id () {
   curl -s --connect-timeout 2 http://169.254.169.254/latest/meta-data/instance-id
 }
@@ -28,6 +32,8 @@ get_machine_id () {
     MACHINE_ID=$(get_watchman_id)
   elif get_do_instance_id; then
     MACHINE_ID="DO-$(get_do_instance_id)"
+  elif get_docker_instance_id; then
+    MACHINE_ID="DKR-$(get_docker_instance_id)"
   elif get_ec2_instance_id; then
     MACHINE_ID="EC2-$(get_ec2_instance_id)"
   elif get_gce_instance_id; then


### PR DESCRIPTION
During my testing i utilized docker instances running ubuntu 16.04, and 14.04 it would fail because it failed to set a MACHINE_ID.  

This patch adds support for docker containers to the linux script ( `template.sh` )