### PR TITLE
Regroup accounts/ URLs

### DIFF
--- a/conf/mdm/docker/nginx/conf.d/zentral.conf
+++ b/conf/mdm/docker/nginx/conf.d/zentral.conf
@@ -16,7 +16,7 @@ server {
 	}
 
         location /prometheus/ {
-                auth_request    /admin/users/nginx/auth_request/;
+                auth_request    /accounts/nginx/auth_request/;
                 error_page      401 /401$request_uri;
 		proxy_pass	http://promsrv:9090;
         }
@@ -25,7 +25,7 @@ server {
                 proxy_pass      http://scepserver:8080;
         }
 
-        location /admin/users/nginx/auth_request/ {
+        location /accounts/nginx/auth_request/ {
                 internal;
                 proxy_pass              http://web:8000;
                 proxy_pass_request_body off;

--- a/conf/start/docker/nginx/conf.d/zentral.conf
+++ b/conf/start/docker/nginx/conf.d/zentral.conf
@@ -33,12 +33,12 @@ server {
 	}
 
         location /prometheus/ {
-                auth_request    /admin/users/nginx/auth_request/;
+                auth_request    /accounts/nginx/auth_request/;
                 error_page      401 /401$request_uri;
 		proxy_pass	http://promsrv:9090;
         }
 
-        location /admin/users/nginx/auth_request/ {
+        location /accounts/nginx/auth_request/ {
                 internal;
                 proxy_pass              http://web:8000;
                 proxy_pass_request_body off;

--- a/server/accounts/models.py
+++ b/server/accounts/models.py
@@ -140,7 +140,7 @@ class UserTOTP(UserVerificationDevice):
         unique_together = (("user", "name"),)
 
     def get_verification_url(self):
-        return reverse("verify_totp")
+        return reverse("users:verify_totp")
 
     def verify(self, code):
         return pyotp.TOTP(self.secret).verify(code)
@@ -159,7 +159,7 @@ class UserU2F(UserVerificationDevice):
         unique_together = (("user", "device"), ("user", "name"))
 
     def get_verification_url(self):
-        return reverse("verify_u2f")
+        return reverse("users:verify_u2f")
 
     def test_user_agent(self, user_agent):
         if user_agent:

--- a/server/accounts/urls.py
+++ b/server/accounts/urls.py
@@ -30,8 +30,12 @@ urlpatterns = [
          name="add_totp"),
     path('totp/<int:pk>/delete/', views.DeleteTOTPView.as_view(),
          name="delete_totp"),
+    path('verify_totp/', views.VerifyTOTPView.as_view(),
+         name='verify_totp'),
     path('u2f_devices/register/', views.RegisterU2FDeviceView.as_view(),
          name="register_u2f_device"),
     path('u2f_devices/<int:pk>/delete/', views.DeleteU2FDeviceView.as_view(),
          name="delete_u2f_device"),
+    path(r'verify_u2f/', views.VerifyU2FView.as_view(),
+         name='verify_u2f'),
 ]

--- a/server/templates/accounts/verify_u2f.html
+++ b/server/templates/accounts/verify_u2f.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="row">
   <div class="col-md-4 col-md-offset-4">
-    <form id="u2f_form" action="{% url 'verify_u2f' %}" class="panel panel-default" method="POST">{% csrf_token %}
+    <form id="u2f_form" action="{% url 'users:verify_u2f' %}" class="panel panel-default" method="POST">{% csrf_token %}
       <input type="hidden" id="token_response" name="token_response">
       <div class="panel-heading">
         <h3 class="panel-title">


### PR DESCRIPTION
Move users admin and authentication views under the same path prefix.
This is cleaner and can help with an eventual request rate limiting
configuration.