### PR TITLE
Update MDM ADE Skip Keys

### DIFF
--- a/zentral/contrib/mdm/schema_data/README.md
+++ b/zentral/contrib/mdm/schema_data/README.md
@@ -6,4 +6,4 @@ In this folder, we copy some of the files from the Apple GitHub repository that 
 
 We start with the SkipKeys that can be used to configure which panes to skip in the Setup Assistant.
 
-URL: https://github.com/apple/device-management/blob/b838baacf2e790db729b6ca3f52724adc8bfb96d/other/skipkeys.yaml
+URL: https://github.com/apple/device-management/blob/39e2a8223418ec2eeffb084177ea8bd706114eb0/other/skipkeys.yaml

--- a/zentral/contrib/mdm/schema_data/skipkeys.yaml
+++ b/zentral/contrib/mdm/schema_data/skipkeys.yaml
@@ -12,6 +12,8 @@ payload:
     tvOS:
       introduced: '10.2'
       always-skippable: true
+    visionOS:
+      introduced: n/a
     watchOS:
       introduced: n/a
 payloadkeys:
@@ -29,6 +31,19 @@ payloadkeys:
   presence: optional
   content: The key to skip the Accessibility pane, when creating additional users.
     This key is not available in macOS.
+- key: ActionButton
+  title: Skip Action Button setup pane
+  supportedOS:
+    iOS:
+      introduced: '17.0'
+    macOS:
+      introduced: n/a
+    tvOS:
+      introduced: n/a
+  type: <string>
+  presence: optional
+  content: The key to skip the Action Button configuration pane. This key is available
+    in iOS 17 and later.
 - key: Android
   title: Prevents migration from Android device
   supportedOS:
@@ -465,8 +480,9 @@ payloadkeys:
       introduced: n/a
   type: <string>
   presence: optional
-  content: If the key is included in the SkipSetup array the Wallpaper pane will be
-    skipped.
+  content: |-
+    The key to skip Wallpaper setup.
+    This key is available in macOS 14.1 and later,
 - key: WatchMigration
   title: Skip watch migration
   supportedOS:

--- a/zentral/contrib/mdm/skip_keys.py
+++ b/zentral/contrib/mdm/skip_keys.py
@@ -13,7 +13,7 @@ def build_skippable_setup_panes():
     skipkeys = load_yaml()
     skippable_setup_panes = []
     for payloadkey in skipkeys["payloadkeys"]:
-        skippable_setup_panes.append((payloadkey["key"], payloadkey["content"]))
+        skippable_setup_panes.append((payloadkey["key"], payloadkey["title"]))
     return skippable_setup_panes
 
 


### PR DESCRIPTION
 - Update `skipkeys.yaml` to Release_iOS-17-4_macOS-14-4
 - Use the `title` key instead of the `content` key in the form