### PR TITLE
Add MDM request signature header verification

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -2,6 +2,18 @@
 
 Zentral can be used as MDM server for Apple devices.
 
+## Zentral configuration
+
+To activate the MDM module, you need to add a `zentral.contrib.mdm` section to the `apps` section in `base.json`.
+
+### SCEP CA issuer chain
+
+To authenticate the OTA enrollments, Zentral needs the SCEP CA issuer certificate chain in PEM form in the `scep_ca_fullchain` key of the `zentral.contrib.mdm` section. It is possible to use the `{{ file:PATH_TO_PEM_CHAIN }}` substitution to load the chain from a file on disk.
+
+### mTLS proxy
+
+Zentral is expecting the client certificate in PEM form in the `X-SSL-Client-Cert` header, and the client certificate subject DN in the `X-SSL-Client-S-DN` header. If this is not possible, you can set `mtls_proxy` to `false` in the `zentral.contrib.mdm` section. In that case, the Apple devices will be configured to add a header containing the payload signature in each HTTP request. See the [Apple documentation](https://developer.apple.com/documentation/devicemanagement/implementing_device_management/managing_certificates_for_mdm_servers_and_devices#3677960). This adds approximately 2KB of data to each message.
+
 ## Push certificates
 
 To be able to send notifications to the devices, Zentral needs a push certificate (aka. APNS certificate). To get one, you first need to generate an MDM vendor certificate. An Apple [Developer Enterprise Account](https://developer.apple.com/programs/enterprise/) with the ability to generate MDM CSRs is required. You can then use this vendor certificate to sign an APNS certificate request. The `mdmcerts` Zentral management command can be used to help with this process.

--- a/zentral/contrib/mdm/crypto.py
+++ b/zentral/contrib/mdm/crypto.py
@@ -123,12 +123,16 @@ def verify_certificate_signature(certificate, signer, payload):
         return True
 
 
-def verify_signed_payload(data):
-    content_info = cms.ContentInfo.load(data)
+def verify_signed_payload(payload, detached_signature=None):
+    if detached_signature:
+        content_info = cms.ContentInfo.load(detached_signature)
+    else:
+        content_info = cms.ContentInfo.load(payload)
     if content_info["content_type"].native != "signed_data":
         raise ValueError("Not signed data")
     content = content_info["content"]
-    payload = content['encap_content_info']['content'].native
+    if not detached_signature:
+        payload = content['encap_content_info']['content'].native
     certificates = []
     for signer in content["signer_infos"]:
         certificate_i, certificate_bytes, certificate = get_signer_certificate(content, signer)


### PR DESCRIPTION
This allows the Zentral MDM to work behind all proxies or load balancers, even if they cannot be configured to pass the client certificate data.