### PR TITLE
fix: get_client_secret vs client_secret on template

### DIFF
--- a/ee/zentral/contrib/intune/templates/intune/tenant_detail.html
+++ b/ee/zentral/contrib/intune/templates/intune/tenant_detail.html
@@ -54,7 +54,7 @@
         <td>Client Secret</td>
         <td>
             <span class="glyphicon glyphicon-eye-open" aria-hidden="true" style="cursor:pointer"></span>
-            <span hidden>{{ object.client_secret }}</span>
+            <span hidden>{{ object.get_client_secret }}</span>
         </td>
     </tr>
   </tbody>

--- a/tests/intune/test_index_view.py
+++ b/tests/intune/test_index_view.py
@@ -110,6 +110,7 @@ class IntuneViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "intune/tenant_detail.html")
         tenant = response.context["object"]
+        self.assertContains(response, tenant.get_client_secret())
         self.assertEqual(tenant.name, name)
         self.assertEqual(tenant.description, description)
         self.assertEqual(tenant.tenant_id, tenant_id)


### PR DESCRIPTION
Displaying correct info when revealing secrets on tenant display template

![Screenshot 2023-05-29 at 14 39 16](https://github.com/zentralopensource/zentral/assets/121728/0a435dbf-bfee-40d6-b9e0-e79bef5338db)


