### PR TITLE
Better handle inactive names in sub manifests

### DIFF
--- a/tests/monolith/test_models.py
+++ b/tests/monolith/test_models.py
@@ -62,6 +62,7 @@ class MonolithModelsTestCase(TestCase):
                                                  data={"name": cls.pkginfo_name_2.name,
                                                        "version": "1.0"})
         cls.pkginfo_2_1.catalogs.set([cls.catalog_1, cls.catalog_2])
+        cls.pkginfo_name_3 = PkgInfoName.objects.create(name="bbbb third name")
         # simulate 1 install of 1v1 and 3 installs of 1v2, 1 install of 2v1
         ManagedInstall.objects.create(
             machine_serial_number=get_random_string(12),
@@ -82,6 +83,11 @@ class MonolithModelsTestCase(TestCase):
             installed_version=cls.pkginfo_2_1.version,
             installed_at=datetime.utcnow()
         )
+
+    def test_pkg_info_name_has_active_pkginfos(self):
+        self.assertTrue(self.pkginfo_name_1.has_active_pkginfos)
+        self.assertTrue(self.pkginfo_name_2.has_active_pkginfos)
+        self.assertFalse(self.pkginfo_name_3.has_active_pkginfos)
 
     def test_manifest_sub_manifest(self):
         self.assertEqual(self.manifest.sub_manifest(self.sub_manifest_1.pk),

--- a/zentral/contrib/monolith/models.py
+++ b/zentral/contrib/monolith/models.py
@@ -117,8 +117,9 @@ class PkgInfoName(models.Model):
     def __str__(self):
         return self.name
 
-    def active_pkginfos(self):
-        return self.pkginfo_set.filter(archived_at__isnull=True)
+    @cached_property
+    def has_active_pkginfos(self):
+        return self.pkginfo_set.filter(archived_at__isnull=True).count() > 0
 
 
 class PkgInfoManager(models.Manager):

--- a/zentral/contrib/monolith/templates/monolith/sub_manifest.html
+++ b/zentral/contrib/monolith/templates/monolith/sub_manifest.html
@@ -89,7 +89,7 @@
     </td>
   </tr>
   {% for name, smo in key_list %}
-  <tr{% if smo.type and smo.trashed_at %} class="warning"{% endif %}>
+  <tr{% if smo.type and smo.trashed_at %} class="warning"{% endif %}{% if smo.pkg_info_name and not smo.pkg_info_name.has_active_pkginfos %} class="danger"{% endif %}>
     <td>
       {% if smo.pkg_info_name %}
       {% if perms.monolith.view_pkginfoname %}
@@ -187,7 +187,7 @@
     </td>
     {% else %}
     <td>
-      {% if perms.monolith.change_submanifestpkginfo %}
+      {% if smo.pkg_info_name.has_active_pkginfos and perms.monolith.change_submanifestpkginfo %}
       <a class="btn btn-default" href="{% url 'monolith:update_sub_manifest_pkg_info' object.id smo.id %}">
         <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
       </a>


### PR DESCRIPTION
- Display a red background for PkgInfoNames without active PkgInfos in sub manifests.
- Do not display the edit button for PkgInfoNames without active PkgInfos in sub manifests.