### PR TITLE
Add stop() method to queues

### DIFF
--- a/zentral/contrib/mdm/management/commands/send_device_notification.py
+++ b/zentral/contrib/mdm/management/commands/send_device_notification.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 from zentral.contrib.mdm.models import EnrolledDevice
 from zentral.contrib.mdm.apns import send_enrolled_device_notification
+from zentral.core.queues import queues
 
 
 class Command(BaseCommand):
@@ -24,3 +25,4 @@ class Command(BaseCommand):
                 self.stdout.write("OK")
             else:
                 self.stdout.write("Failure")
+        queues.stop()

--- a/zentral/contrib/mdm/management/commands/sync_software_updates.py
+++ b/zentral/contrib/mdm/management/commands/sync_software_updates.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 from zentral.contrib.mdm.software_updates import sync_software_updates
+from zentral.core.queues import queues
 
 
 class Command(BaseCommand):
@@ -7,3 +8,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         sync_software_updates()
+        queues.stop()

--- a/zentral/core/queues/backends/aws_sns_sqs/consumer.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/consumer.py
@@ -28,13 +28,9 @@ class BaseConsumer:
         ]
 
     def _handle_signal(self, signum, frame):
-        if signum == signal.SIGTERM:
-            signum = "SIGTERM"
-        elif signum == signal.SIGINT:
-            signum = "SIGINT"
-        logger.debug("received signal %s", signum)
+        logger.info("Received signal %s.", signal.Signals(signum).name)
         if not self.stop_receiving_event.is_set():
-            logger.error("signal %s - stop receiving events", signum)
+            logger.info("Stop receiving events.")
             self.stop_receiving_event.set()
 
     def run(self, *args, **kwargs):
@@ -47,17 +43,17 @@ class BaseConsumer:
             self.start_run_loop()
         except Exception:
             exit_status = 1
-            logger.exception("%s: run loop exception", self.name)
+            logger.exception("%s: run loop exception.", self.name)
             if not self.stop_receiving_event.is_set():
-                logger.error("%s: stop receiving", self.name)
+                logger.info("%s: stop receiving.", self.name)
                 self.stop_receiving_event.set()
         # graceful stop
         if not self.stop_event.is_set():
-            logger.error("Set stop event")
+            logger.info("Set stop event.")
             self.stop_event.set()
             for thread in self._threads:
                 thread.join()
-            logger.error("All threads stopped.")
+            logger.info("All threads stopped.")
         return exit_status
 
     def start_run_loop(self):

--- a/zentral/core/queues/backends/base.py
+++ b/zentral/core/queues/backends/base.py
@@ -1,0 +1,31 @@
+class BaseEventQueues:
+    def __init__(self, config_d):
+        pass
+
+    # workers
+
+    def get_preprocess_worker(self):
+        raise NotImplementedError
+
+    def get_enrich_worker(self, enrich_event):
+        raise NotImplementedError
+
+    def get_process_worker(self, process_event):
+        raise NotImplementedError
+
+    def get_store_worker(self, event_store):
+        raise NotImplementedError
+
+    # post events
+
+    def post_raw_event(self, routing_key, raw_event):
+        raise NotImplementedError
+
+    def post_event(self, event):
+        raise NotImplementedError
+
+    # stop
+
+    def stop(self):
+        """Whatever needs to be done to gracefully stop"""
+        pass

--- a/zentral/core/queues/backends/kombu.py
+++ b/zentral/core/queues/backends/kombu.py
@@ -5,6 +5,7 @@ from zentral.conf import settings
 from kombu import Connection, Consumer, Exchange, Queue
 from kombu.mixins import ConsumerMixin, ConsumerProducerMixin
 from kombu.pools import producers
+from zentral.core.queues.backends.base import BaseEventQueues
 from zentral.core.queues.exceptions import RetryLater
 from zentral.utils.json import save_dead_letter
 
@@ -229,8 +230,9 @@ class StoreWorker(ConsumerMixin, BaseWorker):
             self.inc_counter("stored_events", event_type)
 
 
-class EventQueues(object):
+class EventQueues(BaseEventQueues):
     def __init__(self, config_d):
+        super().__init__(config_d)
         self.backend_url = config_d['backend_url']
         self.transport_options = config_d.get('transport_options')
         self.connection = self._get_connection()


### PR DESCRIPTION
Can be used to stop existing threads in the command line utilities.

Also reworked the graceful stop in the AWS queues to trigger the original signal handler. This is used when running in gunicorn.