### PR TITLE
Post the DEP profile updates in background task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Add auto admin unique passwords for ADE. This is similare to Windows LAPS.
 
+### Bug fixes
+
+Fix DEP enrollment update view timeout when the corresponding profile is assigned to 10000s of devices in ABM.
+
 ### Backward incompatibilities
 
 #### 🧨 MDM auto admin password

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -1,16 +1,14 @@
 import logging
 from celery import shared_task
-from .dep import sync_dep_virtual_server_devices, DEPClientError
-from .models import DEPVirtualServer
+from .dep import define_dep_profile, sync_dep_virtual_server_devices, DEPClientError
+from .models import DEPEnrollment, DEPVirtualServer
 from .software_updates import sync_software_updates
 
 
 logger = logging.getLogger("zentral.contrib.mdm.tasks")
 
 
-#
 # DEP
-#
 
 
 @shared_task
@@ -41,9 +39,14 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk):
     return result
 
 
-#
+@shared_task
+def define_dep_profile_task(dep_enrollment_pk):
+    dep_enrollment = DEPEnrollment.objects.select_related("virtual_server").get(pk=dep_enrollment_pk)
+    return define_dep_profile(dep_enrollment)
+
+
 # Software updates
-#
+
 
 @shared_task
 def sync_software_updates_task():


### PR DESCRIPTION
When a DEP profile is assigned to a lot of devices, the profile update with ABM can take a long time. This commit moves the update to a background task.
We also only post an update when the DEP profile changes, and avoid posting an update when only DEP enrollment attributes that do not affect the profile are changed.