### PR TITLE
fix: Broken image links in documentation

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -31,7 +31,7 @@
 
 ### Key Components
 
-![Software Architecture overview](/images/architecture/key_components.svg)
+![Software Architecture overview](../../images/architecture/key_components.svg)
 
 #### Description
 
@@ -63,7 +63,7 @@
 
 A module refers to a **pluggable standalone component or extension** that provides additional functionality to the platform. Some of the ones supported by Zentral are shown in the following diagram.
 
-![Software Architecture Modules](/images/architecture/modules.svg)
+![Software Architecture Modules](../../images/architecture/modules.svg)
 
 ### Interactions with Endpoints
 

--- a/docs/deployment/zaio-gcp.md
+++ b/docs/deployment/zaio-gcp.md
@@ -29,17 +29,17 @@ Select a **Region** and a **Zone**.
 
 The default _General-purpose_ **Machine family**, and _e2-standard-2_ **Machine type** are OK to test Zentral.
 
-![Create instance form first sections](/images/deployment/zaio-gcp/create_instance_top_form.png)
+![Create instance form first sections](../../images/deployment/zaio-gcp/create_instance_top_form.png)
 
 In the **Boot disk** section, click on the [Change] button, go to the [Custom images] tab. Set `sublime-delight-encoder` or `Zentral Pro Services` as the project, and in the dropdown, select the latest `zaio-ARCH-YYYYMMDD-HHMMSS`.
 
-![Select zentral-all-in-one custom image](/images/deployment/zaio-gcp/select_image.png)
+![Select zentral-all-in-one custom image](../../images/deployment/zaio-gcp/select_image.png)
 
 You can start with one 10GB SSD persistent disk. But that would be only enough to store a limited amount of events. As a rule of thumb, you will need about 9GB + 1GB for every million of events stored, but that can vary a lot depending on your inventory sources, and the kind of events you are collecting.
 
 This is what you should see in the *Boot disk* section:
 
-![zentral-all-in-one-image-selected](/images/deployment/zaio-gcp/boot_disk_selected.png)
+![zentral-all-in-one-image-selected](../../images/deployment/zaio-gcp/boot_disk_selected.png)
 
 We will use the **Compute engine default service account** and the **default access scopes**. Again, not recemmended for production.
 
@@ -59,6 +59,6 @@ Zentral requires at leat one domain name resolving to the IP address of the laun
 
 You can open a ssh session via the Google Cloud. Click on the instance in the [list of all instance](https://console.cloud.google.com/compute/instances). At the top of the instance page, open the **Remote access / SSH** menu and select _Open in browser window_. A new tab will open and a ssh session will start.
 
-![open ssh in browser window](/images/deployment/zaio-gcp/open_ssh_in_browser_window.png)
+![open ssh in browser window](../../images/deployment/zaio-gcp/open_ssh_in_browser_window.png)
 
 Once logged in, you can use a [command line tool to setup your instance](../zaio-setup). Because this last step is the same for a AWS deployment, we have kept it on a separate wiki page.


### PR DESCRIPTION
Looks like the paths for images should be relative instead of absolute despite having WARNINGS on the mkdocs logs.

Follow up of #671 

```logs
WARNING  -  Documentation file 'architecture/index.md' contains a link to '../images/architecture/key_components.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'architecture/index.md' contains a link to '../images/architecture/modules.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'deployment/zaio-gcp.md' contains a link to '../images/deployment/zaio-gcp/create_instance_top_form.png' which is not found in the documentation
            files.
WARNING  -  Documentation file 'deployment/zaio-gcp.md' contains a link to '../images/deployment/zaio-gcp/select_image.png' which is not found in the documentation files.
WARNING  -  Documentation file 'deployment/zaio-gcp.md' contains a link to '../images/deployment/zaio-gcp/boot_disk_selected.png' which is not found in the documentation files.
WARNING  -  Documentation file 'deployment/zaio-gcp.md' contains a link to '../images/deployment/zaio-gcp/open_ssh_in_browser_window.png' which is not found in the documentation
```