### PR TITLE
[Build Fix]Update docker copy commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN curl -fsSL https://github.com/mackyle/xar/archive/xar-1.6.1.tar.gz | tar xvz
 RUN python -m venv /opt/venv && /opt/venv/bin/pip install -U pip setuptools wheel
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY constraints.txt requirements.txt .
+COPY constraints.txt requirements.txt ./
 RUN pip install -r requirements.txt
 
 
@@ -73,19 +73,19 @@ RUN pip install -r requirements.txt
 
 # Installing the extra requirements for dev
 FROM base-builder as dev-builder
-COPY constraints.txt requirements_*.txt .
+COPY constraints.txt requirements_*.txt ./
 RUN pip install -r requirements_dev.txt -r requirements_aws.txt -r requirements_gcp.txt
 
 
 # Installing the extra requirements for aws
 FROM base-builder as aws-builder
-COPY constraints.txt requirements_aws.txt .
+COPY constraints.txt requirements_aws.txt ./
 RUN pip install -r requirements_aws.txt
 
 
 # Installing the extra requirements for gcp
 FROM base-builder as gcp-builder
-COPY constraints.txt requirements_gcp.txt .
+COPY constraints.txt requirements_gcp.txt ./
 RUN pip install -r requirements_gcp.txt
 
 
@@ -176,7 +176,7 @@ COPY --from=gcp-builder /opt/venv /opt/venv
 #
 
 FROM ${APP_ENV}-runner as final
-MAINTAINER Éric Falconnier <eric@zentral.pro>
+LABEL maintainer="Éric Falconnier <eric@zentral.pro>"
 
 COPY docker-entrypoint.py /zentral/
 COPY ./server /zentral/server


### PR DESCRIPTION
Small Fix following on from https://github.com/zentralopensource/zentral/pull/171 which added PiP constraints and attempted to copy an additional file to the path of `.` sadly this is not supported and gives an error when trying to do the local docker-compose workflows. 

Error from linter. 

```
When using COPY with more than one source file, the destination must be a directory and end with a / or a \dockerfile-utils(23)
```

