### PR TITLE
Fix DB error during Santa bundle rule migration

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -29,7 +29,7 @@ cryptography==44.0.1
 decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
-Django==4.2.20
+Django==4.2.21
 django-celery-results==2.4.0
 django-filter==24.3
 django-redis==5.4.0

--- a/zentral/contrib/santa/migrations/0037_configuration_banned_threshold_and_more.py
+++ b/zentral/contrib/santa/migrations/0037_configuration_banned_threshold_and_more.py
@@ -21,9 +21,17 @@ def flatten_bundle_rules(apps, schema_editor):
     for rule in Rule.objects.filter(target__type="BUNDLE"):
         rules_to_delete.append(rule.pk)
         for binary_target in list(rule.target.bundle.binary_targets.all()):
-            rule.pk = None
-            rule.target = binary_target
-            rule.save()
+            if not Rule.objects.filter(configuration=rule.configuration, target=binary_target).exists():
+                rule.pk = None
+                rule.target = binary_target
+                rule.save()
+            else:
+                print(">>>>", "DUPLICATED BINARY RULE",
+                      rule.configuration.pk,
+                      rule.configuration,
+                      binary_target.pk,
+                      binary_target,
+                      "<<<<")
     Rule.objects.filter(pk__in=rules_to_delete).delete()
 
 


### PR DESCRIPTION
Different legacy bundle rules can cover the same binary. That could cause integrity error during the migration.