### PR TITLE
Fix `managed_updates` sub manifest filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Fixed slow MDM Artifact deletion check.
 
 Fixed slow MDM APNS device and user notification queries.
 
+Fixed `managed_updates` filtering in the Monolith sub manifests.
+
 ### Backward incompatibilities
 
 #### 🧨 macOS inventory disk information

--- a/zentral/contrib/monolith/models.py
+++ b/zentral/contrib/monolith/models.py
@@ -661,7 +661,7 @@ class SubManifest(models.Model):
                     options = smpi.options
                 else:
                     options = None
-                if key in ('managed_installs', 'optional_installs'):
+                if key in ('managed_installs', 'managed_updates', 'optional_installs'):
                     val = (name, options)
                 else:
                     val = name

--- a/zentral/contrib/monolith/utils.py
+++ b/zentral/contrib/monolith/utils.py
@@ -164,7 +164,7 @@ def filter_catalog_data(catalog_data, serial_number, tag_names):
 
 
 def filter_sub_manifest_data_dict(smd, serial_number, tag_names):
-    for key in ('managed_installs', 'optional_installs'):
+    for key in ('managed_installs', 'managed_updates', 'optional_installs'):
         if key not in smd:
             continue
         smd[key] = [


### PR DESCRIPTION
The `managed_updates` were always included, regardless of the tags and shards.