### PR TITLE
Add principal_user to machine model

### DIFF
--- a/docs/apps/inventory.md
+++ b/docs/apps/inventory.md
@@ -1,0 +1,25 @@
+# Inventory
+
+The Zentral Inventory app is mandatory in a Zentral deployment. It is used to store all the inventory information.
+
+## Zentral configuration
+
+A `zentral.contrib.inventory` subsection must be present in the `apps` section in [the configuration](/configuration).
+
+### `event_serialization`
+
+**OPTIONAL**
+
+This subsection can be used to change the machine information serialization in the Zentral event metadata. There are two options available:
+
+#### `include_groups`
+
+**OPTIONAL**
+
+This boolean is used to toggle the inclusion of the machine groups in the event metadata. `true` by default.
+
+#### `include_principal_user`
+
+**OPTIONAL**
+
+This boolean is used to toggle the inclusion of the principal user in the event metadata. `true` by default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Event stores: configuration/stores.md
   - Users: configuration/users.md
 - Apps:
+  - Inventory: apps/inventory.md
   - Monolith: apps/monolith.md
   - Osquery: apps/osquery.md
   - Santa: apps/santa.md


### PR DESCRIPTION
This is a small change to contrib/inventory/models.py which adds the "principal user" information to the serialized machine info tied to an event. I accomplished this using pre-existing patterns.

This change was necessary to allow a Slack bot to easily identify which user to notify about a Santa block event.