### PR TITLE
Switch back to MDM command for legacy profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ New `zentral.core.stores.backends.panther` store backend for [Panther](https://p
 
 ### Backward incompatibilities
 
+#### 🧨 MDM Profiles *NOT* managed via DDM anymore
+
+The DDM implementation of the legacy profile declarations is not robust enough at the moment. Network disruptions might leave the device in an indesirable state that can only be fixed with a reboot. This is not good enough, especially during the MDM enrollment. We have decided to switch back to the InstallProfile command until this is fixed by Apple.
+
 #### 🧨 Santa bundle rules removed
 
 Zentral doesn't support rules with a Bundle as target anymore. A migration will translated those rules into Binary rules.

--- a/tests/mdm/test_artifacts.py
+++ b/tests/mdm/test_artifacts.py
@@ -758,7 +758,10 @@ class TestMDMArtifacts(TestCase):
 
     # activation
 
-    def test_device_activation_enterprise_app_not_included(self):
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_device_activation_enterprise_app_not_included(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         _, profile_a, (profile_av,) = self._force_blueprint_artifact()
         self._force_blueprint_artifact(artifact_type=Artifact.Type.ENTERPRISE_APP)
         activation = Target(self.enrolled_device).activation
@@ -769,7 +772,20 @@ class TestMDMArtifacts(TestCase):
         self.assertIn(f"zentral.blueprint.{self.blueprint1.pk}.management-status-subscriptions", scs)
         self.assertIn(f"zentral.legacy-profile.{profile_a.pk}", scs)
 
-    def test_device_activation_required_profile_included(self):
+    def test_device_activation_enterprise_app_and_profile_not_included(self):
+        _, profile_a, (profile_av,) = self._force_blueprint_artifact()
+        self._force_blueprint_artifact(artifact_type=Artifact.Type.ENTERPRISE_APP)
+        activation = Target(self.enrolled_device).activation
+        self.assertEqual(sorted(activation.keys()), ["Identifier", "Payload", "ServerToken", "Type"])
+        self.assertEqual(sorted(activation["Payload"].keys()), ["StandardConfigurations"])
+        scs = activation["Payload"]["StandardConfigurations"]
+        self.assertEqual(len(scs), 1)
+        self.assertIn(f"zentral.blueprint.{self.blueprint1.pk}.management-status-subscriptions", scs)
+
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_device_activation_required_profile_included(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         profile_a, _ = self._force_artifact(
             artifact_type=Artifact.Type.PROFILE,
             version_count=1,
@@ -783,7 +799,10 @@ class TestMDMArtifacts(TestCase):
         self.assertIn(f"zentral.blueprint.{self.blueprint1.pk}.management-status-subscriptions", scs)
         self.assertIn(f"zentral.legacy-profile.{profile_a.pk}", scs)
 
-    def test_device_activation_required_enterprise_app_installed_profile_included(self):
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_device_activation_required_enterprise_app_installed_profile_included(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         ea_a, (ea_av,) = self._force_artifact(
             artifact_type=Artifact.Type.ENTERPRISE_APP,
             version_count=1,
@@ -888,7 +907,10 @@ class TestMDMArtifacts(TestCase):
 
     # declaration items
 
-    def test_user_declaration_items_enterprise_app_not_included(self):
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_user_declaration_items_enterprise_app_not_included(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         _, profile_a, (profile_av,) = self._force_blueprint_artifact(channel=Channel.USER)
         profile_a.reinstall_on_os_update = Artifact.ReinstallOnOSUpdate.PATCH
         profile_a.reinstall_interval = 100000
@@ -917,7 +939,10 @@ class TestMDMArtifacts(TestCase):
         self.assertEqual(configurations[1]["Identifier"], f"zentral.legacy-profile.{profile_a.pk}")
         self.assertEqual(configurations[1]["ServerToken"], f"{profile_av.pk}.ov-13.1.0.ri-0.rc-2")  # max rc = 2
 
-    def test_device_declaration_items_required_profile_included(self):
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_device_declaration_items_required_profile_included(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         profile_a, (profile_av,) = self._force_artifact(
             artifact_type=Artifact.Type.PROFILE,
             version_count=1,
@@ -1655,7 +1680,10 @@ class TestMDMArtifacts(TestCase):
              "active": True}
         )
 
-    def test_update_target_artifacts_from_status_report_cleanup(self):
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_update_target_artifacts_from_status_report_cleanup(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         _, profile_a, (profile_av,) = self._force_blueprint_artifact()
         target = Target(self.enrolled_device)
         target.update_target_artifact(profile_av, TargetArtifact.Status.INSTALLED)
@@ -1672,7 +1700,10 @@ class TestMDMArtifacts(TestCase):
         self.assertTrue(target.update_target_artifacts_with_status_report(status_report) is True)
         self.assertEqual(DeviceArtifact.objects.filter(enrolled_device=self.enrolled_device).count(), 0)
 
-    def test_update_target_artifacts_from_status_report_cleanup_two_then_one(self):
+    @patch("zentral.contrib.mdm.artifacts.Target.ddm_managed_artifact_types")
+    def test_update_target_artifacts_from_status_report_cleanup_two_then_one(self, ddm_managed_artifact_types):
+        # force inclusion of the PROFILE
+        ddm_managed_artifact_types.return_value = tuple(t for t in Artifact.Type if t.is_declaration)
         _, profile_a, (profile_av,) = self._force_blueprint_artifact()
         _, profile_b, (profile_bv,) = self._force_blueprint_artifact()
         # 2 installed

--- a/tests/mdm/test_workers.py
+++ b/tests/mdm/test_workers.py
@@ -33,6 +33,14 @@ class MDMWorkersTestCase(TestCase):
             DevicesAPNSWorker()
 
     @patch("zentral.contrib.mdm.workers.settings")
+    def test_bad_max_command_waiting_time_value_error(self, settings):
+        settings.__getitem__.return_value = ConfigDict({
+            "zentral.contrib.mdm": {"apns": {"max_command_waiting_time": "A"}}
+        })
+        with self.assertRaises(ImproperlyConfigured, msg="APNS maximum command waiting time must be an integer"):
+            DevicesAPNSWorker()
+
+    @patch("zentral.contrib.mdm.workers.settings")
     def test_min_target_age_min(self, settings):
         settings.__getitem__.return_value = ConfigDict({
             "zentral.contrib.mdm": {"apns": {"min_target_age": "0"}}

--- a/zentral/contrib/mdm/commands/scheduling.py
+++ b/zentral/contrib/mdm/commands/scheduling.py
@@ -174,12 +174,9 @@ def _trigger_declarative_management_sync(target, enrollment_session, status):
 def _install_artifacts(target, enrollment_session, status):
     if status == RequestStatus.NOT_NOW:
         return
-    included_types = None
+    included_types = (t for t in Artifact.Type if t.can_be_installed)
     if target.declarative_management:
-        # device profiles managed using declarative management
-        included_types = (Artifact.Type.ENTERPRISE_APP, Artifact.Type.STORE_APP)
-    else:
-        included_types = (Artifact.Type.ENTERPRISE_APP, Artifact.Type.PROFILE, Artifact.Type.STORE_APP)
+        included_types = tuple(t for t in included_types if t not in target.ddm_managed_artifact_types())
     artifact_version = target.next_to_install(included_types=included_types)
     if artifact_version:
         command_class = None
@@ -202,10 +199,9 @@ def _install_artifacts(target, enrollment_session, status):
 def _remove_artifacts(target, enrollment_session, status):
     if status == RequestStatus.NOT_NOW:
         return
-    included_types = None
+    included_types = (t for t in Artifact.Type if t.can_be_removed)
     if target.declarative_management:
-        # device profiles managed using declarative management
-        included_types = (Artifact.Type.STORE_APP,)
+        included_types = tuple(t for t in included_types if t not in target.ddm_managed_artifact_types())
     artifact_version = target.next_to_remove(included_types=included_types)
     if artifact_version:
         if artifact_version.artifact.type == Artifact.Type.PROFILE:

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -2279,6 +2279,14 @@ class Artifact(models.Model):
         def can_be_linked_to_blueprint(self):
             return not self.is_asset and not self.value == self.MANUAL_CONFIGURATION
 
+        @property
+        def can_be_installed(self):
+            return self.value in (self.ENTERPRISE_APP, self.PROFILE, self.STORE_APP)
+
+        @property
+        def can_be_removed(self):
+            return self.value in (self.PROFILE, self.STORE_APP)
+
     class ReinstallOnOSUpdate(models.TextChoices):
         NO = "No"
         MAJOR = "Major"
@@ -2329,7 +2337,7 @@ class Artifact(models.Model):
 
     @property
     def can_be_removed(self):
-        return self.get_type() in (self.Type.PROFILE, self.Type.STORE_APP)
+        return self.get_type().can_be_removed
 
     def blueprints(self):
         # directly included


### PR DESCRIPTION
At the moment, the MDM agent and daemon do no retry the failed downloads of configuration profiles. This is problematic, especially when some payloads disrupt the network (Firewall config). The devices could be left in a state that requires a reboot to recover from. This is not good enough, especially during an MDM enrollment.