### PR TITLE
Ensure Santa ballot unicity across realms

### DIFF
--- a/tests/santa/test_ballot_box.py
+++ b/tests/santa/test_ballot_box.py
@@ -231,6 +231,13 @@ class SantaBallotBoxTestCase(TestCase):
         ballot = force_ballot(self.file_target, realm_user, ((configuration, True, 17),))
         self.assertEqual(BallotBox.for_realm_user(self.file_target, realm_user).existing_ballot, ballot)
 
+    def test_ballot_box_existing_ballot_different_realm_same_username(self):
+        realm, realm_user = force_realm_user()
+        _, realm_user2 = force_realm_user(username=realm_user.username)
+        configuration = force_configuration(voting_realm=realm)
+        ballot = force_ballot(self.file_target, realm_user, ((configuration, True, 17),))
+        self.assertEqual(BallotBox.for_realm_user(self.file_target, realm_user2).existing_ballot, ballot)
+
     def test_ballot_box_existing_replacing_ballot(self):
         realm, realm_user = force_realm_user()
         configuration = force_configuration(voting_realm=realm)


### PR DESCRIPTION
Make sure that not only a ballot from the same realm user is a match, but also a ballot from a different realm user with the same username. This avoids double votes in the case of 2 SAML apps with different scopes (All the employees for the portal, only the admins for the Zentral console) but from the same IdP, so with the same usernames.