### PR TITLE
Fix osquery file carving transaction race

### DIFF
--- a/zentral/contrib/osquery/views/api.py
+++ b/zentral/contrib/osquery/views/api.py
@@ -237,7 +237,7 @@ class CarverContinueView(BaseNodeView):
                                  "session_finished": session_finished,
                                  "session_id": self.session_id}])
         if session_finished:
-            build_carve_session_archive.apply_async((self.session_id,))
+            transaction.on_commit(lambda: build_carve_session_archive.apply_async((self.session_id,)))
         return {}
 
 

--- a/zentral/utils/storage.py
+++ b/zentral/utils/storage.py
@@ -1,0 +1,6 @@
+from django.core.files.storage import get_storage_class
+
+
+def file_storage_has_signed_urls():
+    # TODO better detection!
+    return get_storage_class().__name__ in ('S3Boto3Storage', 'GoogleCloudStorage')


### PR DESCRIPTION
The background task to build the archive would start before the last
block was committed to the DB.