### PR TITLE
Use faster DB query for apps search source field

### DIFF
--- a/zentral/contrib/inventory/forms.py
+++ b/zentral/contrib/inventory/forms.py
@@ -169,7 +169,7 @@ class AddMachineTagForm(AddTagForm):
 class MacOSAppSearchForm(forms.Form):
     bundle_name = forms.CharField(label='Bundle name', max_length=64,
                                   widget=forms.TextInput(attrs={"autofocus": "true"}))
-    source = forms.ModelChoiceField(queryset=Source.objects.current_macos_apps_sources(),
+    source = forms.ModelChoiceField(queryset=Source.objects.current_machine_snapshot_sources(),
                                     required=False)
     order = forms.ChoiceField(choices=[], required=False)
     order_mapping = {"bn": "bundle_name",

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -131,6 +131,8 @@ class SourceManager(MTObjectManager):
                     .order_by("module", "name"))
 
     def current_macos_apps_sources(self):
+        # can get really expensive if there are a lot of machines and apps
+        # it is recommended to use current_machine_snapshot_sources() instead
         return (self.filter(machinesnapshot__currentmachinesnapshot__isnull=False,
                             machinesnapshot__osx_app_instances__isnull=False)
                     .distinct()


### PR DESCRIPTION
The query that is exactly returning the current sources with apps in the
inventory is too slow. It needs to be optimized if possible. In the
meantime, we use the faster query to find all the inventory sources –
some of them without apps.