### PR TITLE
Set DDM status report response code to `200`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Better apps & books locations read-only API.
 
 Add blueprint option to distribute the legacy profiles via DDM.
 
+### Bug fixes
+
+Fix DDM status report response code. It should be `200`.
+
 ## 2025.10
 
 ### Features

--- a/tests/mdm/test_mdm_views.py
+++ b/tests/mdm/test_mdm_views.py
@@ -1069,7 +1069,7 @@ class MDMViewsTestCase(TestCase):
             "Endpoint": "status",
         }
         response = self._put(reverse("mdm_public:checkin"), payload, session)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
 
     # legacy profile
 

--- a/zentral/contrib/mdm/public_views/mdm.py
+++ b/zentral/contrib/mdm/public_views/mdm.py
@@ -388,7 +388,7 @@ class CheckinView(MDMView):
         elif endpoint == "status":
             self.target.update_target_with_status_report(json_data)
             self.post_event("success", **event_payload)
-            return HttpResponse(status=204)
+            return HttpResponse(status=200)
         elif endpoint.startswith("declaration/"):
             try:
                 response = build_declaration_response(endpoint, event_payload, self.enrollment_session, self.target)


### PR DESCRIPTION
It was `204` before, probably from early documentation. `204` causes fatal crashes in the OS!