### PR TITLE
Fix minor and patch OS versions metrics labels

### DIFF
--- a/tests/inventory/test_metrics_views.py
+++ b/tests/inventory/test_metrics_views.py
@@ -61,7 +61,7 @@ class PrometheusViewsTestCase(TestCase):
             "source": {"module": "tests2.zentral.io", "name": "Zentral Tests2"},
             "serial_number": "0123456789",
             "system_info": {"hardware_model": "MacBookPro14,2"},
-            "os_version": {'name': 'OS X', 'major': 12, 'minor': 2, 'version': "(a)"},
+            "os_version": {'name': 'OS X', 'major': 12, 'minor': 2, 'patch': 0, 'version': "(a)"},
             "android_apps": [
                 {"display_name": "AndroidApp1",
                  "version_name": "2.1"},
@@ -363,7 +363,7 @@ class PrometheusViewsTestCase(TestCase):
                                   'major': '12',
                                   'minor': '2',
                                   'name': 'OS X',
-                                  'patch': '',
+                                  'patch': '0',
                                   'version': '(a)',
                                   'source_name': self.ms2.source.name,
                                   'source_id': str(self.ms2.source.pk),

--- a/zentral/contrib/inventory/metrics_views.py
+++ b/zentral/contrib/inventory/metrics_views.py
@@ -67,7 +67,7 @@ class MetricsView(BasePrometheusMetricsView):
                   registry=self.registry)
         for r in os_version_count(sources):
             labels = {
-                k: r[k] or ""
+                k: "" if r[k] is None else r[k]
                 for k in ('name',
                           'major', 'minor', 'patch',
                           'build', 'version',


### PR DESCRIPTION
The minor and patch OS version in the database should default to 0, and 0 is a valid value for those 2 labels.