### PR TITLE
fix: Remove unnecessary method from intune views

### DIFF
--- a/ee/zentral/contrib/intune/views.py
+++ b/ee/zentral/contrib/intune/views.py
@@ -17,15 +17,6 @@ logger = logging.getLogger('zentral.contrib.intune.views')
 class IndexView(LoginRequiredMixin, TemplateView):
     template_name = "intune/index.html"
 
-    def get_context_data(self, **kwargs):
-        if not self.request.user.has_module_perms("intune"):
-            raise PermissionDenied("Not allowed")
-        ctx = super().get_context_data(**kwargs)
-        tenant_qs = Tenant.objects.all()
-        ctx["tenants"] = tenant_qs
-        ctx["tenant_count"] = tenant_qs.count()
-        return ctx
-
 
 # Tenants
 


### PR DESCRIPTION
Removed `get_context_data` from intune views, as is not needed (same as default one).