### PR TITLE
Specify dependency on apple enterprise developer program

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -4,7 +4,7 @@ Zentral can be used as MDM server for Apple devices.
 
 ## Push certificates
 
-To be able to send notifications to the devices, Zentral needs a push certificate (aka. APNS certificate). To get one, you first need to generate an MDM vendor certificate that you then use to sign an APNS certificate request. The `mdmcerts` Zentral management command can be used to help with this process.
+To be able to send notifications to the devices, Zentral needs a push certificate (aka. APNS certificate). To get one, you first need to generate an MDM vendor certificate under Apple's [Developer Enterprise Program](https://developer.apple.com/programs/enterprise/). You can then use this vendor certificate to sign an APNS certificate request. The `mdmcerts` Zentral management command can be used to help with this process.
 
 ### MDM vendor certificate
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -4,7 +4,7 @@ Zentral can be used as MDM server for Apple devices.
 
 ## Push certificates
 
-To be able to send notifications to the devices, Zentral needs a push certificate (aka. APNS certificate). To get one, you first need to generate an MDM vendor certificate under Apple's [Developer Enterprise Program](https://developer.apple.com/programs/enterprise/). You can then use this vendor certificate to sign an APNS certificate request. The `mdmcerts` Zentral management command can be used to help with this process.
+To be able to send notifications to the devices, Zentral needs a push certificate (aka. APNS certificate). To get one, you first need to generate an MDM vendor certificate. An Apple [Developer Enterprise Account](https://developer.apple.com/programs/enterprise/) with the ability to generate MDM CSRs is required. You can then use this vendor certificate to sign an APNS certificate request. The `mdmcerts` Zentral management command can be used to help with this process.
 
 ### MDM vendor certificate
 


### PR DESCRIPTION
I think this is a requirement in order for you to sign your own APNS certs with a vendor cert? You have to be an approved MDM vendor. 

I was not able to get this to work otherwise. When I log into my apple developer account, I get no link to manage my certificates, as per the instructions. 
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/5359586/189198961-4737ee5d-7ded-41be-9ab3-290680f675b8.png">
