### PR TITLE
Use HostName instead of localhostname for definitive 'name', for display in events/machine inventory list

### DIFF
--- a/zentral/contrib/munki/osx_package/build.tmpl/root/usr/local/zentral/munki/zentral_postflight
+++ b/zentral/contrib/munki/osx_package/build.tmpl/root/usr/local/zentral/munki/zentral_postflight
@@ -169,7 +169,7 @@ class SystemProfilerReport(object):
 
         # preferable name to track since end users screw with other labels
         # oddly, falls back to hostname's bonjour-alike output if scutil would return Not Set
-        system_info['computer_name'] = os.uname()[1]
+        system_info['computer_name'] = os.uname().nodename
 
         # uptime
         # up 7:21:19:44

--- a/zentral/contrib/munki/osx_package/build.tmpl/root/usr/local/zentral/munki/zentral_postflight
+++ b/zentral/contrib/munki/osx_package/build.tmpl/root/usr/local/zentral/munki/zentral_postflight
@@ -167,10 +167,9 @@ class SystemProfilerReport(object):
             raise ValueError('0 or more than one item in a SPSoftwareDataType output!')
         item_d = data['_items'][0]
 
-        try:
-            system_info['computer_name'] = item_d['local_host_name']
-        except KeyError:
-            pass
+        # preferable name to track since end users screw with other labels
+        # oddly, falls back to hostname's bonjour-alike output if scutil would return Not Set
+        system_info['computer_name'] = os.uname()[1]
 
         # uptime
         # up 7:21:19:44


### PR DESCRIPTION
We set all three values from scutil to the same asset tag ID, but end users are free to change what they see in System Preferences -> Sharing, which modifies the value we had been getting from SysProfiler (ComputerName which is most closely associated with Apple Remote Desktop's need to name computers easily). I don't see a reason to retain it or the bonjour sharing name end users can alter, adding HostName as an extra label to associate with the computer also doesn't seem helpful. It wasn't straightforward to me and my unclassful python to pull from the ManagedInstallReport parsing happening elsewhere in postinstall, so I'm using the same way munki gets it - https://github.com/munki/munki/blob/7f736a4901397711e67cf6e9282be0194c59e9eb/code/client/munkilib/info.py#L658

comment explains fallback behavior (tested on a cleanly wiped Big Sur machine), so I can feel pretty confident the try/except is unneeded as the system ensures a .local sharing hostname.