### PR TITLE
Upgrade django-celery-results to v2.4.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -22,7 +22,7 @@ decorator==4.4.2
 defusedxml==0.7.1
 Django==3.2.14
 django-bootstrap-form==3.4
-django-celery-results==2.2.0
+django-celery-results==2.4.0
 django-filter==2.4.0
 django-redis==5.0.0
 django-storages==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 asn1crypto                      # MDM, mTLS, SCEP
 boto3                           # conf, monolith, events (kinesis, sns/sqs)
 celery<6
-django-celery-results==2.2.0
+django-celery-results==2.4.0
 cryptography                    # MDM, monolith (cloudfront), munki
 defusedxml
 django-bootstrap-form

--- a/server/server/celery.py
+++ b/server/server/celery.py
@@ -3,6 +3,7 @@ from celery import Celery
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings')
 app = Celery('zentral')
+app.conf.result_extended = True
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 


### PR DESCRIPTION
To address CVE-2020-17495, we use django-celery-results v2.4.0 and
configure explicitly the storage of the tasks arguments.