### PR TITLE
fix: osquery public endpoint test was incorrect.

### DIFF
--- a/tests/osquery/test_osquery_api.py
+++ b/tests/osquery/test_osquery_api.py
@@ -1423,4 +1423,4 @@ class OsqueryAPIViewsTestCase(TestCase):
                 url_prefix + reverse(f"osquery_public_legacy:{route}", urlconf=urlpatterns_w_legacy)
             )
             with self.assertRaises(NoReverseMatch):
-                reverse("osquery_public:{route}", args=urlpatterns_wo_legacy)
+                reverse(f"osquery_public_legacy:{route}", args=urlpatterns_wo_legacy)

--- a/tests/osquery/test_osquery_api.py
+++ b/tests/osquery/test_osquery_api.py
@@ -1423,4 +1423,4 @@ class OsqueryAPIViewsTestCase(TestCase):
                 url_prefix + reverse(f"osquery_public_legacy:{route}", urlconf=urlpatterns_w_legacy)
             )
             with self.assertRaises(NoReverseMatch):
-                reverse(f"osquery_public_legacy:{route}", args=urlpatterns_wo_legacy)
+                reverse(f"osquery_public_legacy:{route}", urlconf=urlpatterns_wo_legacy)


### PR DESCRIPTION
Refer to:

https://github.com/zentralopensource/zentral/pull/635#pullrequestreview-1310332734