### PR TITLE
Publish audit events on creating or deleting a api token for a user.

### DIFF
--- a/server/accounts/management/commands/create_zentral_user.py
+++ b/server/accounts/management/commands/create_zentral_user.py
@@ -119,8 +119,9 @@ class Command(BaseCommand):
             if APIToken.objects.filter(user=self.user).exists():
                 self.print("Existing API token")
             else:
+                _, api_key = APIToken.objects.update_or_create_for_user(self.user)
                 self.context.update({
-                    "api_token": APIToken.objects.update_or_create_for_user(self.user),
+                    "api_token": api_key,
                     "api_token_created": True,
                 })
                 self.print("Created API token:", self.context["api_token"])

--- a/tests/core_probes/test_api_action_views.py
+++ b/tests/core_probes/test_api_action_views.py
@@ -25,7 +25,7 @@ class ProbeActionAPIViewsTestCase(TestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/core_probes/test_api_probe_views.py
+++ b/tests/core_probes/test_api_probe_views.py
@@ -26,7 +26,7 @@ class ProbeAPIViewsTestCase(TestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/core_stores/test_api_store_views.py
+++ b/tests/core_stores/test_api_store_views.py
@@ -25,7 +25,7 @@ class StoreAPIViewsTestCase(TestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/core_terraform/test_api_backend_views.py
+++ b/tests/core_terraform/test_api_backend_views.py
@@ -27,7 +27,7 @@ class TerraformBackendAPIViewsTestCase(TestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/intune/test_api_views.py
+++ b/tests/intune/test_api_views.py
@@ -28,7 +28,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.bu = cls.mbu.create_enrollment_business_unit()
 

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -26,7 +26,7 @@ class InventoryAPITests(APITestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(user=cls.user)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(user=cls.user)
 
     def setUp(self):
         super().setUp()

--- a/tests/inventory/test_compliance_checks_api.py
+++ b/tests/inventory/test_compliance_checks_api.py
@@ -23,7 +23,7 @@ class JMESPathCheckAPITests(APITestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.user)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.user)
 
     def setUp(self):
         super().setUp()

--- a/tests/inventory/test_update_machine_tags.py
+++ b/tests/inventory/test_update_machine_tags.py
@@ -22,7 +22,7 @@ class InventoryAPITests(TestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.user)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.user)
         cls.url = reverse("inventory_api:update_machine_tags")
 
     # utility methods

--- a/tests/mdm/test_api_acme_issuers_views.py
+++ b/tests/mdm/test_api_acme_issuers_views.py
@@ -30,7 +30,7 @@ class MDMACMEIssuerAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_apps_books_views.py
+++ b/tests/mdm/test_api_apps_books_views.py
@@ -23,7 +23,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.dep_enrollment_session, _, _ = force_dep_enrollment_session(
             cls.mbu, authenticated=True, completed=True

--- a/tests/mdm/test_api_artifacts_views.py
+++ b/tests/mdm/test_api_artifacts_views.py
@@ -27,7 +27,7 @@ class MDMArtifactsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_blueprint_artifacts_views.py
+++ b/tests/mdm/test_api_blueprint_artifacts_views.py
@@ -28,7 +28,7 @@ class MDMBlueprintArtifactsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_blueprints_views.py
+++ b/tests/mdm/test_api_blueprints_views.py
@@ -30,7 +30,7 @@ class MDMBlueprintsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_cert_assets_views.py
+++ b/tests/mdm/test_api_cert_assets_views.py
@@ -44,7 +44,7 @@ class MDMCertAssetsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_commands_views.py
+++ b/tests/mdm/test_api_commands_views.py
@@ -30,7 +30,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.dep_enrollment_session, _, _ = force_dep_enrollment_session(
             cls.mbu, authenticated=True, completed=True

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -33,7 +33,7 @@ class MDMDataAssetsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_declarations_views.py
+++ b/tests/mdm/test_api_declarations_views.py
@@ -29,7 +29,7 @@ class MDMDeclarationsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -29,7 +29,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
 

--- a/tests/mdm/test_api_enrolled_devices_views.py
+++ b/tests/mdm/test_api_enrolled_devices_views.py
@@ -32,7 +32,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.dep_enrollment_session, _, _ = force_dep_enrollment_session(
             cls.mbu, authenticated=True, completed=True

--- a/tests/mdm/test_api_enterprise_apps_views.py
+++ b/tests/mdm/test_api_enterprise_apps_views.py
@@ -32,7 +32,7 @@ class MDMEnterpriseAppsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_filevault_configs_views.py
+++ b/tests/mdm/test_api_filevault_configs_views.py
@@ -27,7 +27,7 @@ class MDMFileVaultConfigsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_ota_enrollments_views.py
+++ b/tests/mdm/test_api_ota_enrollments_views.py
@@ -28,7 +28,7 @@ class MDMOTAEnrollmentsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
 

--- a/tests/mdm/test_api_profiles_views.py
+++ b/tests/mdm/test_api_profiles_views.py
@@ -30,7 +30,7 @@ class MDMProfilesAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_push_certificates_views.py
+++ b/tests/mdm/test_api_push_certificates_views.py
@@ -23,7 +23,7 @@ class MDMPushCertificateAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_recovery_password_configs_views.py
+++ b/tests/mdm/test_api_recovery_password_configs_views.py
@@ -27,7 +27,7 @@ class MDMRecoveryPasswordConfigsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_scep_issuers_views.py
+++ b/tests/mdm/test_api_scep_issuers_views.py
@@ -30,7 +30,7 @@ class MDMSCEPIssuerAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_software_update_enforcements_views.py
+++ b/tests/mdm/test_api_software_update_enforcements_views.py
@@ -29,7 +29,7 @@ class MDMSoftwareUpdateEnforcementsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_software_updates_views.py
+++ b/tests/mdm/test_api_software_updates_views.py
@@ -21,7 +21,7 @@ class SoftwareUpdatesAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/mdm/test_api_store_apps_views.py
+++ b/tests/mdm/test_api_store_apps_views.py
@@ -28,7 +28,7 @@ class MDMStoreAppsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/monolith/test_api_views.py
+++ b/tests/monolith/test_api_views.py
@@ -49,7 +49,7 @@ class MonolithAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(user=cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(user=cls.service_account)
         # mbu
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(64))
         cls.mbu.create_enrollment_business_unit()

--- a/tests/monolith/test_monolith_enrollment_package_api_views.py
+++ b/tests/monolith/test_monolith_enrollment_package_api_views.py
@@ -33,7 +33,7 @@ class MonolithAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(user=cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(user=cls.service_account)
 
     # utility methods
 

--- a/tests/munki/test_api_views.py
+++ b/tests/munki/test_api_views.py
@@ -32,7 +32,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
 

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -35,7 +35,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
 

--- a/tests/santa/test_api_views.py
+++ b/tests/santa/test_api_views.py
@@ -36,7 +36,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.maxDiff = None
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()

--- a/tests/server_accounts/test_users_models.py
+++ b/tests/server_accounts/test_users_models.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+from accounts.models import APIToken, User
+
+
+class UsersModelsTestCase(TestCase):
+
+    def test_api_token_serialize_for_event_keys_only(self):
+        # Given
+        username = get_random_string(19)
+        email = "{}@zentral.io".format(get_random_string(12))
+
+        token, _ = APIToken.objects.update_or_create_for_user(
+            User.objects.create_user(username, email))
+
+        # When
+        actual = token.serialize_for_event(keys_only=True)
+
+        # Then
+        self.assertEqual(actual, {
+            "pk": token.pk,
+            "username": username,
+            "email": email
+        })

--- a/tests/server_base/test_api_views.py
+++ b/tests/server_base/test_api_views.py
@@ -26,7 +26,7 @@ class BaseAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/server_realms/test_api_views.py
+++ b/tests/server_realms/test_api_views.py
@@ -23,7 +23,7 @@ class RealmsAPIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
 
     # utility methods
 

--- a/tests/server_realms/test_realm_scim_views.py
+++ b/tests/server_realms/test_realm_scim_views.py
@@ -28,7 +28,7 @@ class RealmViewsTestCase(TestCase):
         )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
-        cls.api_token = APIToken.objects.update_or_create_for_user(user=cls.service_account)
+        _, cls.api_token = APIToken.objects.update_or_create_for_user(user=cls.service_account)
         cls.realm = force_realm()
         cls.realm.scim_enabled = True
         cls.realm.save()

--- a/tests/wsone/test_api_views.py
+++ b/tests/wsone/test_api_views.py
@@ -22,7 +22,7 @@ class APIViewsTestCase(TestCase):
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
-        cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
+        _, cls.api_key = APIToken.objects.update_or_create_for_user(cls.service_account)
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.bu = cls.mbu.create_enrollment_business_unit()
 


### PR DESCRIPTION
Publish a audit event when creating or deleting a api token for a user.