### PR TITLE
Better MDM commands schedule

### DIFF
--- a/tests/mdm/test_certificate_list_command.py
+++ b/tests/mdm/test_certificate_list_command.py
@@ -6,7 +6,7 @@ from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit, MetaMachine
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import CertificateList
-from zentral.contrib.mdm.commands.scheduling import _update_inventory
+from zentral.contrib.mdm.commands.scheduling import _update_extra_inventory
 from zentral.contrib.mdm.models import Blueprint, Channel, Platform, RequestStatus
 from .utils import force_dep_enrollment_session
 
@@ -167,9 +167,9 @@ class CertificateListCommandTestCase(TestCase):
         ms = m.snapshots[0]
         self.assertEqual(ms.certificates.count(), 0)
 
-    # _update_inventory
+    # _update_extra_inventory
 
-    def test_update_inventory_do_not_collect_certificates_noop(self):
+    def test_update_extra_inventory_do_not_collect_certificates_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.assertEqual(self.enrolled_device.blueprint.collect_apps,
@@ -178,13 +178,13 @@ class CertificateListCommandTestCase(TestCase):
         self.assertEqual(self.enrolled_device.blueprint.collect_profiles,
                          Blueprint.InventoryItemCollectionOption.NO)
         self.assertIsNone(self.enrolled_device.certificates_updated_at)
-        self.assertIsNone(_update_inventory(
+        self.assertIsNone(_update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
         ))
 
-    def test_update_inventory_managed_certificates_updated_at_none(self):
+    def test_update_extra_inventory_managed_certificates_updated_at_none(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.assertEqual(self.enrolled_device.blueprint.collect_apps,
@@ -193,7 +193,7 @@ class CertificateListCommandTestCase(TestCase):
         self.assertEqual(self.enrolled_device.blueprint.collect_profiles,
                          Blueprint.InventoryItemCollectionOption.NO)
         self.assertIsNone(self.enrolled_device.certificates_updated_at)
-        cmd = _update_inventory(
+        cmd = _update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
@@ -202,7 +202,7 @@ class CertificateListCommandTestCase(TestCase):
         self.assertTrue(cmd.managed_only)
         self.assertTrue(cmd.update_inventory)
 
-    def test_update_inventory_all_certificates_updated_at_old(self):
+    def test_update_extra_inventory_all_certificates_updated_at_old(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.ALL
@@ -211,7 +211,7 @@ class CertificateListCommandTestCase(TestCase):
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.apps_updated_at = datetime.utcnow()
         self.enrolled_device.certificates_updated_at = datetime(2000, 1, 1)
-        cmd = _update_inventory(
+        cmd = _update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
@@ -220,7 +220,7 @@ class CertificateListCommandTestCase(TestCase):
         self.assertFalse(cmd.managed_only)
         self.assertTrue(cmd.update_inventory)
 
-    def test_update_inventory_all_certificates_noop(self):
+    def test_update_extra_inventory_all_certificates_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.ALL
@@ -229,7 +229,7 @@ class CertificateListCommandTestCase(TestCase):
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.apps_updated_at = datetime.utcnow()
         self.enrolled_device.certificates_updated_at = datetime.utcnow()
-        self.assertIsNone(_update_inventory(
+        self.assertIsNone(_update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,

--- a/tests/mdm/test_commands_scheduling.py
+++ b/tests/mdm/test_commands_scheduling.py
@@ -7,7 +7,8 @@ from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import DeviceInformation
 from zentral.contrib.mdm.commands.scheduling import (
     _get_next_queued_command,
-    _update_inventory,
+    _update_base_inventory,
+    _update_extra_inventory,
 )
 from zentral.contrib.mdm.models import (
     Blueprint,
@@ -91,29 +92,48 @@ class TestMDMCommandsScheduling(TestCase):
 
     # update inventory
 
-    def test_update_inventory_not_now_noop(self):
+    def test_update_base_inventory_not_now_noop(self):
         self.assertIsNone(
-            _update_inventory(
+            _update_base_inventory(
                 Target(self.enrolled_device),
                 self.dep_enrollment_session,
                 RequestStatus.NOT_NOW,
             )
         )
 
-    def test_update_inventory_user_channel_noop(self):
+    def test_update_extra_inventory_not_now_noop(self):
+        self.assertIsNone(
+            _update_extra_inventory(
+                Target(self.enrolled_device),
+                self.dep_enrollment_session,
+                RequestStatus.NOT_NOW,
+            )
+        )
+
+    def test_update_base_inventory_user_channel_noop(self):
         self.assertIsNotNone(self.enrolled_device.blueprint)
         self.assertIsNone(
-            _update_inventory(
+            _update_base_inventory(
                 Target(self.enrolled_device, self.enrolled_user),
                 self.dep_enrollment_session,
                 RequestStatus.IDLE,
             )
         )
 
-    def test_update_inventory_no_blueprint_noop(self):
+    def test_update_extra_inventory_user_channel_noop(self):
+        self.assertIsNotNone(self.enrolled_device.blueprint)
+        self.assertIsNone(
+            _update_extra_inventory(
+                Target(self.enrolled_device, self.enrolled_user),
+                self.dep_enrollment_session,
+                RequestStatus.IDLE,
+            )
+        )
+
+    def test_update_extra_inventory_no_blueprint_noop(self):
         self.enrolled_device.blueprint = None
         self.assertIsNone(
-            _update_inventory(
+            _update_extra_inventory(
                 Target(self.enrolled_device),
                 self.dep_enrollment_session,
                 RequestStatus.IDLE,
@@ -136,7 +156,14 @@ class TestMDMCommandsScheduling(TestCase):
         self.enrolled_device.certificates_updated_at = datetime.utcnow()
         self.enrolled_device.profiles_updated_at = datetime.utcnow()
         self.assertIsNone(
-            _update_inventory(
+            _update_base_inventory(
+                Target(self.enrolled_device),
+                self.dep_enrollment_session,
+                RequestStatus.IDLE,
+            )
+        )
+        self.assertIsNone(
+            _update_extra_inventory(
                 Target(self.enrolled_device),
                 self.dep_enrollment_session,
                 RequestStatus.IDLE,

--- a/tests/mdm/test_device_configured_command.py
+++ b/tests/mdm/test_device_configured_command.py
@@ -88,13 +88,15 @@ class DeviceConfiguredCommandTestCase(TestCase):
             RequestStatus.IDLE,
         ))
 
-    def test_device_configured_notnow_noop(self):
+    def test_device_configured_notnow_ok(self):
         self.enrolled_device.awaiting_configuration = True
-        self.assertIsNone(_finish_dep_enrollment_configuration(
+        command = _finish_dep_enrollment_configuration(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.NOT_NOW,
-        ))
+        )
+        self.assertIsInstance(command, DeviceConfigured)
+        self.assertEqual(command.channel, Channel.DEVICE)
 
     def test_device_configured(self):
         self.enrolled_device.awaiting_configuration = True

--- a/tests/mdm/test_device_information_command.py
+++ b/tests/mdm/test_device_information_command.py
@@ -8,7 +8,7 @@ from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit, MetaMachine
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import DeviceInformation, SecurityInfo
-from zentral.contrib.mdm.commands.scheduling import _update_inventory
+from zentral.contrib.mdm.commands.scheduling import _update_base_inventory
 from zentral.contrib.mdm.models import Blueprint, Channel, Platform, RequestStatus
 from .utils import force_dep_enrollment_session
 
@@ -211,30 +211,30 @@ class DeviceInformationCommandTestCase(TestCase):
         self.assertEqual(enrolled_device.build_version_extra, "22E772610a")
         self.assertEqual(enrolled_device.full_os_version, "13.0 (a) (22E772610a)")
 
-    # _update_inventory
+    # _update_base_inventory
 
-    def test_update_inventory_device_information_updated_at_none(self):
+    def test_update_base_inventory_device_information_updated_at_none(self):
         self.assertIsNone(self.enrolled_device.device_information_updated_at)
-        cmd = _update_inventory(
+        cmd = _update_base_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
         )
         self.assertIsInstance(cmd, DeviceInformation)
 
-    def test_update_inventory_device_information_updated_at_old(self):
+    def test_update_base_inventory_device_information_updated_at_old(self):
         self.enrolled_device.device_information_updated_at = datetime(2000, 1, 1)
-        cmd = _update_inventory(
+        cmd = _update_base_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
         )
         self.assertIsInstance(cmd, DeviceInformation)
 
-    def test_update_inventory_device_information_updated_at_ok(self):
+    def test_update_base_inventory_device_information_updated_at_ok(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.assertIsNone(self.enrolled_device.security_info_updated_at)
-        cmd = _update_inventory(
+        cmd = _update_base_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,

--- a/tests/mdm/test_installed_application_list_command.py
+++ b/tests/mdm/test_installed_application_list_command.py
@@ -6,7 +6,7 @@ from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit, MetaMachine
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import InstalledApplicationList
-from zentral.contrib.mdm.commands.scheduling import _update_inventory
+from zentral.contrib.mdm.commands.scheduling import _update_extra_inventory
 from zentral.contrib.mdm.models import Blueprint, Channel, Platform, RequestStatus
 from .utils import force_dep_enrollment_session
 
@@ -131,9 +131,9 @@ class InstalledApplicationListCommandTestCase(TestCase):
         ms = m.snapshots[0]
         self.assertEqual(ms.osx_app_instances.count(), 0)
 
-    # _update_inventory
+    # _update_extra_inventory
 
-    def test_update_inventory_do_not_collect_apps_noop(self):
+    def test_update_extra_inventory_do_not_collect_apps_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.NO
@@ -142,13 +142,13 @@ class InstalledApplicationListCommandTestCase(TestCase):
         self.assertEqual(self.enrolled_device.blueprint.collect_profiles,
                          Blueprint.InventoryItemCollectionOption.NO)
         self.assertIsNone(self.enrolled_device.apps_updated_at)
-        self.assertIsNone(_update_inventory(
+        self.assertIsNone(_update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
         ))
 
-    def test_update_inventory_managed_apps_updated_at_none(self):
+    def test_update_extra_inventory_managed_apps_updated_at_none(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.MANAGED_ONLY
@@ -157,7 +157,7 @@ class InstalledApplicationListCommandTestCase(TestCase):
         self.assertEqual(self.enrolled_device.blueprint.collect_profiles,
                          Blueprint.InventoryItemCollectionOption.NO)
         self.assertIsNone(self.enrolled_device.apps_updated_at)
-        cmd = _update_inventory(
+        cmd = _update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
@@ -166,7 +166,7 @@ class InstalledApplicationListCommandTestCase(TestCase):
         self.assertTrue(cmd.managed_only)
         self.assertTrue(cmd.update_inventory)
 
-    def test_update_inventory_all_apps_updated_at_old(self):
+    def test_update_extra_inventory_all_apps_updated_at_old(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.ALL
@@ -175,7 +175,7 @@ class InstalledApplicationListCommandTestCase(TestCase):
         self.assertEqual(self.enrolled_device.blueprint.collect_profiles,
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.apps_updated_at = datetime(2000, 1, 1)
-        cmd = _update_inventory(
+        cmd = _update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
@@ -184,7 +184,7 @@ class InstalledApplicationListCommandTestCase(TestCase):
         self.assertFalse(cmd.managed_only)
         self.assertTrue(cmd.update_inventory)
 
-    def test_update_inventory_managed_apps_noop(self):
+    def test_update_extra_inventory_managed_apps_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.MANAGED_ONLY
@@ -193,7 +193,7 @@ class InstalledApplicationListCommandTestCase(TestCase):
         self.assertEqual(self.enrolled_device.blueprint.collect_profiles,
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.apps_updated_at = datetime.utcnow()
-        self.assertIsNone(_update_inventory(
+        self.assertIsNone(_update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,

--- a/tests/mdm/test_profile_list_command.py
+++ b/tests/mdm/test_profile_list_command.py
@@ -6,7 +6,7 @@ from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit, MetaMachine
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import ProfileList
-from zentral.contrib.mdm.commands.scheduling import _update_inventory
+from zentral.contrib.mdm.commands.scheduling import _update_extra_inventory
 from zentral.contrib.mdm.models import Blueprint, Channel, Platform, RequestStatus
 from .utils import force_dep_enrollment_session
 
@@ -214,9 +214,9 @@ class ProfileListCommandTestCase(TestCase):
         ms = m.snapshots[0]
         self.assertEqual(ms.profiles.count(), 0)
 
-    # _update_inventory
+    # _update_extra_inventory
 
-    def test_update_inventory_do_not_collect_profiles_noop(self):
+    def test_update_extra_inventory_do_not_collect_profiles_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.assertEqual(self.enrolled_device.blueprint.collect_apps,
@@ -225,13 +225,13 @@ class ProfileListCommandTestCase(TestCase):
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.blueprint.collect_profiles = Blueprint.InventoryItemCollectionOption.NO
         self.assertIsNone(self.enrolled_device.profiles_updated_at)
-        self.assertIsNone(_update_inventory(
+        self.assertIsNone(_update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
         ))
 
-    def test_update_inventory_managed_profiles_updated_at_none(self):
+    def test_update_extra_inventory_managed_profiles_updated_at_none(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.assertEqual(self.enrolled_device.blueprint.collect_apps,
@@ -240,7 +240,7 @@ class ProfileListCommandTestCase(TestCase):
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.blueprint.collect_profiles = Blueprint.InventoryItemCollectionOption.MANAGED_ONLY
         self.assertIsNone(self.enrolled_device.profiles_updated_at)
-        cmd = _update_inventory(
+        cmd = _update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
@@ -249,7 +249,7 @@ class ProfileListCommandTestCase(TestCase):
         self.assertTrue(cmd.managed_only)
         self.assertTrue(cmd.update_inventory)
 
-    def test_update_inventory_all_profiles_updated_at_old(self):
+    def test_update_extra_inventory_all_profiles_updated_at_old(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.enrolled_device.blueprint.collect_apps = Blueprint.InventoryItemCollectionOption.ALL
@@ -258,7 +258,7 @@ class ProfileListCommandTestCase(TestCase):
         self.enrolled_device.apps_updated_at = datetime.utcnow()
         self.enrolled_device.certificates_updated_at = datetime.utcnow()
         self.enrolled_device.profiles_updated_at = datetime(2000, 1, 1)
-        cmd = _update_inventory(
+        cmd = _update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
@@ -267,7 +267,7 @@ class ProfileListCommandTestCase(TestCase):
         self.assertFalse(cmd.managed_only)
         self.assertTrue(cmd.update_inventory)
 
-    def test_update_inventory_managed_profiles_noop(self):
+    def test_update_extra_inventory_managed_profiles_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.assertEqual(self.enrolled_device.blueprint.collect_apps,
@@ -276,7 +276,7 @@ class ProfileListCommandTestCase(TestCase):
                          Blueprint.InventoryItemCollectionOption.NO)
         self.enrolled_device.blueprint.collect_profiles = Blueprint.InventoryItemCollectionOption.MANAGED_ONLY
         self.enrolled_device.profiles_updated_at = datetime.utcnow()
-        self.assertIsNone(_update_inventory(
+        self.assertIsNone(_update_extra_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,

--- a/tests/mdm/test_security_info_command.py
+++ b/tests/mdm/test_security_info_command.py
@@ -10,7 +10,7 @@ from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import SecurityInfo
-from zentral.contrib.mdm.commands.scheduling import _update_inventory
+from zentral.contrib.mdm.commands.scheduling import _update_base_inventory
 from zentral.contrib.mdm.commands.setup_filevault import get_escrow_key_certificate_der_bytes
 from zentral.contrib.mdm.crypto import encrypt_cms_payload
 from zentral.contrib.mdm.events import FileVaultPRKUpdatedEvent
@@ -223,26 +223,26 @@ class SecurityInfoCommandTestCase(TestCase):
         self.assertIsNone(self.enrolled_device.bootstrap_token_required_for_software_update)
         self.assertIsNone(self.enrolled_device.bootstrap_token_required_for_kext_approval)
 
-    # _update_inventory
+    # _update_base_inventory
 
-    def test_update_inventory_security_info_updated_at_old(self):
+    def test_update_base_inventory_security_info_updated_at_old(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime(2000, 1, 1)
-        cmd = _update_inventory(
+        cmd = _update_base_inventory(
             Target(self.enrolled_device),
             self.dep_enrollment_session,
             RequestStatus.IDLE,
         )
         self.assertIsInstance(cmd, SecurityInfo)
 
-    def test_update_inventory_security_info_updated_at_ok_no_inventory_items_collection_noop(self):
+    def test_update_base_inventory_security_info_updated_at_ok_no_inventory_items_collection_noop(self):
         self.enrolled_device.device_information_updated_at = datetime.utcnow()
         self.enrolled_device.security_info_updated_at = datetime.utcnow()
         self.assertEqual(self.blueprint.collect_apps, Blueprint.InventoryItemCollectionOption.NO)
         self.assertEqual(self.blueprint.collect_certificates, Blueprint.InventoryItemCollectionOption.NO)
         self.assertEqual(self.blueprint.collect_profiles, Blueprint.InventoryItemCollectionOption.NO)
         self.assertIsNone(
-            _update_inventory(
+            _update_base_inventory(
                 Target(self.enrolled_device),
                 self.dep_enrollment_session,
                 RequestStatus.IDLE,


### PR DESCRIPTION
 - Always send the DeviceConfigured command
 - Send the base inventory commands (Device, Security info) even if there are no blueprints.
 - Send the extra inventory commands (Certs, Profiles, Apps) after the device is configured.