### PR TITLE
Fail hard on machine snapshot commit errors

### DIFF
--- a/tests/inventory/test_utils_db.py
+++ b/tests/inventory/test_utils_db.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+from zentral.contrib.inventory.events import AddMachine, InventoryHeartbeat
+from zentral.contrib.inventory.models import MachineSnapshot
+from zentral.contrib.inventory.utils import (commit_machine_snapshot_and_trigger_events,
+                                             commit_machine_snapshot_and_yield_events)
+
+
+class InventoryUtilsDBTestCase(TestCase):
+    def _create_machine_snapshot_tree(self, serial_number=None):
+        if serial_number is None:
+            serial_number = get_random_string(12)
+        source = {
+            "module": "tests.zentral.com",
+            "name": "Zentral Tests",
+        }
+        return serial_number, {
+            "source": source,
+            "business_unit": {
+                "name": "yolo",
+                "reference": "fomo",
+                "source": source},
+            "serial_number": serial_number,
+        }
+
+    @patch("zentral.contrib.inventory.utils.db.MachineSnapshotCommit")
+    def test_commit_machine_snapshot_and_trigger_events_error(self, msc):
+        msc.objects.commit_machine_snapshot_tree.side_effect = ValueError("BOOM!")
+        serial_number, tree = self._create_machine_snapshot_tree()
+        with self.assertRaises(ValueError) as cm:
+            commit_machine_snapshot_and_trigger_events(tree)
+        self.assertEqual(cm.exception.args[0], "BOOM!")
+        self.assertFalse(MachineSnapshot.objects.filter(serial_number=serial_number).exists())
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_commit_machine_snapshot_and_trigger_events(self, post_event):
+        serial_number, tree = self._create_machine_snapshot_tree()
+        commit_machine_snapshot_and_trigger_events(tree)
+        self.assertEqual(len(post_event.call_args_list), 2)
+        self.assertIsInstance(post_event.call_args_list[0].args[0], AddMachine)
+        self.assertIsInstance(post_event.call_args_list[1].args[0], InventoryHeartbeat)
+        self.assertTrue(MachineSnapshot.objects.filter(serial_number=serial_number).exists())
+
+    @patch("zentral.contrib.inventory.utils.db.MachineSnapshotCommit")
+    def test_commit_machine_snapshot_and_yield_events_error(self, msc):
+        msc.objects.commit_machine_snapshot_tree.side_effect = ValueError("BOOM!")
+        serial_number, tree = self._create_machine_snapshot_tree()
+        with self.assertRaises(ValueError) as cm:
+            list(commit_machine_snapshot_and_yield_events(tree))
+        self.assertEqual(cm.exception.args[0], "BOOM!")
+        self.assertFalse(MachineSnapshot.objects.filter(serial_number=serial_number).exists())
+
+    def test_commit_machine_snapshot_and_yield_events(self):
+        serial_number, tree = self._create_machine_snapshot_tree()
+        events = list(commit_machine_snapshot_and_yield_events(tree))
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], AddMachine)
+        self.assertIsInstance(events[1], InventoryHeartbeat)
+        self.assertTrue(MachineSnapshot.objects.filter(serial_number=serial_number).exists())

--- a/zentral/contrib/inventory/utils/db.py
+++ b/zentral/contrib/inventory/utils/db.py
@@ -1,5 +1,4 @@
 import logging
-from zentral.utils.json import save_dead_letter
 from zentral.contrib.inventory.compliance_checks import jmespath_checks_cache
 from zentral.contrib.inventory.events import (iter_inventory_events)
 from zentral.contrib.inventory.models import MachineSnapshotCommit
@@ -83,7 +82,7 @@ def commit_machine_snapshot_and_trigger_events(tree):
         msc, machine_snapshot, last_seen = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(tree)
     except Exception:
         logger.exception("Could not commit machine snapshot")
-        save_dead_letter(tree, "machine snapshot commit error")
+        raise
     else:
         # inventory events
         if msc:
@@ -100,6 +99,7 @@ def commit_machine_snapshot_and_yield_events(tree):
         msc, _, last_seen = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(tree)
     except Exception:
         logger.exception("Could not commit machine snapshot")
+        raise
     else:
         # inventory events
         if msc:


### PR DESCRIPTION
This fixes an issue with the pre-processing of inventory updates with a broken database connection. The pre-processor will stop and will be automatically restarted now if there is a DB error.