### PR TITLE
bump api interval test to match change in #261

### DIFF
--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -233,7 +233,7 @@ class APIViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'queries': {'first_query': {'interval': ['Ensure this value is less than or equal to 86400.']}}}
+            {'queries': {'first_query': {'interval': ['Ensure this value is less than or equal to 1000000.']}}}
         )
 
     def test_put_invalid_shard_query(self):

--- a/zentral/contrib/osquery/serializers.py
+++ b/zentral/contrib/osquery/serializers.py
@@ -57,7 +57,7 @@ class OsqueryPlatformField(serializers.ListField):
 
 class OsqueryQuerySerializer(serializers.Serializer):
     query = serializers.CharField(allow_blank=False)
-    interval = serializers.IntegerField(min_value=1, max_value=86400)
+    interval = serializers.IntegerField(min_value=1, max_value=1000000)
     removed = serializers.BooleanField(required=False)
     snapshot = serializers.BooleanField(required=False)
     platform = OsqueryPlatformField(required=False)


### PR DESCRIPTION
GUI can be modified, but updates over the API still fail with the message referenced in the test. Also modified serializer as it has the same ceiling for interval values, feel free to cherrypick/drop if that's not appropriate