### PR TITLE
Optimize machine info serialization for the events

### DIFF
--- a/tests/inventory/utils.py
+++ b/tests/inventory/utils.py
@@ -10,5 +10,6 @@ class MockMetaMachine(object):
     def get_probe_filtering_values(self):
         return self.platform, self.type, self.meta_business_unit_id_set, self.tag_id_set
 
-    def get_cached_probe_filtering_values(self):
+    @property
+    def cached_probe_filtering_values(self):
         return self.get_probe_filtering_values()

--- a/zentral/contrib/osquery/templates/osquery/query_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/query_detail.html
@@ -89,8 +89,8 @@
   <tr>
     <td><a href="{{ distributed_query.get_absolute_url }}">{{ distributed_query }}</a></td>
     <td>{{ distributed_query.query_version }}</td>
-    <td>{{ distributed_query.valid_from }}</td>
-    <td>{{ distributed_query.valid_util|default:"-" }}</td>
+    <td class="{% if distributed_query.is_active %}text-success{% else %}text-muted{% endif %}">{{ distributed_query.valid_from }}</td>
+    <td class="{% if distributed_query.is_active %}text-success{% else %}text-muted{% endif %}">{{ distributed_query.valid_until|default:"-" }}</td>
     <td>{{ distributed_query.in_flight_count }}</td>
     <td>{{ distributed_query.ok_count }}</td>
     <td>{{ distributed_query.error_count }}</td>

--- a/zentral/core/events/base.py
+++ b/zentral/core/events/base.py
@@ -4,11 +4,9 @@ import os.path
 import re
 import uuid
 from dateutil import parser
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.contenttypes.models import ContentType
 from django.utils.functional import cached_property
-from django.utils.text import slugify
 from geoip2.models import City
 from zentral.contrib.inventory.models import MetaMachine
 from zentral.core.probes.conf import all_probes_dict
@@ -227,45 +225,6 @@ class EventMetadata(object):
             kwargs['request'] = EventRequest.deserialize(request_d)
         return cls(**kwargs)
 
-    def _serialize_machine(self):
-        machine_d_cache_key = "machine_d_{}".format(self.machine.get_urlsafe_serial_number())
-        machine_d = cache.get(machine_d_cache_key)
-        if not machine_d:
-            machine_d = {}
-            for ms in self.machine.snapshots:
-                source = ms.source
-                ms_d = {'name': ms.get_machine_str()}
-                if ms.business_unit:
-                    if not ms.business_unit.is_api_enrollment_business_unit():
-                        ms_d['business_unit'] = {'reference': ms.business_unit.reference,
-                                                 'key': ms.business_unit.get_short_key(),
-                                                 'name': ms.business_unit.name}
-                if ms.os_version:
-                    ms_d['os_version'] = str(ms.os_version)
-                for group in ms.groups.all():
-                    ms_d.setdefault('groups', []).append({'reference': group.reference,
-                                                          'key': group.get_short_key(),
-                                                          'name': group.name})
-                key = slugify(source.name)
-                if key in ms_d:
-                    # TODO: earlier warning in conf check ?
-                    logger.warning('Inventory source slug %s exists already', key)
-                machine_d[key] = ms_d
-            for tag in self.machine.tags:
-                machine_d.setdefault('tags', []).append({'id': tag.id,
-                                                         'name': tag.name})
-            for meta_business_unit in self.machine.meta_business_units:
-                machine_d.setdefault('meta_business_units', []).append({
-                    'name': meta_business_unit.name,
-                    'id': meta_business_unit.id
-                })
-            if self.machine.platform:
-                machine_d['platform'] = self.machine.platform
-            if self.machine.type:
-                machine_d['type'] = self.machine.type
-            cache.set(machine_d_cache_key, machine_d, 60)  # TODO: Hard coded timeout value
-        return machine_d
-
     def serialize(self, machine_metadata=True):
         d = {'created_at': self.created_at.isoformat(),
              'id': str(self.uuid),
@@ -286,9 +245,10 @@ class EventMetadata(object):
             d['machine_serial_number'] = self.machine_serial_number
         if not machine_metadata or not self.machine:
             return d
-        machine_d = self._serialize_machine()
-        if machine_d:
-            d['machine'] = machine_d
+        elif self.machine:
+            machine_d = self.machine.cached_serialized_info_for_event
+            if machine_d:
+                d['machine'] = machine_d
         return d
 
     def add_probe(self, probe):

--- a/zentral/core/probes/base.py
+++ b/zentral/core/probes/base.py
@@ -21,7 +21,7 @@ class InventoryFilter(object):
             setattr(self, attr, set(data.get(attr, [])))
 
     def test_machine(self, meta_machine):
-        m_platform, m_type, m_mbu_id_set, m_tag_id_set = meta_machine.get_cached_probe_filtering_values()
+        m_platform, m_type, m_mbu_id_set, m_tag_id_set = meta_machine.cached_probe_filtering_values
         if self.meta_business_unit_ids and not self.meta_business_unit_ids & m_mbu_id_set:
             return False
         if self.tag_ids and not self.tag_ids & m_tag_id_set:


### PR DESCRIPTION
First steps to speed up the event enrichment.
Use single DB query for all event machine info.
Use this query results for probe filtering and machine info serialization.