### PR TITLE
Resolve: XSS bug in TAG field

### DIFF
--- a/zentral/contrib/inventory/forms.py
+++ b/zentral/contrib/inventory/forms.py
@@ -6,6 +6,7 @@ from zentral.utils.forms import validate_sha256
 from .models import (MachineSnapshot, MachineTag, MetaMachine,
                      MetaBusinessUnit, MetaBusinessUnitTag,
                      Source, Tag)
+from django.core.validators import RegexValidator
 
 
 class MachineSearchForm(forms.Form):
@@ -85,8 +86,9 @@ class MBUAPIEnrollmentForm(forms.ModelForm):
 
 
 class AddTagForm(forms.Form):
+    alphanumeric_validator = RegexValidator(r'^[-0-9a-zA-Z_]*$', 'Only alphanumeric and _,- characters are allowed.')
     existing_tag = forms.ModelChoiceField(label="existing tag", queryset=Tag.objects.none(), required=False)
-    new_tag_name = forms.CharField(label="new tag name", max_length=50, required=False)
+    new_tag_name = forms.CharField(label="new tag name", max_length=50, required=False, validators=[alphanumeric_validator])
     new_tag_color = forms.CharField(label="color", max_length=6, required=False)
 
     def clean(self):

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -22,6 +22,7 @@ from .conf import (has_deb_packages,
                    PLATFORM_CHOICES, PLATFORM_CHOICES_DICT,
                    TYPE_CHOICES, TYPE_CHOICES_DICT)
 from .exceptions import EnrollmentSecretVerificationFailed
+from django.core.validators import RegexValidator
 
 logger = logging.getLogger('zentral.contrib.inventory.models')
 
@@ -584,8 +585,9 @@ def validate_color(value):
 
 
 class Tag(models.Model):
+    alphanumeric_validator = RegexValidator(r'^[-0-9a-zA-Z_]*$', 'Only alphanumeric and _,- characters are allowed.')
     meta_business_unit = models.ForeignKey(MetaBusinessUnit, blank=True, null=True)
-    name = models.CharField(max_length=50, unique=True)
+    name = models.CharField(max_length=50, unique=True, validators=[alphanumeric_validator])
     slug = models.SlugField(unique=True)
     color = models.CharField(max_length=6,
                              default="0079bf",  # blue from UpdateTagView


### PR DESCRIPTION
Add whitelisting characters only to prevent XSS bug in "create new tag"
field. New tag can be created by going into the list of machines and
then select any perticular machine and click on "manage tags" or by
clicking direclty into "Inventories" and go to "Tags" fields