### PR TITLE
Swap primary branch refs from 'master' to 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Zentral
 
-![Tests](https://github.com/zentralopensource/zentral/workflows/Tests/badge.svg?branch=master)
+![Tests](https://github.com/zentralopensource/zentral/workflows/Tests/badge.svg?branch=main)
 [![Documentation Status](https://readthedocs.org/projects/zentral/badge/?version=latest)](https://zentral.readthedocs.io/en/latest/?badge=latest)
 
 Zentral is an Event Hub to gather, process, and monitor system events and link them to an inventory.
 
 ## Docs
 
-The Zentral docs are in the [docs](https://github.com/zentralopensource/zentral/blob/master/docs) directory. They are published at [https://zentral.readthedocs.io](https://zentral.readthedocs.io).
+The Zentral docs are in the [docs](https://github.com/zentralopensource/zentral/blob/main/docs) directory. They are published at [https://zentral.readthedocs.io](https://zentral.readthedocs.io).
 
 ## Releases
 

--- a/docs/deployment/zaio-setup.md
+++ b/docs/deployment/zaio-setup.md
@@ -11,7 +11,7 @@ On every _Zentral all in one_ instance, there is a setup script that will automa
 ## How to run it
 
 Once you are logged into your instance, use the following command:
- 
+
 ```cmd
 sudo /home/zentral/app/utils/setup.py \
      zentral.example.com \
@@ -54,10 +54,10 @@ Some commands to manage your _Zentral all in one_ instance.
 To restart the application, after having changed the configuration for example:
 
 ```bash
-sudo /home/zentral/app/utils/reload_restart.sh 
+sudo /home/zentral/app/utils/reload_restart.sh
 ```
 
-To deploy the master branch from the github repository:
+To deploy the main branch from the github repository:
 
 ```bash
 sudo /home/zentral/app/utils/deploy.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Zentral
 theme: readthedocs
 
 repo_url: https://github.com/zentralopensource/zentral
-edit_uri: https://github.com/zentralopensource/zentral/edit/master/docs/
+edit_uri: https://github.com/zentralopensource/zentral/edit/main/docs/
 docs_dir: docs/
 site_dir: build/
 extra_css:


### PR DESCRIPTION
While perusing the Zentral docs (at https://zentral.readthedocs.io/en/latest/) I noticed that the 'Edit on GitHub' link 404's because it references https://github.com/zentralopensource/zentral/edit/**master**/docs/index.md but it seems that, at some point, the primary/default branch was changed from `master` to `main`.

This PR will fix the broken 'Edit on GitHub' URL in the docs, as well as swap-out a couple other refs to the `master` branch that exist in the repo.