### PR TITLE
munge datetimes to offset-aware

### DIFF
--- a/zentral/contrib/munki/osx_package/build.tmpl/root/usr/local/zentral/munki/zentral_postflight
+++ b/zentral/contrib/munki/osx_package/build.tmpl/root/usr/local/zentral/munki/zentral_postflight
@@ -157,15 +157,15 @@ class ManagedInstallReport(object):
         return dt
 
     def _events(self):
-        events = [(self.start_time, {'type': 'start'})]
+        events = [(self._ensure_aware(self.start_time), {'type': 'start'})]
         for ir in self.data.get('InstallResults', []):
             events.append((self._ensure_aware(ir.pop('time')), dict(ir, type='install')))
         for rr in self.data.get('RemovalResults', []):
             events.append((self._ensure_aware(rr.pop('time')), dict(rr, type='removal')))
         for err in set(self.data.get('Errors', [])):
-            events.append((self.end_time or self.start_time, {'type': 'error', 'message': err}))
+            events.append((self._ensure_aware(self.end_time or self.start_time), {'type': 'error', 'message': err}))
         for warn in set(self.data.get('Warnings', [])):
-            events.append((self.end_time or self.start_time, {'type': 'warning', 'message': warn}))
+            events.append((self._ensure_aware(self.end_time or self.start_time), {'type': 'warning', 'message': warn}))
         events.sort(key=lambda t: t[0])
         return events
 


### PR DESCRIPTION
avoids TypeError in build_reports_payload when gathering events as of munki7:
```py
    /usr/local/munki/postflight stderr: Traceback (most recent call last):
  File "/usr/local/munki/postflight.d/zentral", line 884, in <module>
    data['reports'], data['last_seen_report_found'] = build_reports_payload(last_seen_sha1sum)
                                                      ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/postflight.d/zentral", line 284, in build_reports_payload
    payload.append(mir.serialize())
                   ~~~~~~~~~~~~~^^
  File "/usr/local/munki/postflight.d/zentral", line 251, in serialize
    'events': self._events()}
              ~~~~~~~~~~~~^^
  File "/usr/local/munki/postflight.d/zentral", line 169, in _events
    events.sort(key=lambda t: t[0])
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

Disclaimer: I did have ClaudeCode think about the option for me, but I qa'd it on a machine that showed the issue initially, it was able to function as expected on a subsequent run after applying this change locally