### PR TITLE
google_workspace: remove orphaned machine tags when user leaves all mapped groups

### DIFF
--- a/tests/google_workspace/test_utils.py
+++ b/tests/google_workspace/test_utils.py
@@ -28,11 +28,11 @@ class UtilsTestCase(TestCase):
     def _given_serial_number(self):
         return f"sn_{get_random_string(8)}"
 
-    def _force_machine(self, user_email, serial_number=None):
+    def _force_machine(self, user_email, serial_number=None, source_name='zentral'):
         if not serial_number:
             serial_number = self._given_serial_number()
         MachineSnapshotCommit.objects.commit_machine_snapshot_tree({
-            "source": {'module': 'io.zentral.tests', 'name': 'zentral'},
+            "source": {'module': 'io.zentral.tests', 'name': source_name},
             "serial_number": serial_number,
             "principal_user": {
                 "source": {"type": "LOGGED_IN_USER", "properties": {"method": "System Configuration"}},
@@ -438,6 +438,106 @@ class UtilsTestCase(TestCase):
             self.assertTrue(metadata["machine_serial_number"] == serial_number
                             or metadata["machine_serial_number"] == other_serial_number)
             self.assertEqual(metadata["tags"], ["machine"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch('zentral.contrib.google_workspace.api_client.build')
+    def test_sync_group_tag_mappings_removes_tag_when_user_leaves_all_groups(self, build, post_event):
+        # Given
+        user_email = self._given_user_email()
+        build.return_value.members.return_value.list.return_value.execute.return_value = {
+            "members": [{'email': user_email, 'type': "USER"}]}
+
+        serial_number = self._force_machine(user_email)
+        connection = self._given_connection()
+        tag = self._given_tag()
+        self._given_group_tag_mapping(connection, tag)
+
+        # First sync: user is a member, tag is added
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_group_tag_mappings(connection)
+        self.assertTrue(MachineTag.objects.filter(serial_number=serial_number, tag_id=tag.pk).exists())
+        self.assertEqual(result, {"added": 1, "removed": 0})
+
+        # User leaves the group
+        build.return_value.members.return_value.list.return_value.execute.return_value = {"members": []}
+        post_event.reset_mock()
+
+        # When: second sync
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            result = sync_group_tag_mappings(connection)
+
+        # Then: tag is removed
+        self.assertFalse(MachineTag.objects.filter(serial_number=serial_number, tag_id=tag.pk).exists())
+        self.assertEqual(result, {"added": 0, "removed": 1})
+        self.assertEqual(len(callbacks), 1)
+
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, MachineTagEvent)
+        self.assertEqual(
+            event.payload,
+            self._expected_machine_tag_event_payload(tag, "removed")
+        )
+        self.assertEqual(event.metadata.serialize()["machine_serial_number"], serial_number)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch('zentral.contrib.google_workspace.api_client.build')
+    def test_sync_group_tag_mappings_orphan_removal_preserves_unmanaged_tags(self, build, post_event):
+        # Given
+        user_email = self._given_user_email()
+        build.return_value.members.return_value.list.return_value.execute.return_value = {"members": []}
+
+        serial_number = self._force_machine(user_email)
+        connection = self._given_connection()
+        managed_tag = self._given_tag()
+        unmanaged_tag = self._given_tag()
+        self._given_group_tag_mapping(connection, managed_tag)
+
+        # device has both tags applied outside the sync
+        self._given_machine_tag(serial_number, managed_tag)
+        self._given_machine_tag(serial_number, unmanaged_tag)
+
+        # When
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_group_tag_mappings(connection)
+
+        # Then: managed tag removed, unmanaged tag preserved
+        self.assertFalse(MachineTag.objects.filter(serial_number=serial_number, tag_id=managed_tag.pk).exists())
+        self.assertTrue(MachineTag.objects.filter(serial_number=serial_number, tag_id=unmanaged_tag.pk).exists())
+        self.assertEqual(result, {"added": 0, "removed": 1})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch('zentral.contrib.google_workspace.api_client.build')
+    def test_sync_group_tag_mappings_keeps_tag_when_any_source_reports_member(self, build, post_event):
+        # Given: one serial number with two current snapshots from different
+        # inventory sources reporting different principal users.
+        member_email = self._given_user_email()
+        other_email = self._given_user_email()
+        build.return_value.members.return_value.list.return_value.execute.return_value = {
+            "members": [{'email': member_email, 'type': "USER"}]}
+
+        serial_number = self._force_machine(member_email, source_name='source-a')
+        self._force_machine(other_email, serial_number=serial_number, source_name='source-b')
+
+        connection = self._given_connection()
+        tag = self._given_tag()
+        self._given_group_tag_mapping(connection, tag)
+
+        # When
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_group_tag_mappings(connection)
+
+        # Then: tag is added via source-a's member principal user, and the
+        # cleanup does not remove it just because source-b reports a
+        # non-member principal user.
+        self.assertTrue(MachineTag.objects.filter(serial_number=serial_number, tag_id=tag.pk).exists())
+        self.assertEqual(result, {"added": 1, "removed": 0})
+
+        # When syncing again
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_group_tag_mappings(connection)
+
+        # Then: no flip-flopping
+        self.assertEqual(result, {"added": 0, "removed": 0})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     @patch('zentral.contrib.google_workspace.api_client.build')

--- a/zentral/contrib/google_workspace/tasks.py
+++ b/zentral/contrib/google_workspace/tasks.py
@@ -1,5 +1,6 @@
 import uuid
 import logging
+from django.db import transaction
 from celery import shared_task
 from zentral.contrib.google_workspace.models import Connection
 from zentral.core.events.base import EventRequest
@@ -22,7 +23,8 @@ def sync_group_tag_mappings_task(
     event_request = None
     if serialized_event_request:
         event_request = EventRequest.deserialize(serialized_event_request)
-    count = sync(connection, event_request)
+    with transaction.atomic():
+        count = sync(connection, event_request)
     return {
         "connection": {"pk": str(connection.pk), "name": connection.name},
         "machine_tags": count}

--- a/zentral/contrib/google_workspace/utils.py
+++ b/zentral/contrib/google_workspace/utils.py
@@ -1,5 +1,4 @@
 import logging
-import psycopg2.extras
 from collections import defaultdict
 from collections.abc import Iterator
 from django.db import connection, transaction
@@ -25,64 +24,76 @@ def _resolve_group_members_to_tags(api_connection: Connection) -> tuple[dict[str
     return email_tags, tag_pks
 
 
-def _iter_group_members_tags(email_tags: dict[str, set[int]], tag_pks: set[int]) -> Iterator[tuple[str, int, bool]]:
-    for email, expected_tags in email_tags.items():
-        for tag_pk in tag_pks:
-            yield (email, tag_pk, tag_pk in expected_tags)
+def _iter_email_tags(email_tags: dict[str, set[int]], tag_pks: set[int]) -> Iterator[tuple[str | None, int]]:
+    seen_tag_pks = set()
+    for email, expected_tag_pks in email_tags.items():
+        seen_tag_pks.update(expected_tag_pks)
+        for tag_pk in expected_tag_pks:
+            yield (email, tag_pk)
+    for tag_pk in tag_pks - seen_tag_pks:
+        # the tag is managed, but no matching member was found.
+        # still included in the data to delete orphan tags.
+        yield (None, tag_pk)
 
 
 def _sync_machine_tags(
-        group_member_tags: Iterator[tuple[str, int, bool]],
+        email_tag_iterator: Iterator[tuple[str | None, int]],
         event_request: EventRequest
-        ) -> dict[str, int]:
+) -> dict[str, int]:
+    # Pass all the email → tag_pk as arrays that will be unnested together (efficiency trick).
+    # We cannot use an iterator with `execute_values` because this query works only if all the
+    # tuples are present at query execution time.
+    emails: list[str | None] = []
+    tag_ids: list[int] = []
+    for email, tag_id in email_tag_iterator:
+        emails.append(email)
+        tag_ids.append(tag_id)
     query = """
         with given_values as (
-             select email, tag_id, add_operation from (values %s) as v(email, tag_id, add_operation)),
-        serial_numbers as (
-            select ms.serial_number, v.email, v.tag_id, v.add_operation from
+             select * from unnest(%(emails)s::text[], %(tag_ids)s::int[]) as v(email, tag_id)),
+        machine_managed_tags as (
+            select ms.serial_number, v.tag_id from
                 inventory_machinesnapshot ms
                 join inventory_currentmachinesnapshot cms on (cms.machine_snapshot_id = ms.id)
                 join inventory_principaluser pu on (pu.id = ms.principal_user_id)
                 join given_values v on v.email = pu.unique_id
-            group by ms.serial_number, v.email, v.tag_id, v.add_operation),
+                where v.email is not null
+            group by ms.serial_number, v.tag_id),
         inserted_tags as (
             insert into inventory_machinetag(serial_number, tag_id)
-                select sn.serial_number, sn.tag_id
-                from serial_numbers sn
-                where sn.add_operation
+                select serial_number, tag_id
+                from machine_managed_tags
             on conflict do nothing
             returning serial_number, tag_id, 'added'::text as action),
         deleted_tags as (
-            delete from inventory_machinetag im
-            using serial_numbers sn
-            where not sn.add_operation
-                and im.serial_number = sn.serial_number
-                and im.tag_id = sn.tag_id
-            returning im.serial_number, im.tag_id, 'removed'::text as action),
+            delete from inventory_machinetag mt
+            where exists (
+              -- tag is managed
+              select * from given_values
+              where tag_id = mt.tag_id
+            )
+            and not exists (
+              -- tag is not set for the machine
+              select * from machine_managed_tags
+              where serial_number = mt.serial_number
+              and tag_id = mt.tag_id
+            )
+            returning mt.serial_number, mt.tag_id, 'removed'::text as action),
         results as (
-            select
-                it.serial_number, 'added' action, it.tag_id pk
-            from
-                inserted_tags it
+            select * from inserted_tags
             union
-            select
-                dt.serial_number, 'removed' action, dt.tag_id pk
-            from
-                deleted_tags dt
+            select * from deleted_tags
         )
         select
-            r.serial_number, r.action, r.pk, t.name, tx.id taxonomy_pk, tx.name taxonomy_name
+            r.serial_number, r.action, t.id, t.name, tx.id taxonomy_pk, tx.name taxonomy_name
         from
             results r
-            join inventory_tag t on (r.pk = t.id)
+            join inventory_tag t on (r.tag_id = t.id)
             left join inventory_taxonomy tx on (t.taxonomy_id = tx.id)"""
+
     with connection.cursor() as cursor:
-        results = psycopg2.extras.execute_values(
-            cursor, query,
-            group_member_tags,
-            page_size=1000,
-            fetch=True
-        )
+        cursor.execute(query, {"emails": emails, "tag_ids": tag_ids})
+        results = cursor.fetchall()
 
     def send_machine_tag_added_events():
         send_machine_tag_events_with_event_request(results, event_request)
@@ -105,7 +116,7 @@ def _sync_machine_tags(
     return result_count
 
 
-def sync_group_tag_mappings(api_connection: Connection, event_request: EventRequest = None) -> None:
+def sync_group_tag_mappings(api_connection: Connection, event_request: EventRequest = None) -> dict[str, int]:
     email_tags, tag_pks = _resolve_group_members_to_tags(api_connection)
-    group_member_tags = _iter_group_members_tags(email_tags, tag_pks)
-    return _sync_machine_tags(group_member_tags, event_request)
+    email_tag_iterator = _iter_email_tags(email_tags, tag_pks)
+    return _sync_machine_tags(email_tag_iterator, event_request)


### PR DESCRIPTION
## Summary

`sync_group_tag_mappings` does not remove a machine's tag when the principal user leaves *all* mapped groups. Cross-group reconciliation works (a user moving from group A to group B has tag A removed), but a user who leaves every mapped group keeps their managed tags indefinitely.

## Root cause

`_iter_group_members_tags` iterates only `email_tags.items()`, which contains *current* group members. An ex-member's email is not in the dict, so no `(email, tag_pk, False)` removal tuple is yielded and the DELETE in `_sync_machine_tags` never fires for them.

## Repro

1. Map group G → tag T. User U is a member; their machine M has principal_user U.
2. Sync → M tagged T. ✓
3. Remove U from G.
4. Sync → log shows `Found 1 managed tags for N-1 emails` (count dropped) but `removed 0`. Tag T remains on M.

We hit this validating the feature for production use — leaving the access group did not revoke the tag-scoped Santa rule.

## Fix

Add a follow-up DELETE in `_sync_machine_tags` for orphaned tags: `inventory_machinetag` rows where `tag_id` is in the connection's managed set and the machine's current principal user is not in the current member set. Results are unioned into the existing event/count reporting. The original CTE query is unchanged.

Handles the empty-members edge case (all tagged machines cleaned) and leaves tags not managed by any mapping untouched.

## Tests

Two new cases in `tests/google_workspace/test_utils.py`:
- user leaves all groups → tag removed, `removed: 1` reported, `MachineTagEvent` emitted
- orphan removal does not touch unmanaged tags on the same machine