### PR TITLE
Adding prefix (public) to osquery endpoints

### DIFF
--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -41,11 +41,22 @@ for app_name, app_config in zentral_settings.get('apps', {}).items():
     app_shortname = app_name.rsplit('.', 1)[-1]
     for url_prefix, url_module_name in (("", "urls"),
                                         ("api/", "api_urls"),
-                                        ("metrics/", "metrics_urls")):
+                                        ("metrics/", "metrics_urls"),
+                                        ("public/", "public_urls")):
         if url_module_name == "metrics_urls" and not app_config.get("metrics", False):
             continue
         try:
             urlpatterns.append(path(f"{url_prefix}{app_shortname}/", include(f"{app_name}.{url_module_name}")))
+            if url_module_name == "public_urls" and app_config.get('mount_legacy_public_endpoints', False):
+                urlpatterns.append(
+                    path(
+                         f"{app_shortname}/",
+                         include(
+                              f"{app_name}.{url_module_name}",
+                              namespace=f"{app_shortname}_public_legacy"
+                         )
+                    )
+                )
         except ModuleNotFoundError:
             pass
 

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -38,14 +38,8 @@ urlpatterns = [
 
 
 # zentral apps
-def build_urlpatterns_for_zentral_apps(mount_legacy_public_endpoints=None):
+def build_urlpatterns_for_zentral_apps():
     """ Builds urlpatterns objects from zentral app configurations.
-
-    Args:
-        mount_legacy_public_endpoints (boolean, optional):
-            Set to True if we want do include {url_prefix} endpoints
-            False if not.
-            Defaults to None (injection for testing)
 
     Returns:
         urlpatterns: a list of path or re_path elements
@@ -61,10 +55,7 @@ def build_urlpatterns_for_zentral_apps(mount_legacy_public_endpoints=None):
                 continue
             try:
                 urlpatterns.append(path(f"{url_prefix}{app_shortname}/", include(f"{app_name}.{url_module_name}")))
-                if (
-                    url_module_name == "public_urls" and
-                    (mount_legacy_public_endpoints or app_config.get('mount_legacy_public_endpoints', False))
-                ):
+                if (url_module_name == "public_urls" and app_config.get('mount_legacy_public_endpoints', False)):
                     urlpatterns.append(
                         path(
                             f"{app_shortname}/",

--- a/tests/conf/base.json
+++ b/tests/conf/base.json
@@ -188,9 +188,7 @@
     },
     "zentral.contrib.nagios": {},
     "zentral.contrib.okta": {},
-    "zentral.contrib.osquery": {
-      "mount_legacy_public_endpoints": true
-    },
+    "zentral.contrib.osquery": {},
     "zentral.contrib.puppet": {
       "instances": [
         {

--- a/tests/conf/base.json
+++ b/tests/conf/base.json
@@ -188,7 +188,9 @@
     },
     "zentral.contrib.nagios": {},
     "zentral.contrib.okta": {},
-    "zentral.contrib.osquery": {},
+    "zentral.contrib.osquery": {
+      "mount_legacy_public_endpoints": true
+    },
     "zentral.contrib.puppet": {
       "instances": [
         {

--- a/tests/osquery/test_osquery_api.py
+++ b/tests/osquery/test_osquery_api.py
@@ -1399,7 +1399,7 @@ class OsqueryAPIViewsTestCase(TestCase):
         response = self.post_as_json("carver_continue", post_data)
         self.assertEqual(response.status_code, 400)
 
-    def test_public_urls_are_disabled_on_tests(self):
+    def test_legacy_public_urls_are_disabled_on_tests(self):
         routes = ['enroll', 'config', 'carver_start', 'carver_continue', 'distributed_read', 'distributed_write']
 
         for route in routes:
@@ -1411,9 +1411,10 @@ class OsqueryAPIViewsTestCase(TestCase):
         url_prefix = "/public"
         routes = ['enroll', 'config', 'carver_start', 'carver_continue', 'distributed_read', 'distributed_write']
 
-        settings._collection["apps"]._collection["zentral.contrib.osquery"]._collection["mount_legacy_public_endpoints"] = True  # NOQA
+        obsquery_conf = settings._collection["apps"]._collection["zentral.contrib.osquery"]
+        obsquery_conf._collection["mount_legacy_public_endpoints"] = True
         urlpatterns_w_legacy = tuple(build_urlpatterns_for_zentral_apps())
-        settings._collection["apps"]._collection["zentral.contrib.osquery"]._collection["mount_legacy_public_endpoints"] = False  # NOQA
+        obsquery_conf._collection["mount_legacy_public_endpoints"] = False
         urlpatterns_wo_legacy = tuple(build_urlpatterns_for_zentral_apps())
 
         for route in routes:

--- a/tests/osquery/test_osquery_api.py
+++ b/tests/osquery/test_osquery_api.py
@@ -1411,10 +1411,10 @@ class OsqueryAPIViewsTestCase(TestCase):
         url_prefix = "/public"
         routes = ['enroll', 'config', 'carver_start', 'carver_continue', 'distributed_read', 'distributed_write']
 
-        obsquery_conf = settings._collection["apps"]._collection["zentral.contrib.osquery"]
-        obsquery_conf._collection["mount_legacy_public_endpoints"] = True
+        osquery_conf = settings._collection["apps"]._collection["zentral.contrib.osquery"]
+        osquery_conf._collection["mount_legacy_public_endpoints"] = True
         urlpatterns_w_legacy = tuple(build_urlpatterns_for_zentral_apps())
-        obsquery_conf._collection["mount_legacy_public_endpoints"] = False
+        osquery_conf._collection["mount_legacy_public_endpoints"] = False
         urlpatterns_wo_legacy = tuple(build_urlpatterns_for_zentral_apps())
 
         for route in routes:

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -385,23 +385,23 @@ class Configuration(models.Model):
 
             # tls config every 1200s
             "config_plugin": "tls",
-            "config_tls_endpoint": reverse("osquery:config"),
+            "config_tls_endpoint": reverse("osquery_public:config"),
             "config_refresh": 1200,
 
             # distributed queries enabled with a 60s interval
             "disable_distributed": False,
             "distributed_plugin": "tls",
             "distributed_interval": 60,
-            "distributed_tls_read_endpoint": reverse("osquery:distributed_read"),
-            "distributed_tls_write_endpoint": reverse("osquery:distributed_write"),
+            "distributed_tls_read_endpoint": reverse("osquery_public:distributed_read"),
+            "distributed_tls_write_endpoint": reverse("osquery_public:distributed_write"),
 
             # force tls enrollment
             "disable_enrollment": False,
-            "enroll_tls_endpoint": reverse("osquery:enroll"),
+            "enroll_tls_endpoint": reverse("osquery_public:enroll"),
 
             # tls logger with a 60s period, and compression
             "logger_plugin": "tls",
-            "logger_tls_endpoint": reverse("osquery:log"),
+            "logger_tls_endpoint": reverse("osquery_public:log"),
             "logger_tls_period": 60,
             "logger_tls_compress": True,
         }
@@ -410,8 +410,8 @@ class Configuration(models.Model):
             flags.update({
                 "carver_disable_function": False,
                 "disable_carver": False,
-                "carver_continue_endpoint": reverse("osquery:carver_continue"),
-                "carver_start_endpoint": reverse("osquery:carver_start"),
+                "carver_continue_endpoint": reverse("osquery_public:carver_continue"),
+                "carver_start_endpoint": reverse("osquery_public:carver_start"),
                 "carver_compression": False,  # TODO: implement!
             })
         # Forced because we need the Osquery API views to work

--- a/zentral/contrib/osquery/public_urls.py
+++ b/zentral/contrib/osquery/public_urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
+from . import public_views
+
+app_name = "osquery_public"
+urlpatterns = [
+    # osquery API
+    path('enroll', csrf_exempt(public_views.EnrollView.as_view()), name='enroll'),
+    path('config', csrf_exempt(public_views.ConfigView.as_view()), name='config'),
+    path('carver/start', csrf_exempt(public_views.StartFileCarvingView.as_view()), name='carver_start'),
+    path('carver/continue', csrf_exempt(public_views.ContinueFileCarvingView.as_view()), name='carver_continue'),
+    path('distributed/read', csrf_exempt(public_views.DistributedReadView.as_view()), name='distributed_read'),
+    path('distributed/write', csrf_exempt(public_views.DistributedWriteView.as_view()), name='distributed_write'),
+    path('log', csrf_exempt(public_views.LogView.as_view()), name='log'),
+]

--- a/zentral/contrib/osquery/public_views.py
+++ b/zentral/contrib/osquery/public_views.py
@@ -28,7 +28,7 @@ from zentral.contrib.osquery.tasks import build_file_carving_session_archive
 from zentral.core.events.base import post_machine_conflict_event
 from zentral.utils.http import user_agent_and_ip_address_from_request
 from zentral.utils.json import remove_null_character
-from .utils import (prepare_file_carving_session_if_necessary,
+from .views.utils import (prepare_file_carving_session_if_necessary,
                     update_tree_with_enrollment_host_details, update_tree_with_inventory_query_snapshot)
 
 

--- a/zentral/contrib/osquery/urls.py
+++ b/zentral/contrib/osquery/urls.py
@@ -86,15 +86,6 @@ urlpatterns = [
     path('configurations/<int:configuration_pk>/enrollments/<int:pk>/bump_version/',
          views.EnrollmentBumpVersionView.as_view(),
          name='bump_enrollment_version'),
-
-    # osquery API
-    path('enroll', csrf_exempt(views.EnrollView.as_view()), name='enroll'),
-    path('config', csrf_exempt(views.ConfigView.as_view()), name='config'),
-    path('carver/start', csrf_exempt(views.StartFileCarvingView.as_view()), name='carver_start'),
-    path('carver/continue', csrf_exempt(views.ContinueFileCarvingView.as_view()), name='carver_continue'),
-    path('distributed/read', csrf_exempt(views.DistributedReadView.as_view()), name='distributed_read'),
-    path('distributed/write', csrf_exempt(views.DistributedWriteView.as_view()), name='distributed_write'),
-    path('log', csrf_exempt(views.LogView.as_view()), name='log'),
 ]
 
 

--- a/zentral/contrib/osquery/views/__init__.py
+++ b/zentral/contrib/osquery/views/__init__.py
@@ -1,4 +1,3 @@
-from .api import *  # NOQA
 from .atcs import *  # NOQA
 from .configurations import *  # NOQA
 from .distributed_queries import *  # NOQA


### PR DESCRIPTION
Following [URL prefix for agent views](https://zentral-pro.slab.com/public/posts/url-prefix-for-agent-views-mqpd51kg)

* Added new files for public endpoints and views.
* New configuration flag `mount_legacy_public_endpoints` for apps.
* New test for public urls `test_public_urls`
* Tests enabling/disabling `mount_legacy_public_endpoints`

TBD
* Extend strategy to Santa.
