### PR TITLE
Remove unsafe-inline fallback

### DIFF
--- a/server/base/middlewares.py
+++ b/server/base/middlewares.py
@@ -14,7 +14,7 @@ CSP_HEADER = 'Content-Security-Policy'
 DEFAULT_CSP_POLICIES = {
   "default-src": "'self'",
   "img-src": "'self' https://*.mzstatic.com",
-  "script-src": "'self' 'unsafe-inline'",  # unsafe-inline ignored when nonce-* is supported
+  "script-src": "'self'",
   "base-uri": "'none'",
   "frame-ancestors": "'none'",
   "object-src": "'none'",

--- a/tests/server_base/test_index.py
+++ b/tests/server_base/test_index.py
@@ -67,7 +67,7 @@ class BaseViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "base/index.html")
         self.assertIn(";object-src 'none';", response["Content-Security-Policy"])
-        self.assertIn(";script-src 'self' 'unsafe-inline' 'nonce-", response["Content-Security-Policy"])
+        self.assertIn(";script-src 'self' 'nonce-", response["Content-Security-Policy"])
         self.assertNotIn("unsafe-eval", response["Content-Security-Policy"])
 
     # extra links


### PR DESCRIPTION
Unnecessary. We do not want to support older browsers.