### PR TITLE
Fix CodeQL conflicting values alerts on EventsMixin

### DIFF
--- a/zentral/contrib/inventory/views.py
+++ b/zentral/contrib/inventory/views.py
@@ -959,7 +959,7 @@ class ComplianceCheckView(PermissionRequiredMixin, DetailView):
                 urlencode({"source_name": self.object.source_name,
                            "jmespath_expression": self.object.jmespath_expression})
             )
-        if self.request.user.has_perms(ComplianceCheckEventsMixin.permission_required):
+        if self.request.user.has_perm(ComplianceCheckEventsMixin.permission_required):
             ctx["show_events_link"] = frontend_store.object_events
             store_links = []
             for store in stores.iter_events_url_store_for_user("object", self.request.user):
@@ -1062,7 +1062,7 @@ class DeleteComplianceCheckView(PermissionRequiredMixin, DeleteView):
 
 
 class ComplianceCheckEventsMixin:
-    permission_required = ("inventory.view_jmespathcheck",)
+    permission_required = "inventory.view_jmespathcheck"
     store_method_scope = "object"
 
     def get_object(self, **kwargs):

--- a/zentral/contrib/monolith/views.py
+++ b/zentral/contrib/monolith/views.py
@@ -144,7 +144,7 @@ class PkgInfoNameView(PermissionRequiredMixin, DetailView):
         ctx = super().get_context_data(**kwargs)
         pkg_info_name = ctx["object"]
         # events
-        if self.request.user.has_perms(EventsMixin.permission_required):
+        if self.request.user.has_perms(("monolith.view_pkginfo", "monolith.view_pkginfoname")):
             ctx["show_events_link"] = frontend_store.object_events
             store_links = []
             for store in stores.iter_events_url_store_for_user("object", self.request.user):
@@ -174,7 +174,6 @@ class PkgInfoNameView(PermissionRequiredMixin, DetailView):
 
 
 class EventsMixin:
-    permission_required = ("monolith.view_pkginfo", "monolith.view_pkginfoname")
     store_method_scope = "object"
 
     def get_object(self, **kwargs):
@@ -200,15 +199,16 @@ class EventsMixin:
 
 
 class PkgInfoNameEventsView(EventsMixin, EventsView):
+    permission_required = ("monolith.view_pkginfo", "monolith.view_pkginfoname")
     template_name = "monolith/pkg_info_name_events.html"
 
 
 class FetchPkgInfoNameEventsView(EventsMixin, FetchEventsView):
-    pass
+    permission_required = ("monolith.view_pkginfo", "monolith.view_pkginfoname")
 
 
 class PkgInfoNameEventsStoreRedirectView(EventsMixin, EventsStoreRedirectView):
-    pass
+    permission_required = ("monolith.view_pkginfo", "monolith.view_pkginfoname")
 
 
 # PPDs

--- a/zentral/contrib/puppet/views.py
+++ b/zentral/contrib/puppet/views.py
@@ -67,7 +67,7 @@ class InstanceView(PermissionRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        if self.request.user.has_perms(EventsMixin.permission_required):
+        if self.request.user.has_perm(EventsMixin.permission_required):
             ctx["show_events_link"] = frontend_store.object_events
             store_links = []
             for store in stores.iter_events_url_store_for_user("object", self.request.user):
@@ -107,7 +107,7 @@ class DeleteInstanceView(PermissionRequiredMixin, DeleteView):
 
 
 class EventsMixin:
-    permission_required = ("puppet.view_instance",)
+    permission_required = "puppet.view_instance"
     store_method_scope = "object"
 
     def get_object(self, **kwargs):

--- a/zentral/contrib/santa/views/setup.py
+++ b/zentral/contrib/santa/views/setup.py
@@ -56,7 +56,12 @@ class ConfigurationView(PermissionRequiredMixin, DetailView):
         ctx["enrollments"] = enrollments
         ctx["enrollments_count"] = len(enrollments)
         ctx["rules_count"] = self.object.rule_set.count()
-        if self.request.user.has_perms(EventsMixin.permission_required):
+        if self.request.user.has_perms(
+            ("santa.view_configuration",
+             "santa.view_enrollment",
+             "santa.view_rule",
+             "santa.view_ruleset")
+        ):
             ctx["show_events_link"] = frontend_store.object_events
             store_links = []
             for store in stores.iter_events_url_store_for_user("object", self.request.user):
@@ -71,10 +76,6 @@ class ConfigurationView(PermissionRequiredMixin, DetailView):
 
 
 class EventsMixin:
-    permission_required = ("santa.view_configuration",
-                           "santa.view_enrollment",
-                           "santa.view_rule",
-                           "santa.view_ruleset")
     store_method_scope = "object"
 
     def get_object(self, **kwargs):
@@ -99,15 +100,25 @@ class EventsMixin:
 
 
 class ConfigurationEventsView(EventsMixin, EventsView):
+    permission_required = ("santa.view_configuration",
+                           "santa.view_enrollment",
+                           "santa.view_rule",
+                           "santa.view_ruleset")
     template_name = "santa/configuration_events.html"
 
 
 class FetchConfigurationEventsView(EventsMixin, FetchEventsView):
-    pass
+    permission_required = ("santa.view_configuration",
+                           "santa.view_enrollment",
+                           "santa.view_rule",
+                           "santa.view_ruleset")
 
 
 class ConfigurationEventsStoreRedirectView(EventsMixin, EventsStoreRedirectView):
-    pass
+    permission_required = ("santa.view_configuration",
+                           "santa.view_enrollment",
+                           "santa.view_rule",
+                           "santa.view_ruleset")
 
 
 class UpdateConfigurationView(PermissionRequiredMixin, UpdateView):

--- a/zentral/contrib/wsone/views.py
+++ b/zentral/contrib/wsone/views.py
@@ -66,7 +66,7 @@ class InstanceView(PermissionRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        if self.request.user.has_perms(EventsMixin.permission_required):
+        if self.request.user.has_perm(EventsMixin.permission_required):
             ctx["show_events_link"] = frontend_store.object_events
             store_links = []
             for store in stores.iter_events_url_store_for_user("object", self.request.user):
@@ -106,7 +106,7 @@ class DeleteInstanceView(PermissionRequiredMixin, DeleteView):
 
 
 class EventsMixin:
-    permission_required = ("wsone.view_instance",)
+    permission_required = "wsone.view_instance"
     store_method_scope = "object"
 
     def get_object(self, **kwargs):


### PR DESCRIPTION
Either use a string for permission_required, or explicitly override its
value in each view.