### PR TITLE
Fix MDM apps & books preprocessor

### DIFF
--- a/tests/mdm/test_apns.py
+++ b/tests/mdm/test_apns.py
@@ -90,7 +90,7 @@ class MDMAPNSTestCase(TestCase):
         session, _, _ = force_dep_enrollment_session(
             self.mbu, authenticated=True, completed=True, push_certificate=self.push_certificate
         )
-        success = send_enrolled_device_notification(session.enrolled_device)
+        success, _ = send_enrolled_device_notification(session.enrolled_device)
         self.assertFalse(success)
         sleep.assert_not_called()
         self.assertEqual(len(post_event.call_args_list), 1)
@@ -110,7 +110,7 @@ class MDMAPNSTestCase(TestCase):
         session, _, _ = force_dep_enrollment_session(
             self.mbu, authenticated=True, completed=True, push_certificate=self.push_certificate
         )
-        success = send_enrolled_device_notification(session.enrolled_device)
+        success, _ = send_enrolled_device_notification(session.enrolled_device)
         self.assertFalse(success)
         self.assertEqual(len(sleep.call_args), APNSClient.max_retries)
         self.assertEqual(len(post_event.call_args_list), 1)
@@ -130,7 +130,7 @@ class MDMAPNSTestCase(TestCase):
         session, _, _ = force_dep_enrollment_session(
             self.mbu, authenticated=True, completed=True, push_certificate=self.push_certificate
         )
-        success = send_enrolled_device_notification(session.enrolled_device)
+        success, _ = send_enrolled_device_notification(session.enrolled_device)
         self.assertTrue(success)
         sleep.assert_not_called()
         self.assertEqual(len(post_event.call_args_list), 1)
@@ -151,7 +151,7 @@ class MDMAPNSTestCase(TestCase):
             self.mbu, authenticated=True, completed=True, push_certificate=self.push_certificate
         )
         enrolled_user = force_enrolled_user(session.enrolled_device)
-        success = send_enrolled_user_notification(enrolled_user)
+        success, _ = send_enrolled_user_notification(enrolled_user)
         self.assertFalse(success)
         sleep.assert_not_called()
         self.assertEqual(len(post_event.call_args_list), 1)
@@ -172,7 +172,7 @@ class MDMAPNSTestCase(TestCase):
             self.mbu, authenticated=True, completed=True, push_certificate=self.push_certificate
         )
         enrolled_user = force_enrolled_user(session.enrolled_device)
-        success = send_enrolled_user_notification(enrolled_user)
+        success, _ = send_enrolled_user_notification(enrolled_user)
         self.assertFalse(success)
         self.assertEqual(len(sleep.call_args), APNSClient.max_retries)
         self.assertEqual(len(post_event.call_args_list), 1)
@@ -193,7 +193,7 @@ class MDMAPNSTestCase(TestCase):
             self.mbu, authenticated=True, completed=True, push_certificate=self.push_certificate
         )
         enrolled_user = force_enrolled_user(session.enrolled_device)
-        success = send_enrolled_user_notification(enrolled_user)
+        success, _ = send_enrolled_user_notification(enrolled_user)
         self.assertTrue(success)
         sleep.assert_not_called()
         self.assertEqual(len(post_event.call_args_list), 1)

--- a/zentral/contrib/mdm/events/mdm.py
+++ b/zentral/contrib/mdm/events/mdm.py
@@ -46,7 +46,7 @@ class MDMDeviceNotificationEvent(BaseEvent):
 register_event_type(MDMDeviceNotificationEvent)
 
 
-def post_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id=None):
+def build_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id=None):
     event_metadata = EventMetadata(machine_serial_number=serial_number)
     event_payload = {
         "udid": udid,
@@ -56,5 +56,9 @@ def post_mdm_device_notification_event(serial_number, udid, priority, expiration
     }
     if user_id:
         event_payload["user_id"] = user_id
-    event = MDMDeviceNotificationEvent(event_metadata, event_payload)
+    return MDMDeviceNotificationEvent(event_metadata, event_payload)
+
+
+def post_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id=None):
+    event = build_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id)
     event.post()

--- a/zentral/contrib/mdm/management/commands/send_device_notification.py
+++ b/zentral/contrib/mdm/management/commands/send_device_notification.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
                 continue
             success = False
             try:
-                success = send_enrolled_device_notification(d)
+                success, _ = send_enrolled_device_notification(d)
             except Exception:
                 pass
             if success:

--- a/zentral/contrib/mdm/preprocessors.py
+++ b/zentral/contrib/mdm/preprocessors.py
@@ -150,7 +150,12 @@ class AppsBooksNotificationPreprocessor:
             for enrolled_device in (EnrolledDevice.objects
                                                   .select_related("push_certificate")
                                                   .filter(serial_number__in=devices_to_notify)):
-                send_enrolled_device_notification(enrolled_device)
+                try:
+                    _, event = send_enrolled_device_notification(enrolled_device, post_event=False)
+                except Exception:
+                    logger.exception("Could not notify device %s", enrolled_device.serial_number)
+                else:
+                    yield event
 
     def process_raw_event(self, raw_event):
         data = raw_event.get("data")


### PR DESCRIPTION
The device notification events were sent directly using the default queues instead of being generated by the preprocessor. On queues with threads, like AWS SQS/SNS, a separate thread would be started to send the event. This thread because it is not managed by the preprocessor would block the graceful shutdown.