### PR TITLE
Fix macOS build parser

### DIFF
--- a/tests/inventory/test_macos_build_parser.py
+++ b/tests/inventory/test_macos_build_parser.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from zentral.contrib.inventory.conf import macos_version_from_build
+from zentral.contrib.inventory.conf import macos_version_from_build, os_version_display
 
 
 class MacOSBuildTestCase(TestCase):
@@ -16,35 +16,41 @@ class MacOSBuildTestCase(TestCase):
             self.assertEqual(cm.exception.args[0], "Cannot parse build str for macos < 10.8")
 
     def test_ok(self):
-        for build, (name, major, minor, patch) in (("12E4022", ("OS X", 10, 8, 4)),
-                                                   ("15G31", ("OS X", 10, 11, 6)),
-                                                   ("19A471t", ("macOS", 10, 15, 0)),
-                                                   ("19D76", ("macOS", 10, 15, 3)),
-                                                   ("20A2411", ("macOS", 11, 0, 0)),
-                                                   ("20B29", ("macOS", 11, 0, 1)),
-                                                   ("20B50", ("macOS", 11, 0, 1)),
-                                                   ("20C69", ("macOS", 11, 1, 0)),
-                                                   ("20D74", ("macOS", 11, 2, 1)),
-                                                   ("20D80", ("macOS", 11, 2, 2)),
-                                                   ("20D91", ("macOS", 11, 2, 3)),
-                                                   ("20G95", ("macOS", 11, 5, 2)),
-                                                   ("20G165", ("macOS", 11, 6, 0)),
-                                                   ("20G224", ("macOS", 11, 6, 1)),
-                                                   ("20G314", ("macOS", 11, 6, 2)),
-                                                   ("20G415", ("macOS", 11, 6, 3)),
-                                                   ("20G417", ("macOS", 11, 6, 4)),
-                                                   ("20G527", ("macOS", 11, 6, 5)),
-                                                   ("20G624", ("macOS", 11, 6, 6)),
-                                                   ("21A5522h", ("macOS Beta", 12, 0, 0)),
-                                                   ("21A558", ("macOS", 12, 0, 1)),
-                                                   ("21C5021h", ("macOS Beta", 12, 1, 0)),
-                                                   ("21D62", ("macOS", 12, 2, 1)),
-                                                   ("21E5212f", ("macOS Beta", 12, 3, 0)),
-                                                   ("21E258", ("macOS", 12, 3, 1)),
-                                                   ("22A5266r", ("macOS Beta", 13, 0, 0))):
-            self.assertEqual(macos_version_from_build(build),
+        for build, (name, major, minor, patch), display in (
+           ("12E4022", ("OS X", 10, 8, 4), "OS X 10.8.4 (12E4022)"),
+           ("15G31", ("OS X", 10, 11, 6), "OS X 10.11.6 (15G31)"),
+           ("19A471t", ("macOS", 10, 15, 0), "macOS 10.15.0 (19A471t)"),
+           ("19D76", ("macOS", 10, 15, 3), "macOS 10.15.3 (19D76)"),
+           ("20A2411", ("macOS", 11, 0, None), "macOS 11.0 (20A2411)"),
+           ("20B29", ("macOS", 11, 0, 1), "macOS 11.0.1 (20B29)"),
+           ("20B50", ("macOS", 11, 0, 1), "macOS 11.0.1 (20B50)"),
+           ("20C69", ("macOS", 11, 1, None), "macOS 11.1 (20C69)"),
+           ("20D74", ("macOS", 11, 2, 1), "macOS 11.2.1 (20D74)"),
+           ("20D80", ("macOS", 11, 2, 2), "macOS 11.2.2 (20D80)"),
+           ("20D91", ("macOS", 11, 2, 3), "macOS 11.2.3 (20D91)"),
+           ("20G95", ("macOS", 11, 5, 2), "macOS 11.5.2 (20G95)"),
+           ("20G165", ("macOS", 11, 6, None), "macOS 11.6 (20G165)"),
+           ("20G224", ("macOS", 11, 6, 1), "macOS 11.6.1 (20G224)"),
+           ("20G314", ("macOS", 11, 6, 2), "macOS 11.6.2 (20G314)"),
+           ("20G415", ("macOS", 11, 6, 3), "macOS 11.6.3 (20G415)"),
+           ("20G417", ("macOS", 11, 6, 4), "macOS 11.6.4 (20G417)"),
+           ("20G527", ("macOS", 11, 6, 5), "macOS 11.6.5 (20G527)"),
+           ("20G624", ("macOS", 11, 6, 6), "macOS 11.6.6 (20G624)"),
+           ("20G630", ("macOS", 11, 6, 7), "macOS 11.6.7 (20G630)"),
+           ("20G730", ("macOS", 11, 6, 8), "macOS 11.6.8 (20G730)"),
+           ("21A5522h", ("macOS Beta", 12, 0, None), "macOS Beta 12.0 (21A5522h)"),
+           ("21A558", ("macOS", 12, 0, 1), "macOS 12.0.1 (21A558)"),
+           ("21C5021h", ("macOS Beta", 12, 1, None), "macOS Beta 12.1 (21C5021h)"),
+           ("21D62", ("macOS", 12, 2, 1), "macOS 12.2.1 (21D62)"),
+           ("21E5212f", ("macOS Beta", 12, 3, None), "macOS Beta 12.3 (21E5212f)"),
+           ("21E258", ("macOS", 12, 3, 1), "macOS 12.3.1 (21E258)"),
+           ("22A5266r", ("macOS Beta", 13, 0, None), "macOS Beta 13.0 (22A5266r)")
+        ):
+            version_d = macos_version_from_build(build)
+            self.assertEqual(version_d,
                              {"name": name,
                               "major": major,
                               "minor": minor,
                               "patch": patch,
                               "build": build})
+            self.assertEqual(os_version_display(version_d), display)

--- a/zentral/contrib/inventory/conf.py
+++ b/zentral/contrib/inventory/conf.py
@@ -227,7 +227,7 @@ def macos_version_from_build(build):
             if build in ("21A558", "21A559", "21D62", "21E258"):
                 patch = 1
             else:
-                patch = 0
+                patch = None
             if minor > 0:
                 minor -= 1
             if match.group("beta"):
@@ -251,8 +251,12 @@ def macos_version_from_build(build):
                 patch = 5
             elif build == "20G624":
                 patch = 6
+            elif build == "20G630":
+                patch = 7
+            elif build == "20G730":
+                patch = 8
             else:
-                patch = 0
+                patch = None
         else:
             major = 10
         return {


### PR DESCRIPTION
- Nullify zero patch number for macOS >= 11
- Add support for 11.6.7 and 11.6.8