### PR TITLE
Better MDM legacy profile download view

### DIFF
--- a/zentral/contrib/mdm/public_urls.py
+++ b/zentral/contrib/mdm/public_urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     path('device_commands/<uuid:uuid>/enterprise_app/',
          public_views.EnterpriseAppDownloadView.as_view(),
          name="enterprise_app_download"),
-    path('profiles/<uuid:pk>/',
+    path('profiles/<str:token>/',
          public_views.ProfileDownloadView.as_view(),
          name="profile_download_view"),
 


### PR DESCRIPTION
We do not rely on mTLS anymore for authentication. Instead, we use a signed token containing the required information to be able to serve the profile.