### PR TITLE
Fix MDM blueprint API concurrency issue

### DIFF
--- a/zentral/contrib/mdm/artifacts.py
+++ b/zentral/contrib/mdm/artifacts.py
@@ -13,7 +13,7 @@ from .declarations import (build_target_management_status_subscriptions,
                            get_legacy_profile_identifier,
                            get_legacy_profile_server_token)
 from .models import (Artifact, ArtifactVersion,
-                     BlueprintArtifact,
+                     Blueprint, BlueprintArtifact,
                      Channel,
                      DeviceArtifact, DeviceCommand,
                      TargetArtifact,
@@ -91,6 +91,9 @@ def _serialize_artifact_version(artifact_version):
 
 def update_blueprint_serialized_artifacts(blueprint, commit=True):
     artifacts = {}
+    # lock the blueprint
+    Blueprint.objects.select_for_update().get(pk=blueprint.pk)
+    # update the blueprint
     for bpa in (BlueprintArtifact.objects.prefetch_related("item_tags__tag",
                                                            "excluded_tags",
                                                            "artifact__requires")


### PR DESCRIPTION
The blueprint serialized artifacts must be updated after the artifacts, profiles, and blueprint artifacts are changed.

If changes occur concurrently, the serialized artifacts may be inconsistent, because of the transaction isolation in PostgreSQL: the blueprint is updated with the changes seen in the transaction, not the other transactions that might be currently open.

We use multiple transactions and locks on the blueprints to make sure all changes are seen before the serialized artifacts are updated.