### PR TITLE
Use header authentication for the Santa agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Support for the Munki `default_installs` key.
 
 Support for the [Santa Signing ID rules](https://santa.dev/concepts/rules.html#signing-id-rules).
 
+Support for the `SyncExtraHeaders` configuration key and implementation of the authentication via `Zentral-Authorization` header.
+
 #### Inventory
 
 Jamf extensions attribute to principal user mapping.
@@ -69,6 +71,10 @@ New `zentral.core.stores.backends.panther` store backend for [Panther](https://p
 🚧 Alpha release of the new UI.
 
 ### Backward incompatibilities
+
+#### 🧨 Santa agent authentication
+
+The Santa agent is now authenticated with an extra `Zentral-Authorization` header that must contain the enrollment secret. The older endpoints are still active, but they are deprecated and will be removed in the near future.
 
 #### 🧨 dependency on Redis
 

--- a/tests/santa/test_setup_views.py
+++ b/tests/santa/test_setup_views.py
@@ -477,10 +477,13 @@ class SantaSetupViewsTestCase(TestCase):
         self.assertEqual(response['Content-Type'], "application/x-plist")
         plist_config = plistlib.loads(response.content)
         self.assertEqual(
-            plist_config["SyncBaseURL"],
-            f'https://{settings["api"]["fqdn"]}/public/santa/sync/{enrollment.secret.secret}/'
+            plist_config,
+            {'ClientMode': configuration.client_mode,
+             'SyncBaseURL': f'https://{settings["api"]["fqdn"]}/public/santa/sync/',
+             'SyncExtraHeaders': {
+                 'Zentral-Authorization': f'Bearer {enrollment.secret.secret}'
+             }}
         )
-        self.assertEqual(plist_config["ClientMode"], configuration.client_mode)
 
     def test_enrollment_configuration_profile_permission_denied(self):
         _, enrollment = self._force_enrollment()

--- a/zentral/contrib/santa/public_urls.py
+++ b/zentral/contrib/santa/public_urls.py
@@ -4,12 +4,21 @@ from . import public_views
 
 app_name = "santa_public"
 urlpatterns = [
-    path('sync/<str:enrollment_secret>/preflight/<str:machine_id>',
+    path('sync/preflight/<str:machine_id>',
          csrf_exempt(public_views.PreflightView.as_view()), name='preflight'),
-    path('sync/<str:enrollment_secret>/ruledownload/<str:machine_id>',
+    path('sync/ruledownload/<str:machine_id>',
          csrf_exempt(public_views.RuleDownloadView.as_view()), name='ruledownload'),
-    path('sync/<str:enrollment_secret>/eventupload/<str:machine_id>',
+    path('sync/eventupload/<str:machine_id>',
          csrf_exempt(public_views.EventUploadView.as_view()), name='eventupload'),
-    path('sync/<str:enrollment_secret>/postflight/<str:machine_id>',
+    path('sync/postflight/<str:machine_id>',
          csrf_exempt(public_views.PostflightView.as_view()), name='postflight'),
+    # deprecated URLs
+    path('sync/<str:enrollment_secret>/preflight/<str:machine_id>',
+         csrf_exempt(public_views.PreflightView.as_view()), name='deprecated_preflight'),
+    path('sync/<str:enrollment_secret>/ruledownload/<str:machine_id>',
+         csrf_exempt(public_views.RuleDownloadView.as_view()), name='deprecated_ruledownload'),
+    path('sync/<str:enrollment_secret>/eventupload/<str:machine_id>',
+         csrf_exempt(public_views.EventUploadView.as_view()), name='deprecated_eventupload'),
+    path('sync/<str:enrollment_secret>/postflight/<str:machine_id>',
+         csrf_exempt(public_views.PostflightView.as_view()), name='deprecated_postflight'),
 ]

--- a/zentral/contrib/santa/utils.py
+++ b/zentral/contrib/santa/utils.py
@@ -10,8 +10,13 @@ def build_santa_enrollment_configuration(enrollment):
     base_url_key = "tls_hostname"
     if configuration.client_certificate_auth:
         base_url_key = "tls_hostname_for_client_cert_auth"
-    config["SyncBaseURL"] = "{}/public/santa/sync/{}/".format(settings["api"][base_url_key],
-                                                              enrollment.secret.secret)
+    config.update({
+        "SyncBaseURL": "{}/public/santa/sync/".format(settings["api"][base_url_key]),
+        # See https://developer.apple.com/documentation/foundation/nsurlrequest#1776617
+        # Authorization is reserved, so we use 'Zentral-Authorization'
+        # See also https://github.com/google/santa/blob/344a35aaf63c24a56f7a021ce18ecab090584da3/Source/common/SNTConfigurator.h#L418-L421  # NOQA
+        "SyncExtraHeaders": {"Zentral-Authorization": f"Bearer {enrollment.secret.secret}"},
+    })
     return config
 
 


### PR DESCRIPTION
 - The enrollment secret must be present as `Bearer` token in the `Zentral-Authorization` header.
 - The existing URLs are deprecated and will be removed in the near future.