### PR TITLE
Do not set an expiry on DEP enrollment sessions

### DIFF
--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -1370,15 +1370,11 @@ class DEPEnrollmentSessionManager(models.Manager):
         # verified only once with the SCEP payload
         quota = 1
 
-        # expires 60 minutes from now, plenty enough for the device to contact the SCEP server
-        expired_at = timezone.now() + timedelta(hours=1)
-
         new_es = EnrollmentSecret(
             meta_business_unit=meta_business_unit,
             serial_numbers=[serial_number],
             udids=[udid],
             quota=quota,
-            expired_at=expired_at,
         )
         new_es.save(secret_length=56)  # CN max 64 - $ separator - prefix MDM$DEP
         new_es.tags.set(tags)


### PR DESCRIPTION
iOS devices will reuse the same session in case of a SCEP verification error, which can lead to a device being unable to enroll, even after the SCEP verification issue has been solved.

Even without an expiry, the session can only be used once.