### PR TITLE
Better solution for custom error pages

### DIFF
--- a/conf/mdm/docker/nginx/conf.d/zentral.conf
+++ b/conf/mdm/docker/nginx/conf.d/zentral.conf
@@ -50,11 +50,4 @@ server {
                 proxy_set_header   X-Url-Scheme     $scheme;
                 client_max_body_size 10m;
 	}
-
-        error_page   500  /500.html;
-        error_page   503  /503.html;
-        error_page   502 504 /50x.html;
-        location ~ ^/50[03x].html$ {
-		root /home/zentral/server/templates/;
-        }
 }

--- a/conf/start/docker/nginx/conf.d/zentral.conf
+++ b/conf/start/docker/nginx/conf.d/zentral.conf
@@ -63,11 +63,4 @@ server {
                 proxy_set_header   X-Url-Scheme     $scheme;
                 client_max_body_size 10m;
 	}
-
-        error_page   500  /500.html;
-        error_page   503  /503.html;
-        error_page   502 504 /50x.html;
-        location ~ ^/50[03x].html$ {
-		root /home/zentral/server/templates/;
-        }
 }

--- a/server/base/management/commands/build_custom_error_pages.py
+++ b/server/base/management/commands/build_custom_error_pages.py
@@ -1,0 +1,31 @@
+import logging
+import os
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.template.loader import get_template
+
+
+logger = logging.getLogger("zentral.server.base.management.commands.build_custom_error_pages")
+
+
+class Command(BaseCommand):
+    help = 'Build custom error pages'
+    errors = (
+      (404, "Not Found"),
+      (500, "Internal Server Error"),
+      (502, "Bad Gateway"),
+      (503, "Service Unavailable"),
+      (504, "Gateway Timeout"),
+    )
+
+    def handle(self, *args, **options):
+        template = get_template("custom_error_page.html")
+        basedir = os.path.join(settings.STATIC_ROOT, "custom_error_pages")
+        os.makedirs(basedir, exist_ok=True)
+        for status_code, message in self.errors:
+            page_content = template.render({
+                "status_code": status_code,
+                "message": message,
+            })
+            with open(os.path.join(basedir, f"{status_code}.html"), "w") as f:
+                f.write(page_content)

--- a/server/templates/custom_error_page.html
+++ b/server/templates/custom_error_page.html
@@ -1,0 +1,5 @@
+{% extends 'base_error.html' %}
+
+{% block content %}
+<h2>{{ status_code }} - {{ message }}</h2>
+{% endblock %}


### PR DESCRIPTION
Add build_custom_error_pages management command to render correct html
error pages that can be used by the HTTP proxy, when the application is
failing.
Remove buggy nginx error_page docker configurations. The new pages are
not configured, because they need to be built before they can be used.
It could be done in the docker-entrypoint, but the web app start is
already slow enough. PRs welcomed!