### PR TITLE
Clean munki enrollment if distributor

### DIFF
--- a/zentral/contrib/munki/osx_package/build.tmpl/scripts/postinstall
+++ b/zentral/contrib/munki/osx_package/build.tmpl/scripts/postinstall
@@ -2,6 +2,7 @@
 import json
 import os
 import plistlib
+import shutil
 import ssl
 import subprocess
 import urllib.request
@@ -12,11 +13,16 @@ ENROLLMENT_URL = "%ENROLLMENT_URL%"
 ENROLLMENT_SECRET = "%ENROLLMENT_SECRET%"
 TLS_SERVER_CERTS = "%TLS_SERVER_CERTS%"
 TLS_HOSTNAME = "%TLS_HOSTNAME%"
+CLEAN_INSTALL = "%CLEAN_INSTALL%"
 
 
 MUNKI_DIR = "/usr/local/munki"
 ZENTRAL_MUNKI_DIR = "/usr/local/zentral/munki/"
 ZENTRAL_MUNKI_POSTFLIGHT_FILE = os.path.join(ZENTRAL_MUNKI_DIR, "zentral_postflight")
+
+
+def is_clean_install():
+    return CLEAN_INSTALL == "YES"
 
 
 def get_serial_number_and_uuid():
@@ -53,6 +59,12 @@ def prepare_munki_preflight_postflight():
     for phase in ("preflight", "postflight"):
         script_path = os.path.join(MUNKI_DIR, phase)
         dir_path = os.path.join(MUNKI_DIR, "{}.d".format(phase))
+
+        # remove old stuff if necessary
+        if is_clean_install():
+            if os.path.isfile(script_path):
+                os.unlink(script_path)
+            shutil.rmtree(dir_path, ignore_errors=True)
 
         # .d dir
         if not os.path.isdir(dir_path):

--- a/zentral/contrib/munki/osx_package/builder.py
+++ b/zentral/contrib/munki/osx_package/builder.py
@@ -27,6 +27,7 @@ class MunkiZentralEnrollPkgBuilder(EnrollmentPackageBuilder):
         postinstall_script = self.get_build_path("scripts", "postinstall")
         replacements.extend([
             ("%ENROLLMENT_SECRET%", self.build_kwargs["enrollment_secret_secret"]),
-            ("%ENROLLMENT_URL%", "https://{}{}".format(tls_hostname, reverse("munki:enroll")))
+            ("%ENROLLMENT_URL%", "https://{}{}".format(tls_hostname, reverse("munki:enroll"))),
+            ("%CLEAN_INSTALL%", "YES" if self.build_kwargs.get("has_distributor") else "NO"),
         ])
         self.replace_in_file(postinstall_script, replacements)

--- a/zentral/utils/osx_package.py
+++ b/zentral/utils/osx_package.py
@@ -423,7 +423,8 @@ class EnrollmentPackageBuilder(PackageBuilder):
         # build kwargs
         build_kwargs = {"version": "{}.0".format(version or enrollment.version),
                         "package_identifier_suffix": "pk-{}".format(enrollment.pk),
-                        "enrollment_secret_secret": enrollment.secret.secret}
+                        "enrollment_secret_secret": enrollment.secret.secret,
+                        "has_distributor": enrollment.distributor is not None}
         build_kwargs.update(extra_build_kwargs)
 
         # business unit


### PR DESCRIPTION
Remove existing pre/postflight setup during the enrollment, if the
package has a distributor, for example, if it is part of a Monolith
manifest.