### PR TITLE
Reschedule some commmands with NotNow status

### DIFF
--- a/server/realms/utils.py
+++ b/server/realms/utils.py
@@ -1,6 +1,8 @@
+import copy
 import base64
 import hashlib
 import logging
+import plistlib
 import random
 from django.conf import settings
 from django.contrib.auth import authenticate, login
@@ -98,3 +100,13 @@ def build_password_hash_dict(password):
             "iterations": iterations
         }
     }
+
+
+def serialize_password_hash_dict(password_hash_dict):
+    password_hash_dict = copy.deepcopy(password_hash_dict)
+    for hash_type, hash_dict in password_hash_dict.items():
+        for k, v in hash_dict.items():
+            if isinstance(v, str):
+                # decode base64 encoded bytes
+                hash_dict[k] = base64.b64decode(v.encode("utf-8"))  # → bytes to get <data/> in the plist
+    return plistlib.dumps(password_hash_dict).strip()

--- a/tests/mdm/test_account_configuration_command.py
+++ b/tests/mdm/test_account_configuration_command.py
@@ -1,0 +1,79 @@
+import plistlib
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+from realms.utils import serialize_password_hash_dict
+from zentral.contrib.inventory.models import MetaBusinessUnit
+from zentral.contrib.mdm.commands import AccountConfiguration
+from .utils import force_dep_enrollment_session
+
+
+class AccountConfigurationCommandTestCase(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+        cls.mbu.create_enrollment_business_unit()
+        cls.dep_enrollment_session, _, _ = force_dep_enrollment_session(
+            cls.mbu,
+            authenticated=True,
+            completed=True,
+            realm_user=True
+        )
+
+    def test_build_command_realm_user_no_password_hash_admin(self):
+        cmd = AccountConfiguration.create_for_device(
+            self.dep_enrollment_session.enrolled_device
+        )
+        response = cmd.build_http_response(self.dep_enrollment_session)
+        payload = plistlib.loads(response.content)["Command"]
+        self.assertEqual(payload["AutoSetupAdminAccounts"], [])
+        self.assertFalse(payload["DontAutoPopulatePrimaryAccountInfo"])
+        self.assertTrue(payload["LockPrimaryAccountInfo"])
+        self.assertEqual(payload["PrimaryAccountFullName"], self.dep_enrollment_session.realm_user.get_full_name())
+        self.assertEqual(payload["PrimaryAccountUserName"], self.dep_enrollment_session.realm_user.device_username)
+        self.assertFalse(payload["SetPrimarySetupAccountAsRegularUser"])
+        self.assertFalse(payload["SkipPrimarySetupAccountCreation"])
+
+    def test_build_command_realm_user_no_password_hash_not_admin(self):
+        dep_enrollment = self.dep_enrollment_session.dep_enrollment
+        dep_enrollment.realm_user_is_admin = False
+        dep_enrollment.admin_full_name = "Admin Full Name"
+        dep_enrollment.admin_short_name = "admin_short_name"
+        dep_enrollment.admin_password_hash = {"SALTED-SHA512-PBKDF2": {"fake": True}}
+        cmd = AccountConfiguration.create_for_device(
+            self.dep_enrollment_session.enrolled_device
+        )
+        response = cmd.build_http_response(self.dep_enrollment_session)
+        payload = plistlib.loads(response.content)["Command"]
+        self.assertEqual(
+            payload["AutoSetupAdminAccounts"],
+            [{"fullName": "Admin Full Name",
+              "shortName": "admin_short_name",
+              "hidden": True,
+              "passwordHash": serialize_password_hash_dict(dep_enrollment.admin_password_hash)}]
+        )
+        self.assertFalse(payload["DontAutoPopulatePrimaryAccountInfo"])
+        self.assertTrue(payload["LockPrimaryAccountInfo"])
+        self.assertEqual(payload["PrimaryAccountFullName"], self.dep_enrollment_session.realm_user.get_full_name())
+        self.assertEqual(payload["PrimaryAccountUserName"], self.dep_enrollment_session.realm_user.device_username)
+        self.assertTrue(payload["SetPrimarySetupAccountAsRegularUser"])
+        self.assertFalse(payload["SkipPrimarySetupAccountCreation"])
+
+    def test_build_command_realm_user_password_hash_admin(self):
+        password_hash = {"SALTED-SHA512-PBKDF2": {"fake": True}}
+        self.dep_enrollment_session.realm_user.password_hash = password_hash
+        cmd = AccountConfiguration.create_for_device(
+            self.dep_enrollment_session.enrolled_device
+        )
+        response = cmd.build_http_response(self.dep_enrollment_session)
+        payload = plistlib.loads(response.content)["Command"]
+        self.assertTrue(payload["DontAutoPopulatePrimaryAccountInfo"])
+        self.assertTrue(payload["SkipPrimarySetupAccountCreation"])
+        self.assertEqual(
+            payload["AutoSetupAdminAccounts"],
+            [{"fullName": self.dep_enrollment_session.realm_user.get_full_name(),
+              "shortName": self.dep_enrollment_session.realm_user.device_username,
+              "hidden": False,
+              "passwordHash": serialize_password_hash_dict(password_hash)}]
+        )

--- a/tests/mdm/test_custom_command.py
+++ b/tests/mdm/test_custom_command.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.commands import CustomCommand
+from zentral.contrib.mdm.models import CommandStatus
 from .utils import force_dep_enrollment_session
 
 
@@ -11,15 +12,20 @@ class CustomCommandTestCase(TestCase):
     def setUpTestData(cls):
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
+        cls.dep_enrollment_session, cls.device_udid, cls.serial_number = force_dep_enrollment_session(
+            cls.mbu,
+            authenticated=True,
+            completed=True,
+        )
+        cls.enrolled_device = cls.dep_enrollment_session.enrolled_device
 
     def test_load_kwargs(self):
-        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
         cmd_payload = {
             "RequestType": "InstalledApplicationList",
             "ManagedAppsOnly": False
         }
         cmd = CustomCommand.create_for_device(
-            session.enrolled_device,
+            self.enrolled_device,
             kwargs={"command": plistlib.dumps(cmd_payload).decode("utf-8")},
             queue=True
         )
@@ -27,14 +33,87 @@ class CustomCommandTestCase(TestCase):
         self.assertEqual(cmd.request_type, "InstalledApplicationList")
 
     def test_build_command(self):
-        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
         cmd_payload = {
             "RequestType": "InstalledApplicationList",
             "ManagedAppsOnly": False
         }
         cmd = CustomCommand.create_for_device(
-            session.enrolled_device,
+            self.enrolled_device,
             kwargs={"command": plistlib.dumps(cmd_payload).decode("utf-8")},
             queue=True
         )
         self.assertEqual(cmd.build_command(), {"ManagedAppsOnly": False})
+
+    def test_process_acknowledge_response(self):
+        cmd_payload = {
+            "RequestType": "InstalledApplicationList",
+            "ManagedAppsOnly": False
+        }
+        cmd = CustomCommand.create_for_device(
+            self.enrolled_device,
+            kwargs={"command": plistlib.dumps(cmd_payload).decode("utf-8")},
+        )
+        cmd.process_response(
+            {"UDID": self.enrolled_device.udid,
+             "Status": "Acknowledged",
+             "CommandUUID": str(cmd.uuid).upper(),
+             "InstalledApplicationList": []},
+            self.dep_enrollment_session,
+            self.mbu
+        )
+        cmd.db_command.refresh_from_db()
+        self.assertEqual(cmd.status, CommandStatus.Acknowledged)
+        self.assertEqual(cmd.db_command.status, CommandStatus.Acknowledged.value)
+
+    def test_process_notnow_response(self):
+        cmd_payload = {
+            "RequestType": "InstalledApplicationList",
+            "ManagedAppsOnly": False
+        }
+        cmd = CustomCommand.create_for_device(
+            self.enrolled_device,
+            kwargs={"command": plistlib.dumps(cmd_payload).decode("utf-8")},
+        )
+        cmd.process_response(
+            {"UDID": self.enrolled_device.udid,
+             "Status": "NotNow",
+             "CommandUUID": str(cmd.uuid).upper()},
+            self.dep_enrollment_session,
+            self.mbu
+        )
+        cmd.db_command.refresh_from_db()
+        self.assertEqual(cmd.status, CommandStatus.NotNow)
+        self.assertEqual(cmd.db_command.status, CommandStatus.NotNow.value)
+        self.assertIsNone(cmd.db_command.result)
+
+    def test_process_rescheduled_acknowledged_response(self):
+        cmd_payload = {
+            "RequestType": "InstalledApplicationList",
+            "ManagedAppsOnly": False
+        }
+        cmd = CustomCommand.create_for_device(
+            self.enrolled_device,
+            kwargs={"command": plistlib.dumps(cmd_payload).decode("utf-8")},
+        )
+        # first not now
+        cmd.process_response(
+            {"UDID": self.enrolled_device.udid,
+             "Status": "NotNow",
+             "CommandUUID": str(cmd.uuid).upper()},
+            self.dep_enrollment_session,
+            self.mbu
+        )
+        # then acknowledged
+        cmd.process_response(
+            {"UDID": self.enrolled_device.udid,
+             "Status": "Acknowledged",
+             "CommandUUID": str(cmd.uuid).upper(),
+             "InstalledApplicationList": []},
+            self.dep_enrollment_session,
+            self.mbu
+        )
+        cmd.db_command.refresh_from_db()
+        self.assertEqual(cmd.status, CommandStatus.Acknowledged)
+        self.assertEqual(cmd.db_command.status, CommandStatus.Acknowledged.value)
+        result = plistlib.loads(cmd.db_command.result)
+        self.assertEqual(result["Status"], CommandStatus.Acknowledged.value)

--- a/tests/mdm/utils.py
+++ b/tests/mdm/utils.py
@@ -222,7 +222,8 @@ def force_dep_enrollment_session(
     authenticated=False, completed=False,
     push_certificate=None,
     device_udid=None,
-    serial_number=None
+    serial_number=None,
+    realm_user=False,
 ):
     dep_enrollment = force_dep_enrollment(mbu, push_certificate)
     if serial_number is None:
@@ -232,6 +233,11 @@ def force_dep_enrollment_session(
     session = DEPEnrollmentSession.objects.create_from_dep_enrollment(
         dep_enrollment, serial_number, device_udid
     )
+    if realm_user:
+        session.dep_enrollment.realm, session.realm_user = force_realm_user()
+        session.dep_enrollment.use_realm_user = True
+        session.dep_enrollment.save()
+        session.save()
     if completed:
         complete_enrollment_session(session)
     elif authenticated:

--- a/tests/server_realms/test_realm_utils.py
+++ b/tests/server_realms/test_realm_utils.py
@@ -1,0 +1,58 @@
+import plistlib
+from unittest.mock import patch
+from django.test import TestCase
+from realms.utils import build_password_hash_dict, serialize_password_hash_dict
+
+
+class RealmUtilsTestCase(TestCase):
+    @patch("realms.utils.random.getrandbits")
+    def test_build_password_hash_dict(self, getrandbits):
+        getrandbits.return_value = 0
+        self.assertEqual(
+            build_password_hash_dict("yolofomo"),
+            {
+                "SALTED-SHA512-PBKDF2": {
+                    "entropy": "gk+6qey048x1NausVGMKYw81gcIR2RNiCSeNujsAgY6Sbipd/7OlomEkZKfkGl3W1IN3epAC1qewQ94"
+                    "TSCsIDCh/0gbi/vL0kTI5Llm1TuaxLyTgLDtVnOglA11KLSQhUXDncSb7y1CvrqCdvfopP7fvFmao3o"
+                    "kpgxzeQ+VfWwg=",
+                    "iterations": 39999,
+                    "salt": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                }
+            },
+        )
+
+    def test_serialize_password_hash_dict(self):
+        self.assertEqual(
+            plistlib.loads(
+                serialize_password_hash_dict(
+                    {
+                        "SALTED-SHA512-PBKDF2": {
+                            "entropy": "gk+6qey048x1NausVGMKYw81gcIR2RNiCSeNujsAgY6Sbipd/7OlomEkZKfkGl3W1IN3epAC1qewQ9"
+                            "4TSCsIDCh/0gbi/vL0kTI5Llm1TuaxLyTgLDtVnOglA11KLSQhUXDncSb7y1CvrqCdvfopP7fvFmao3o"
+                            "kpgxzeQ+VfWwg=",
+                            "iterations": 39999,
+                            "salt": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                        }
+                    }
+                )
+            ),
+            {
+                "SALTED-SHA512-PBKDF2": {
+                    "entropy": b"\x82O\xba\xa9\xec\xb4\xe3\xccu5\xab\xac"
+                    b"Tc\nc\x0f5\x81\xc2\x11\xd9\x13b"
+                    b"\t'\x8d\xba;\x00\x81\x8e\x92n*]"
+                    b"\xff\xb3\xa5\xa2a$d\xa7\xe4\x1a]\xd6"
+                    b"\xd4\x83wz\x90\x02\xd6\xa7\xb0C\xde\x13"
+                    b"H+\x08\x0c(\x7f\xd2\x06\xe2\xfe\xf2\xf4"
+                    b"\x9129.Y\xb5N\xe6\xb1/$\xe0,;U\x9c"
+                    b"\xe8%\x03]J-$!Qp\xe7q&\xfb\xcbP"
+                    b"\xaf\xae\xa0\x9d\xbd\xfa)?\xb7\xef\x16f"
+                    b"\xa8\xde\x89)\x83\x1c\xdeC\xe5_[\x08",
+                    "iterations": 39999,
+                    "salt": b"\x00\x00\x00\x00\x00\x00\x00\x00"
+                    b"\x00\x00\x00\x00\x00\x00\x00\x00"
+                    b"\x00\x00\x00\x00\x00\x00\x00\x00"
+                    b"\x00\x00\x00\x00\x00\x00\x00\x00",
+                }
+            },
+        )

--- a/zentral/contrib/mdm/commands/account_configuration.py
+++ b/zentral/contrib/mdm/commands/account_configuration.py
@@ -1,7 +1,5 @@
-import base64
-import copy
 import logging
-import plistlib
+from realms.utils import serialize_password_hash_dict
 from zentral.contrib.mdm.models import Channel, Platform, DEPEnrollmentSession
 from .base import register_command, Command
 
@@ -15,51 +13,46 @@ class AccountConfiguration(Command):
     allowed_platform = Platform.macOS
     allowed_in_user_enrollment = False
 
-    def _serialize_realm_user_password_hash(self):
-        password_hash = self.realm_user.password_hash
-        if not password_hash:
-            return
-        password_hash = copy.deepcopy(password_hash)
-        for hash_type, hash_dict in password_hash.items():
-            for k, v in hash_dict.items():
-                if isinstance(v, str):
-                    # decode base64 encoded bytes
-                    hash_dict[k] = base64.b64decode(v.encode("utf-8"))  # => bytes to get <data/> in the plist
-        return plistlib.dumps(password_hash).strip()
-
     def build_command(self):
         if not isinstance(self.enrollment_session, DEPEnrollmentSession):
             raise ValueError("Invalid enrollment session")
         dep_enrollment = self.enrollment_session.dep_enrollment
 
         command = {"DontAutoPopulatePrimaryAccountInfo": True,
+                   "SkipPrimarySetupAccountCreation": False,
                    "AutoSetupAdminAccounts": []}
 
-        # TODO upgrade
-        # - when an extra admin is set in enrollment and the primary user is admin
-        # - use ManagedLocalUserShortName
+        # TODO ManagedLocalUserShortName
 
-        # auto populate primary account
-        if dep_enrollment.use_realm_user and dep_enrollment.realm_user_is_admin:
-            serialized_password_hash = self._serialize_realm_user_password_hash()
+        if dep_enrollment.use_realm_user:
+            serialized_password_hash = None
+            if self.realm_user.password_hash:
+                serialized_password_hash = serialize_password_hash_dict(self.realm_user.password_hash)
             if not serialized_password_hash:
-                # Auto populate
+                # Auto populate form with realm user
                 command["DontAutoPopulatePrimaryAccountInfo"] = False
+                command["LockPrimaryAccountInfo"] = True
                 command["PrimaryAccountFullName"] = self.realm_user.get_full_name()
                 command["PrimaryAccountUserName"] = self.realm_user.device_username
-                command["SetPrimarySetupAccountAsRegularUser"] = False
-            else:
-                # Auto setup admin
-                admin_account = {"fullName": self.realm_user.get_full_name(),
-                                 "shortName": self.realm_user.device_username,
-                                 "hidden": False,  # TODO => DEP Profile
-                                 "passwordHash": serialized_password_hash}
-                command["AutoSetupAdminAccounts"].append(admin_account)
+                command["SetPrimarySetupAccountAsRegularUser"] = not dep_enrollment.realm_user_is_admin
+            elif dep_enrollment.realm_user_is_admin:
+                # Auto setup admin with realm user
+                command["AutoSetupAdminAccounts"].append({
+                    "fullName": self.realm_user.get_full_name(),
+                    "shortName": self.realm_user.device_username,
+                    "hidden": False,
+                    "passwordHash": serialized_password_hash,
+                })
+                command["SkipPrimarySetupAccountCreation"] = True
 
-        auto_populate = command.get("DontAutoPopulatePrimaryAccountInfo") is False
+        if dep_enrollment.has_hardcoded_admin():
+            command["AutoSetupAdminAccounts"].append({
+                "fullName": dep_enrollment.admin_full_name,
+                "shortName": dep_enrollment.admin_short_name,
+                "hidden": True,  # TODO => DEP Profile
+                "passwordHash": serialize_password_hash_dict(dep_enrollment.admin_password_hash)
+            })
 
-        command["LockPrimaryAccountInfo"] = auto_populate
-        command["SkipPrimarySetupAccountCreation"] = not auto_populate
         return command
 
 

--- a/zentral/contrib/mdm/commands/base.py
+++ b/zentral/contrib/mdm/commands/base.py
@@ -18,6 +18,7 @@ class Command:
     allowed_in_user_enrollment = False
     artifact_operation = None
     store_result = False
+    reschedule_notnow = False
 
     @classmethod
     def get_db_name(cls):
@@ -96,14 +97,18 @@ class Command:
 
     def __init__(self, channel, db_command):
         self.channel = channel
+        self.status = None
         self.db_command = db_command
         if not self.db_command.pk:
             # new command
-            self.db_command.uuid = uuid.uuid4()
+            self.db_command.uuid = self.uuid = uuid.uuid4()
             self.db_command.name = self.get_db_name()
             if self.artifact_operation:
                 self.db_command.artifact_operation = self.artifact_operation.name
             self.db_command.save()
+        elif self.db_command.status:
+            self.uuid = self.db_command.uuid
+            self.status = CommandStatus(self.db_command.status)
         # enrolled objects
         self.enrolled_device = getattr(db_command, "enrolled_device", None)
         self.enrolled_user = getattr(db_command, "enrolled_user", None)
@@ -136,27 +141,28 @@ class Command:
         return HttpResponse(body, content_type="application/xml; charset=UTF-8")
 
     def process_response(self, response, enrollment_session, meta_business_unit):
-        if self.db_command.result_time:
+        if self.db_command.result_time and (not self.reschedule_notnow or not self.status == CommandStatus.NotNow):
             logger.error("Command {self.db_command.uuid} has already been processed")
             return
         self.db_command.result_time = timezone.now()
-        self.db_command.status = response["Status"]
+        self.status = CommandStatus(response["Status"])
+        self.db_command.status = self.status.value
         self.db_command.error_chain = response.get("ErrorChain")
-        if self.store_result:
+        if self.store_result and self.status != CommandStatus.NotNow:
             self.db_command.result = plistlib.dumps(response)
         self.db_command.save()
         self.response = response
         self.enrollment_session = enrollment_session
         self.realm_user = enrollment_session.realm_user
         self.meta_business_unit = meta_business_unit
-        if self.db_command.status == CommandStatus.Acknowledged.value:
+        if self.status == CommandStatus.Acknowledged:
             self.command_acknowledged()
 
     def command_acknowledged(self):
         pass
 
     def set_time(self):
-        if self.db_command.time:
+        if self.db_command.time and not self.status == CommandStatus.NotNow:
             raise ValueError("Command {self.db_command.uuid} has time")
         self.db_command.time = timezone.now()
         self.db_command.save()

--- a/zentral/contrib/mdm/commands/custom.py
+++ b/zentral/contrib/mdm/commands/custom.py
@@ -15,6 +15,7 @@ class CustomCommand(Command):
     allowed_platform = (Platform.iOS, Platform.iPadOS, Platform.macOS, Platform.tvOS)
     allowed_in_user_enrollment = True
     store_result = True
+    reschedule_notnow = True
 
     def load_kwargs(self):
         self.command = plistlib.loads(self.db_command.kwargs["command"].encode("utf-8"))

--- a/zentral/contrib/mdm/commands/declarative_management.py
+++ b/zentral/contrib/mdm/commands/declarative_management.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("zentral.contrib.mdm.commands.declarative_management"
 class DeclarativeManagement(Command):
     request_type = "DeclarativeManagement"
     allowed_channel = Channel.Device
-    allowed_platform = (Platform.iOS, Platform.iPadOS)
+    allowed_platform = (Platform.iOS, Platform.iPadOS, Platform.macOS, Platform.tvOS)
     allowed_in_user_enrollment = True
 
     def command_acknowledged(self):

--- a/zentral/contrib/mdm/migrations/0035_auto_20210530_0717.py
+++ b/zentral/contrib/mdm/migrations/0035_auto_20210530_0717.py
@@ -179,7 +179,15 @@ class Migration(migrations.Migration):
                 ('kwargs', django.contrib.postgres.fields.jsonb.JSONField(default=dict)),
                 ('time', models.DateTimeField(null=True)),
                 ('result_time', models.DateTimeField(null=True)),
-                ('status', models.CharField(choices=[('A', 'A'), ('E', 'E'), ('C', 'C'), ('N', 'N')], max_length=64, null=True)),
+                ('status', models.CharField(
+                    choices=[
+                        ('Acknowledged', 'Acknowledged'),
+                        ('CommandFormatError', 'CommandFormatError'),
+                        ('Error', 'Error'),
+                        ('NotNow', 'NotNow')
+                    ],
+                    max_length=64, null=True)
+                 ),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
                 ('artifact_version', models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, to='mdm.ArtifactVersion')),
@@ -346,7 +354,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='devicecommand',
             name='status',
-            field=models.CharField(choices=[('A', 'A'), ('E', 'E'), ('C', 'C'), ('N', 'N')], max_length=64, null=True),
+            field=models.CharField(
+                choices=[
+                    ('Acknowledged', 'Acknowledged'),
+                    ('CommandFormatError', 'CommandFormatError'),
+                    ('Error', 'Error'),
+                    ('NotNow', 'NotNow')
+                ],
+                max_length=64, null=True
+            ),
         ),
         migrations.AddField(
             model_name='enrolleddevice',

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -867,8 +867,11 @@ class DEPEnrollment(MDMEnrollment):
                                    "created_at": self.created_at,
                                    "updated_at": self.updated_at}}
 
+    def has_hardcoded_admin(self):
+        return self.admin_full_name and self.admin_short_name and self.admin_password_hash
+
     def requires_account_configuration(self):
-        return self.use_realm_user or (self.admin_full_name and self.admin_short_name and self.admin_password_hash)
+        return self.use_realm_user or self.has_hardcoded_admin()
 
 
 class DEPDevice(models.Model):
@@ -1608,13 +1611,24 @@ class UserArtifact(TargetArtifact):
 
 class CommandStatus(enum.Enum):
     Acknowledged = "Acknowledged"
-    Error = "Error"
     CommandFormatError = "CommandFormatError"
+    Error = "Error"
     NotNow = "NotNow"
 
     @classmethod
     def choices(cls):
         return tuple((i.value[0], i.value[0]) for i in cls)
+
+
+class RequestStatus(enum.Enum):
+    Acknowledged = "Acknowledged"
+    CommandFormatError = "CommandFormatError"
+    Error = "Error"
+    Idle = "Idle"
+    NotNow = "NotNow"
+
+    def is_error(self):
+        return self in (RequestStatus.Error, RequestStatus.CommandFormatError)
 
 
 class Command(models.Model):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -1617,7 +1617,7 @@ class CommandStatus(enum.Enum):
 
     @classmethod
     def choices(cls):
-        return tuple((i.value[0], i.value[0]) for i in cls)
+        return tuple((i.name, i.value) for i in cls)
 
 
 class RequestStatus(enum.Enum):


### PR DESCRIPTION
- Refactor the commands to be able to reschedule some of them when the device checks in with an "Idle" status.
- More MDM command tests.
- Rework the AccountConfiguration command.