### PR TITLE
Better celery task tracking

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -31,7 +31,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 Django==4.2.24
-django-celery-results==2.4.0
+django-celery-results==2.6.0
 django-filter==24.3
 django-redis==5.4.0
 django-storages==1.14.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ azure-storage-blob
 boto3                           # conf, monolith, events (kinesis, sns/sqs)
 celery<6
 clickhouse-connect
-django-celery-results==2.4.0
+django-celery-results==2.6.0
 cryptography                    # MDM, monolith (cloudfront), munki
 defusedxml
 django>=4.2.8,<5

--- a/server/server/celery.py
+++ b/server/server/celery.py
@@ -1,14 +1,65 @@
+import logging
 import os
-from celery import Celery
+from celery import Celery, states
+from celery.signals import before_task_publish
+from django.utils.functional import SimpleLazyObject
+
+
+logger = logging.getLogger("zentral.celery")
+
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings')
 app = Celery('zentral')
 app.conf.broker_connection_retry_on_startup = True
 app.conf.result_extended = True
+app.conf.task_track_started = True
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 
 
-@app.task(bind=True)
-def debug_task(self):
-    print('Request: {0!r}'.format(self.request))
+# workaround for an issue where django-celery-results is not adding PENDING tasks to the database.
+# see https://github.com/celery/django-celery-results/issues/286#issuecomment-1789094153
+
+
+def get_db_result_backend():
+    from django_celery_results.backends.database import DatabaseBackend
+    return DatabaseBackend(app)
+
+
+db_result_backend = SimpleLazyObject(get_db_result_backend)
+
+
+def get_registered_task_names():
+    return app.tasks.keys()
+
+
+registered_task_names = SimpleLazyObject(get_registered_task_names)
+
+
+def create_task_result_on_publish(sender=None, headers=None, **kwargs):
+    if (
+        not isinstance(headers, dict)
+        or "id" not in headers
+        or "task" not in headers
+        or sender not in registered_task_names
+    ):
+        logger.error("Unexpected calling context")
+        return
+
+    # essentially transforms a single-level of the headers dictionary
+    # into an object with properties
+    request = type('request', (object,), headers)
+
+    try:
+        db_result_backend.store_result(
+            headers["id"],
+            None,
+            states.PENDING,
+            traceback=None,
+            request=request,
+        )
+    except Exception:
+        logger.exception("Could not store pending task %s result", headers["id"])
+
+
+before_task_publish.connect(create_task_result_on_publish, dispatch_uid='create_task_result_on_publish')

--- a/tests/server_base/test_celery.py
+++ b/tests/server_base/test_celery.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+from django.test import SimpleTestCase
+from server.celery import create_task_result_on_publish
+
+
+class TestZentralCelery(SimpleTestCase):
+    @patch("server.celery.logger.error")
+    def test_create_task_result_on_publish_unexpected_context(self, logger_error):
+        self.assertIsNone(create_task_result_on_publish())
+        logger_error.assert_called_once_with("Unexpected calling context")
+
+    @patch("server.celery.logger.error")
+    @patch("server.celery.db_result_backend")
+    def test_create_task_result_on_publish_could_not_store(self, db_result_backend, logger_error):
+        db_result_backend.store_result.side_effect = ValueError
+        self.assertIsNone(create_task_result_on_publish(
+            sender="zentral.contrib.mdm.tasks.sync_dep_virtual_server_devices_task",
+            headers={
+                'task': 'zentral.contrib.mdm.tasks.sync_dep_virtual_server_devices_task',
+                'id': '0b56443a-597f-4492-818e-6e2a4ad45a91'
+            },
+        ))
+        logger_error.assert_called_once_with(
+            'Could not store pending task %s result',
+            '0b56443a-597f-4492-818e-6e2a4ad45a91',
+            exc_info=True,
+        )
+        db_result_backend.store_result.assert_called_once()


### PR DESCRIPTION
 - upgrade to django-celery-results v2.6.0
 - activate date_started
 - add signal handler to write pending tasks to the database