### PR TITLE
Fix update machine tags API

### DIFF
--- a/tests/inventory/test_update_machine_tags.py
+++ b/tests/inventory/test_update_machine_tags.py
@@ -221,6 +221,21 @@ class InventoryAPITests(TestCase):
             {'machines': {'found': 1}, 'tags': {'added': 1, 'removed': 0}}
         )
 
+    def test_post_set_existing_taxonomy_tag_with_taxonomy(self):
+        self._set_required_permission()
+        taxonomy = Taxonomy.objects.create(name=get_random_string(12))
+        tag = Tag.objects.create(name=get_random_string(12))
+        response = self._post_json_data({
+            "operations": [{"kind": "SET",
+                            "taxonomy": taxonomy.name,
+                            "names": [tag.name]}],  # With taxonomy but existing tag doesn't have one
+            "serial_numbers": [get_random_string(12)],
+        })
+        self.assertEqual(
+            response.json(),
+            {'machines': {'found': 1}, 'tags': {'added': 1, 'removed': 0}}
+        )
+
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_post_set_add_one_tag(self, post_event):
         self._set_required_permission()

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -65,7 +65,7 @@ class UpdateMachineTags(APIView):
             if kind == "SET":
                 if names:
                     self.tags_to_set.setdefault(taxonomy, []).extend(
-                        Tag.objects.get_or_create(taxonomy=taxonomy, name=name)[0]
+                        Tag.objects.get_or_create(name=name, defaults={"taxonomy": taxonomy})[0]
                         for name in names
                     )
                 else:


### PR DESCRIPTION
Fix `SET` op error on an existing tag without taxonomy