### PR TITLE
Basic Auth and TLS overrides for Elasticsearch

### DIFF
--- a/tests/core_stores/test_elasticsearch_conf.py
+++ b/tests/core_stores/test_elasticsearch_conf.py
@@ -90,6 +90,54 @@ class TestElasticsearchStoreConf(SimpleTestCase):
             }))
         self.assertEqual(cm.exception.args[0], "missing read index")
 
+    def test_kwargs_basic_auth(self):
+        kwargs = EventStore._get_client_kwargs(ConfigDict({
+            'servers': ["http://elastic:9200"],
+            'index': 'zentral-events',
+            'store_name': 'yolo',
+            'basic_auth': ("user", "password"),
+        }))
+        self.assertEqual(
+            kwargs,
+            {'hosts': [{'host': 'elastic',
+                        'port': 9200,
+                        'scheme': 'http'}],
+             'basic_auth': ("user", "password")}
+        )
+
+    def test_kwargs_default_verify_certs(self):
+        kwargs = EventStore._get_client_kwargs(ConfigDict({
+            'servers': ["https://elastic:9200"],
+            'index': 'zentral-events',
+            'store_name': 'yolo'
+        }))
+        self.assertEqual(
+            kwargs,
+            {'hosts': [{'host': 'elastic',
+                        'port': 9200,
+                        'scheme': 'https',
+                        'use_ssl': True}],
+             'verify_certs': True}
+        )
+
+    def test_kwargs_override_verify_certs(self):
+        kwargs = EventStore._get_client_kwargs(ConfigDict({
+            'servers': ["https://elastic:9200"],
+            'index': 'zentral-events',
+            'store_name': 'yolo',
+            'verify_certs': False,
+            'ssl_show_warn': False,
+        }))
+        self.assertEqual(
+            kwargs,
+            {'hosts': [{'host': 'elastic',
+                        'port': 9200,
+                        'scheme': 'https',
+                        'use_ssl': True}],
+             'verify_certs': False,
+             'ssl_show_warn': False}
+        )
+
     def test_one_index_get_event_index(self):
         store_index = get_random_string(12)
         store = EventStore(ConfigDict({

--- a/zentral/core/stores/backends/elasticsearch.py
+++ b/zentral/core/stores/backends/elasticsearch.py
@@ -13,5 +13,13 @@ class EventStore(ESOSEventStore):
     connection_error_class = ConnectionError
     request_error_class = RequestError
 
+    @classmethod
+    def _get_client_kwargs(cls, config_d):
+        kwargs = super()._get_client_kwargs(config_d)
+        basic_auth = config_d.get("basic_auth")
+        if basic_auth:
+            kwargs["basic_auth"] = basic_auth
+        return kwargs
+
     def _streaming_bulk(self, *args, **kwargs):
         return streaming_bulk(*args, **kwargs)

--- a/zentral/core/stores/backends/es_os_base.py
+++ b/zentral/core/stores/backends/es_os_base.py
@@ -105,11 +105,12 @@ class ESOSEventStore(BaseEventStore):
         "month": "M",
     }
 
-    def _get_client_kwargs(self, config_d):
+    @classmethod
+    def _get_client_kwargs(cls, config_d):
         # client kwargs
         kwargs = {}
 
-        # client kwargs > hosts
+        # client kwargs → hosts
         hosts = []
         configured_hosts = config_d.get("hosts", config_d.get("servers"))
         for host in configured_hosts:
@@ -128,8 +129,13 @@ class ESOSEventStore(BaseEventStore):
             hosts.append(host)
         kwargs['hosts'] = hosts
 
-        # client kwargs > verify_certs
-        if any(host.get("use_ssl") for host in hosts):
+        if 'verify_certs' in config_d:
+            # verify certs override
+            kwargs['verify_certs'] = config_d['verify_certs']
+            if 'ssl_show_warn' in config_d:
+                kwargs['ssl_show_warn'] = config_d['ssl_show_warn']
+        elif any(host.get("use_ssl") for host in hosts):
+            # make sure that the certs are verified by default
             kwargs['verify_certs'] = True
 
         return kwargs

--- a/zentral/core/stores/backends/opensearch.py
+++ b/zentral/core/stores/backends/opensearch.py
@@ -15,7 +15,8 @@ class EventStore(ESOSEventStore):
     connection_error_class = ConnectionError
     request_error_class = RequestError
 
-    def _get_client_kwargs(self, config_d):
+    @classmethod
+    def _get_client_kwargs(cls, config_d):
         kwargs = super()._get_client_kwargs(config_d)
         aws_auth = config_d.get("aws_auth")
         if aws_auth is None:


### PR DESCRIPTION
Allow basic auth configuration and cert verification overrides in Elasticsearch event store configurations.