### PR TITLE
Clean Jamf API client IP addresses

### DIFF
--- a/tests/inventory/test_clean_ip_address.py
+++ b/tests/inventory/test_clean_ip_address.py
@@ -1,0 +1,19 @@
+from django.test import SimpleTestCase
+from zentral.contrib.inventory.utils import clean_ip_address
+
+
+class CleanIPAddressTestCase(SimpleTestCase):
+    def test_ipv4(self):
+        for value, result in ((None, None),
+                              (123, None),
+                              ("127.0.0.1 ", "127.0.0.1"),
+                              (" 10.12.13.17 ", "10.12.13.17"),
+                              ("127.0000.0.1", None)):
+            self.assertEqual(clean_ip_address(value), result)
+
+    def test_ipv6(self):
+        for value, result in (("0:0:0:0:0:0:0:1", "::1"),
+                              ("2001:db8::1", "2001:db8::1"),
+                              ("::FFFF:129.144.52.38", "129.144.52.38"),
+                              ):
+            self.assertEqual(clean_ip_address(value), result)

--- a/zentral/contrib/inventory/utils.py
+++ b/zentral/contrib/inventory/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import csv
 from datetime import datetime
+import ipaddress
 from itertools import chain
 import logging
 import os
@@ -1372,3 +1373,25 @@ def verify_enrollment_secret(model, secret,
     else:
         post_enrollment_secret_verification_success(request, model)
         return request
+
+
+def clean_ip_address(addr):
+    if not isinstance(addr, str):
+        return None
+    addr = addr.strip()
+    if not addr:
+        return None
+    try:
+        addr = ipaddress.IPv4Address(addr)
+    except ValueError:
+        try:
+            addr = ipaddress.IPv6Address(addr)
+        except ValueError:
+            return None
+        else:
+            if addr.ipv4_mapped:
+                return str(addr.ipv4_mapped)
+            else:
+                return str(addr)
+    else:
+        return str(addr)

--- a/zentral/contrib/jamf/api_client.py
+++ b/zentral/contrib/jamf/api_client.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 import requests
 from requests.packages.urllib3.util import Retry
 from zentral.conf import settings
+from zentral.contrib.inventory.utils import clean_ip_address
 from .events import JAMF_EVENTS
 
 
@@ -299,7 +300,7 @@ class APIClient(object):
         ct['system_info'] = system_info
 
         # public ip
-        last_reported_ip = computer['general'].get('ip_address', None)
+        last_reported_ip = clean_ip_address(computer['general'].get('ip_address', None))
         if last_reported_ip:
             ct['public_ip_address'] = last_reported_ip
 
@@ -309,7 +310,10 @@ class APIClient(object):
                               ('last_reported_ip', 'address')):
             value = computer['general'].get(attr, None)
             if value:
-                network_interface[ni_attr] = value
+                if attr == "last_reported_ip":
+                    value = clean_ip_address(value)
+                if value:
+                    network_interface[ni_attr] = value
         if len(network_interface) == 2:
             network_interface['interface'] = 'primary'
             ct['network_interfaces'] = [network_interface]


### PR DESCRIPTION
Apply the same normalization as the GenericIPAddressField with the
unpack_ipv4 option to avoid MTObject hash errors.