### PR TITLE
Unify table-object-properties

### DIFF
--- a/ee/zentral/contrib/intune/templates/intune/tenant_detail.html
+++ b/ee/zentral/contrib/intune/templates/intune/tenant_detail.html
@@ -32,7 +32,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <tr>
         <th style="width:20vw">Attribute</th>

--- a/ee/zentral/contrib/wsone/templates/wsone/instance_detail.html
+++ b/ee/zentral/contrib/wsone/templates/wsone/instance_detail.html
@@ -36,7 +36,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <tr>
         <th style="width:20vw">Attribute</th>

--- a/server/realms/templates/realms/realm_detail.html
+++ b/server/realms/templates/realms/realm_detail.html
@@ -33,7 +33,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
             <thead>
                 <th>Attribute</th>
                 <th>Value</th>

--- a/server/static_src/scss/styles.scss
+++ b/server/static_src/scss/styles.scss
@@ -164,6 +164,21 @@ td > p:last-child, td > table:last-child {
     margin-bottom: 0px;
 }
 
+.table-object-properties {
+  @extend .table;
+  @extend .table-striped;
+  @extend .align-middle;
+}
+
+.table-object-properties td:first-child {
+  width: 250px;
+  vertical-align: top;
+}
+
+.table-object-properties > :not(caption) > * > * {
+  padding: $custom-table-padding;
+}
+
 .table-probe  {
     margin-bottom: -1px;
 }
@@ -236,10 +251,6 @@ td > p:last-child, td > table:last-child {
       pointer-events: none;
     }
   }
-}
-
-.table-object-properties > :not(caption) > * > * {
-  padding: $custom-table-padding;
 }
 
 // Zentral logo

--- a/server/templates/accounts/profile.html
+++ b/server/templates/accounts/profile.html
@@ -13,7 +13,7 @@
 <h3>Profile</h3>
 
 <div class="object-details">
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:15%">username</th>

--- a/server/templates/accounts/user_detail.html
+++ b/server/templates/accounts/user_detail.html
@@ -22,7 +22,7 @@
             {% endif %}
         </div>
     </div>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         {% if object.is_service_account %}
         <tr>

--- a/zentral/contrib/inventory/templates/inventory/compliancecheck_detail.html
+++ b/zentral/contrib/inventory/templates/inventory/compliancecheck_detail.html
@@ -45,7 +45,7 @@
     </div>
 
 
-<table class="table table-striped align-middle table-object-properties">
+<table class="table-object-properties">
   <thead>
     <th>Attribute</th>
     <th>Value</th>

--- a/zentral/contrib/jamf/templates/jamf/jamfinstance_detail.html
+++ b/zentral/contrib/jamf/templates/jamf/jamfinstance_detail.html
@@ -35,7 +35,7 @@
         </div>
     </div>
     
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <tr>
         <th style="width:30vw">Attribute</th>

--- a/zentral/contrib/mdm/templates/mdm/artifact_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/artifact_detail.html
@@ -28,7 +28,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:33vw">Type</th>

--- a/zentral/contrib/mdm/templates/mdm/artifactversion_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/artifactversion_detail.html
@@ -33,7 +33,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <tbody>
         {% if enterprise_app %}
         {% include "mdm/_enterprise_app_detail.html" %}

--- a/zentral/contrib/mdm/templates/mdm/blueprint_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/blueprint_detail.html
@@ -29,7 +29,7 @@
 
     <div class="row">
     <div class="col-md-12">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
         <thead>
             <th width="33%">Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/mdm/templates/mdm/depdevice_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/depdevice_detail.html
@@ -28,7 +28,7 @@
             {% endif %}
         </div>
     </div>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th>Serial number</th>

--- a/zentral/contrib/mdm/templates/mdm/depenrollment_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/depenrollment_detail.html
@@ -28,7 +28,7 @@
         </div>
     </div>
     <h4>Configuration</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="200px">Push certificate</th>
@@ -89,7 +89,7 @@
     </table>
 
     <h4>Authentication</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="200px">Realm</th>
@@ -130,7 +130,7 @@
 
     <h4>DEP Profile</h4>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         {% with object.virtual_server as virtual_server %}
         <tr>

--- a/zentral/contrib/mdm/templates/mdm/depvirtualserver_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/depvirtualserver_detail.html
@@ -86,7 +86,7 @@
     <h3>Profile{{ enrollment_count|pluralize }} ({{ enrollment_count }})</h3>
 
     {% if enrollment_count %}
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
       <thead>
         <th class="col-md-4">Enrollment</th>
         <th class="col-md-2">Business unit</th>
@@ -133,7 +133,7 @@
         </div>
     </div>
     {% if devices_count %}
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
       <thead>
         <th>Serial number</th>
         <th>Profile</th>

--- a/zentral/contrib/mdm/templates/mdm/devicecommand_list.html
+++ b/zentral/contrib/mdm/templates/mdm/devicecommand_list.html
@@ -21,7 +21,7 @@
 
     {% pagination next_url previous_url %}
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <tr>
         <th>Name</th>

--- a/zentral/contrib/mdm/templates/mdm/enrolleddevice_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/enrolleddevice_detail.html
@@ -17,7 +17,7 @@
         <h3 class="m-0 fs-5 text-secondary">Device</h3>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:220px">UDID</th>

--- a/zentral/contrib/mdm/templates/mdm/enrolleduser_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/enrolleduser_detail.html
@@ -18,7 +18,7 @@
         <h3 class="m-0 fs-5 text-secondary">User</h3>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:160px">User ID</th>

--- a/zentral/contrib/mdm/templates/mdm/filevaultconfig_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/filevaultconfig_detail.html
@@ -28,7 +28,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="240px">Name</th>

--- a/zentral/contrib/mdm/templates/mdm/location_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/location_detail.html
@@ -29,7 +29,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
       <thead>
         <th width="33%">Attribute</th>
         <th>Value</th>

--- a/zentral/contrib/mdm/templates/mdm/otaenrollment_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/otaenrollment_detail.html
@@ -32,7 +32,7 @@
 
     {% with object.enrollment_secret as secret %}
     <h4>Configuration</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="160px">Push certificate</th>
@@ -85,7 +85,7 @@
     </table>
 
     <h4>Authentication</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="160px">Realm</th>
@@ -115,7 +115,7 @@
     </table>
 
     <h4>Restrictions</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:160px">Serial number{{ secret.serial_numbers|length|pluralize }}</th>
@@ -133,7 +133,7 @@
     </table>
 
     <h4>Status</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:160px">Request count</td>

--- a/zentral/contrib/mdm/templates/mdm/pushcertificate_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/pushcertificate_detail.html
@@ -28,7 +28,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <tbody>
         <tr>
             <th width="160px">Name</th>
@@ -54,7 +54,7 @@
     <h3>DEP enrollment{{ dep_enrollments|length|pluralize }} ({{ dep_enrollments|length }})</h3>
 
     {% if dep_enrollments %}
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <tr>
         <th class="col-md-4">Name</th>
@@ -85,7 +85,7 @@
     <h3>OTA enrollment{{ ota_enrollments|length|pluralize }} ({{ ota_enrollments|length }})</h3>
 
     {% if ota_enrollments %}
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <th class="col-md-4">Name</th>
         <th class="col-md-4">Enrollment tags</th>
@@ -118,7 +118,7 @@
     <h3>User enrollment{{ user_enrollments|length|pluralize }} ({{ user_enrollments|length }})</h3>
 
     {% if user_enrollments %}
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <tr>
         <th class="col-md-4">Name</th>

--- a/zentral/contrib/mdm/templates/mdm/recoverypasswordconfig_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/recoverypasswordconfig_detail.html
@@ -27,7 +27,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="240px">Name</th>

--- a/zentral/contrib/mdm/templates/mdm/scepconfig_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/scepconfig_detail.html
@@ -27,7 +27,7 @@
         </div>
     </div>
 
-<table class="table table-striped align-middle table-object-properties">
+<table class="table-object-properties">
   <tbody>
     <tr>
       <th width="160px">URL</th>

--- a/zentral/contrib/mdm/templates/mdm/softwareupdateenforcement_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/softwareupdateenforcement_detail.html
@@ -28,7 +28,7 @@
         </div>
     </div>
 
-    <table class="table table-light table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
       <tbody>
         <tr>
           <th width="240px">Name</th>

--- a/zentral/contrib/mdm/templates/mdm/softwareupdateenforcement_list.html
+++ b/zentral/contrib/mdm/templates/mdm/softwareupdateenforcement_list.html
@@ -24,7 +24,7 @@
 
     {% pagination next_url previous_url %}
 
-    <table class="table table-light table-striped align-middle table-hover">
+    <table class="table table-striped align-middle table-hover">
     <thead>
         <tr>
         <th>Name</th>

--- a/zentral/contrib/mdm/templates/mdm/userenrollment_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/userenrollment_detail.html
@@ -24,7 +24,7 @@
     </div>
 
     {% with object.enrollment_secret as secret %}
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="160px">Push certificate</th>
@@ -91,7 +91,7 @@
     </table>
 
     <h4>Authentication</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th width="160px">Self-Enrollment</th>
@@ -117,7 +117,7 @@
     </table>
 
     <h4>Restrictions</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:160px">Quota</th>
@@ -127,7 +127,7 @@
     </table>
 
     <h4>Status</h4>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <th style="width:160px">Request count</td>

--- a/zentral/contrib/monolith/templates/monolith/catalog_detail.html
+++ b/zentral/contrib/monolith/templates/monolith/catalog_detail.html
@@ -26,7 +26,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <thead>
         <tr>
             <th scope="col">Attribute</th>

--- a/zentral/contrib/monolith/templates/monolith/condition_detail.html
+++ b/zentral/contrib/monolith/templates/monolith/condition_detail.html
@@ -26,7 +26,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <thead>
         <tr>
             <th scope="col">Attribute</th>

--- a/zentral/contrib/monolith/templates/monolith/manifest.html
+++ b/zentral/contrib/monolith/templates/monolith/manifest.html
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <thead>
             <tr><th style="width:30vw">Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/monolith/templates/monolith/sub_manifest.html
+++ b/zentral/contrib/monolith/templates/monolith/sub_manifest.html
@@ -27,7 +27,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <thead>
             <tr><th style="width:30vw">Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/munki/templates/munki/configuration_detail.html
+++ b/zentral/contrib/munki/templates/munki/configuration_detail.html
@@ -31,7 +31,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <thead>
         <th style="width:30vw">Attribute</th>
         <th>Value</th>

--- a/zentral/contrib/munki/templates/munki/scriptcheck_detail.html
+++ b/zentral/contrib/munki/templates/munki/scriptcheck_detail.html
@@ -39,7 +39,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties table-fixed-scrolleable">
+        <table class="table-object-properties table-fixed-scrolleable">
         <thead>
             <th style="width:15%">Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/osquery/templates/osquery/automatictableconstruction_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/automatictableconstruction_detail.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
         <thead>
             <th>Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/osquery/templates/osquery/configuration_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/configuration_detail.html
@@ -25,7 +25,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
         <thead>
             <th>Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/osquery/templates/osquery/distributedquery_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/distributedquery_detail.html
@@ -29,7 +29,7 @@
     </div>
 
   <div class="table-responsive mb-3">
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
       <thead>
       <tr>
         <th>Attribute</th>
@@ -40,23 +40,23 @@
       <tr>
         <td>Query</td>
         <td>
-          <dl class="row">
+          <dl>
             {% if perms.osquery.view_query and object.query %}
-            <dt class="col-sm-3 text-md-end">Name</dt>
-            <dd class="col-sm-9">
+            <dt>Name</dt>
+            <dd>
               <a href="{{ object.query.get_absolute_url }}">{{ query }}</a>
               {% if object.query_version < object.query.version %}/ <span class="text-danger">Updated since run creation</span>{% endif %}
             </dd>
             {% endif %}
-            <dt class="col-sm-3 text-md-end">SQL</dt>
-            <dd class="col-sm-9">{{ object.get_sql_html|safe }}</dd>
+            <dt>SQL</dt>
+            <dd>{{ object.get_sql_html|safe }}</dd>
             {% if object.platforms %}
-            <dt class="col-sm-3 text-md-end">Platform{{ object.platforms|length|pluralize }}</dt>
-            <dd class="col-sm-9">{{ object.platforms|join:", " }}</dd>
+            <dt>Platform{{ object.platforms|length|pluralize }}</dt>
+            <dd>{{ object.platforms|join:", " }}</dd>
             {% endif %}
             {% if object.minimum_osquery_version %}
-            <dt class="col-sm-3 text-md-end">Min. osquery ver.</dt>
-            <dd class="col-sm-9">{{ object.minimum_osquery_version }}</dd>
+            <dt>Min. osquery ver.</dt>
+            <dd>{{ object.minimum_osquery_version }}</dd>
             {% endif %}
           </dl>
         </td>

--- a/zentral/contrib/osquery/templates/osquery/filecategory_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/filecategory_detail.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
         <thead>
             <th>Attribute</th>
             <th>Value</th>

--- a/zentral/contrib/osquery/templates/osquery/pack_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/pack_detail.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
         <thead>
             <th>Attribute</th>
             <th>Value</th>
@@ -132,7 +132,7 @@
         </div>
     </div>
   </div>
-  <table class="table table-striped align-middle table-object-properties">
+  <table class="table-object-properties">
     <tr>
       <td style="width:15%">Query</td>
       <td>

--- a/zentral/contrib/osquery/templates/osquery/query_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/query_detail.html
@@ -39,7 +39,7 @@
     </div>
     <div class="table-responsive mb-3">
     <div class="col-md-12">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
         <thead>
             <tr>
             <th>Attribute</th>

--- a/zentral/contrib/santa/templates/santa/configuration_detail.html
+++ b/zentral/contrib/santa/templates/santa/configuration_detail.html
@@ -40,7 +40,7 @@
     </div>
 
     <div class="table-responsive mb-3">
-        <table class="table table-striped align-middle table-object-properties">
+        <table class="table-object-properties">
             <thead>
             <tr>
                 <th scope="col">Attribute</th>

--- a/zentral/contrib/santa/templates/santa/target_detail.html
+++ b/zentral/contrib/santa/templates/santa/target_detail.html
@@ -22,7 +22,7 @@
             {% endfor %}
         </div>
     </div>
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <td style="width:20vw">identifier</td>

--- a/zentral/core/incidents/templates/incidents/incident_detail.html
+++ b/zentral/core/incidents/templates/incidents/incident_detail.html
@@ -40,7 +40,7 @@
         </div>
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
     <tbody>
         <tr>
         <td style="width:20vw">Severity</td>

--- a/zentral/core/probes/templates/probes/feed.html
+++ b/zentral/core/probes/templates/probes/feed.html
@@ -30,7 +30,7 @@
         {% endif %}
     </div>
 
-    <table class="table table-striped align-middle table-object-properties">
+    <table class="table-object-properties">
         <thead>
             <tr>
             <th>Attribute</th>

--- a/zentral/core/probes/templates/probes/probe.html
+++ b/zentral/core/probes/templates/probes/probe.html
@@ -12,7 +12,7 @@
 <h3 class="m-0 fs-5 text-secondary mb-3">Probe</h3>
 
 <div class="card card-default mb-3">
-  <table class="table table-probe table-striped align-middle table-object-properties">
+  <table class="table-probe table-object-properties">
     <tr>
       <td>status</td>
       <td>
@@ -146,7 +146,7 @@
 
 {% for inventory_filter in probe.inventory_filters %}
 <div class="card card-default mb-3">
-  <table class="table table-probe table-striped align-middle table-object-properties">
+  <table class="table-probe table-object-properties">
     {% if inventory_filter.meta_business_units %}
     <tr>
       <td>
@@ -214,7 +214,7 @@
 
 {% for metadata_filter in probe.metadata_filters %}
 <div class="card card-default mb-3">
-  <table class="table table-probe table-striped align-middle table-object-properties">
+  <table class="table-probe table-object-properties">
     {% if metadata_filter.event_tags %}
     <tr>
       <td>tags</td>
@@ -253,7 +253,7 @@
 
 {% for payload_filter in probe.payload_filters %}
 <div class="card card-default mb-3">
-  <table class="table table-probe table-striped align-middle table-object-properties">
+  <table class="table-probe table-object-properties">
     {% for attribute, operator, values in payload_filter.items_display %}
     <tr>
       <td>{{ attribute }}</td>
@@ -301,7 +301,7 @@
 {% endif %}
 
 {% if probe.actions %}
-<table class="table table-probe table-striped align-middle table-object-properties">
+<table class="table-probe table-object-properties">
   <thead>
     <th>Name</th>
     <th>Configuration</th>


### PR DESCRIPTION
- Fixed first column width
- extend properties from standard BS properties

Also, fix Osquery run detail view and remove table-light usage.