### PR TITLE
Accept updated content-encoding for santa

### DIFF
--- a/zentral/contrib/santa/views.py
+++ b/zentral/contrib/santa/views.py
@@ -350,7 +350,7 @@ class BaseSyncView(View):
         if not payload:
             return None
         try:
-            if request.META.get('HTTP_CONTENT_ENCODING', None) == "zlib":
+            if request.META.get('HTTP_CONTENT_ENCODING', None) in ("zlib", "deflate"):
                 payload = zlib.decompress(payload)
             return json.loads(payload)
         except ValueError:


### PR DESCRIPTION
After [a few years](https://github.com/google/santa/issues/155), santa (v1.17)[ is finally sending](https://github.com/google/santa/commit/c5a048f4d9d9a421417f72a11f90e1e40970ad6f) the correct `Content-Encoding` header 😉