### PR TITLE
Reschedule SetupFileVault cmds with NotNow status

### DIFF
--- a/zentral/contrib/mdm/commands/setup_filevault.py
+++ b/zentral/contrib/mdm/commands/setup_filevault.py
@@ -107,6 +107,7 @@ def build_payload(enrolled_device):
 class SetupFileVault(Command):
     request_type = "InstallProfile"
     db_name = "SetupFileVault"
+    reschedule_notnow = True
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):


### PR DESCRIPTION
When FV is configured after a device has enrolled, and the device is asleep, the command will fail with a NotNow status. It must be rescheduled when the device wakes up.