### PR TITLE
Add newest macOS builds

### DIFF
--- a/tests/inventory/test_macos_build_parser.py
+++ b/tests/inventory/test_macos_build_parser.py
@@ -74,6 +74,8 @@ class MacOSBuildTestCase(TestCase):
            ("21G816", ("macOS", 12, 7, 0, None), "macOS 12.7 (21G816)"),
            ("21G920", ("macOS", 12, 7, 1, None), "macOS 12.7.1 (21G920)"),
            ("21G1974", ("macOS", 12, 7, 2, None), "macOS 12.7.2 (21G1974)"),
+           ("21H1015", ("macOS", 12, 7, 3, None), "macOS 12.7.3 (21H1015)"),
+           ("21H1123", ("macOS", 12, 7, 4, None), "macOS 12.7.4 (21H1123)"),
            ("22A400", ("macOS", 13, 0, 1, None), "macOS 13.0.1 (22A400)"),
            ("22D68", ("macOS", 13, 2, 1, None), "macOS 13.2.1 (22D68)"),
            ("22E261", ("macOS", 13, 3, 1, None), "macOS 13.3.1 (22E261)"),
@@ -87,6 +89,8 @@ class MacOSBuildTestCase(TestCase):
            ("22G313", ("macOS", 13, 6, 1, None), "macOS 13.6.1 (22G313)"),
            ("22G320", ("macOS", 13, 6, 2, None), "macOS 13.6.2 (22G320)"),
            ("22G436", ("macOS", 13, 6, 3, None), "macOS 13.6.3 (22G436)"),
+           ("22G513", ("macOS", 13, 6, 4, None), "macOS 13.6.4 (22G513)"),
+           ("22G621", ("macOS", 13, 6, 5, None), "macOS 13.6.5 (22G621)"),
            ("23A344", ("macOS", 14, 0, 0, None), "macOS 14.0 (23A344)"),
            ("23B5056e", ("macOS", 14, 1, 0, None), "macOS 14.1 (23B5056e)"),
            ("23B81", ("macOS", 14, 1, 1, None), "macOS 14.1.1 (23B81)"),
@@ -96,6 +100,7 @@ class MacOSBuildTestCase(TestCase):
            ("23C64", ("macOS", 14, 2, 0, None), "macOS 14.2 (23C64)"),
            ("23C71", ("macOS", 14, 2, 1, None), "macOS 14.2.1 (23C71)"),
            ("23D60", ("macOS", 14, 3, 1, None), "macOS 14.3.1 (23D60)"),
+           ("23E214", ("macOS", 14, 4, 0, None), "macOS 14.4 (23E214)"),
         ):
             expected_version_d = {
                 "name": name,

--- a/zentral/contrib/inventory/conf.py
+++ b/zentral/contrib/inventory/conf.py
@@ -255,9 +255,9 @@ def macos_version_from_build(build):
                 patch = 2
             elif build in ("21G417", "21G419", "21H1015", "22G436"):
                 patch = 3
-            elif build in ("21G526", "22G513"):
+            elif build in ("21G526", "22G513", "21H1123"):
                 patch = 4
-            elif build == "21G531":
+            elif build in ("21G531", "22G621"):
                 patch = 5
             elif build == "21G646":
                 patch = 6


### PR DESCRIPTION
This change fixes the automatic parsing of some of the latest macOS releases.

The impact is minimal, this is a simple fix.