### PR TITLE
Bump urllib3 from 2.6.0 to 2.6.3

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -150,7 +150,7 @@ traitlets==5.14.3
 typing_extensions==4.12.2
 tzdata==2024.2
 uritemplate==4.2.0
-urllib3==2.6.0
+urllib3==2.6.3
 vine==5.1.0
 wcwidth==0.2.13
 webauthn==2.2.0


### PR DESCRIPTION
See:

https://github.com/zentralopensource/zentral/pull/1340/changes https://github.com/urllib3/urllib3/security/advisories/GHSA-38jv-5279-wg99