### PR TITLE
Increase contrast for text color for background color

### DIFF
--- a/tests/core_incidents/test_incidents_extras.py
+++ b/tests/core_incidents/test_incidents_extras.py
@@ -9,7 +9,7 @@ class IncidentsExtrasTestCase(SimpleTestCase):
                                          (100, "Minor", "DDDD00"),):
             result = (
                 '<span class="label rounded p-1" '
-                f'style="white-space:nowrap;background-color:#{color};color:#FFF">'
+                f'style="white-space:nowrap;background-color:#{color};color:#000">'
                 f'{display}&nbsp;<i class="bi bi-exclamation-triangle-fill"></i>'
                 '</span>'
             )

--- a/zentral/utils/color.py
+++ b/zentral/utils/color.py
@@ -1,5 +1,9 @@
 import re
-import colorsys
+
+
+def _channel_luminance(c):
+    c = c / 255.0
+    return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
 
 
 def text_color_for_background_color(color):
@@ -8,13 +12,11 @@ def text_color_for_background_color(color):
     if len(color) == 3:
         color = "".join(2 * c for c in color)
     try:
-        hls = colorsys.rgb_to_hls(float(int(color[0:2], 16))/255.0,
-                                  float(int(color[2:4], 16))/255.0,
-                                  float(int(color[4:6], 16))/255.0,)
+        r, g, b = int(color[0:2], 16), int(color[2:4], 16), int(color[4:6], 16)
     except ValueError:
         return "000"
-    else:
-        if hls[1] > .7:
-            return "000"
-        else:
-            return "FFF"
+    luminance = (0.2126 * _channel_luminance(r)
+                 + 0.7152 * _channel_luminance(g)
+                 + 0.0722 * _channel_luminance(b))
+    # WCAG: black text gives better contrast than white when luminance > ~0.179
+    return "000" if luminance > 0.179 else "FFF"


### PR DESCRIPTION
The contrast for the text color on light backgrounds is too low. E.g. the yellow `canary` tag comes with a white font color. This PR increases the contrast for such cases.

|Before|After|
|---|---|
|<img width="241" height="401" alt="Screenshot 2026-04-30 at 10 48 43" src="https://github.com/user-attachments/assets/bc2fbbd2-7569-429d-b37b-3506ece17c31" />|<img width="145" height="250" alt="Screenshot 2026-04-30 at 10 48 27" src="https://github.com/user-attachments/assets/f07acb32-74a7-45c8-9665-514bafccfc67" />|

The Incident Severity tags are using darker text color and a test caught that change. 

|Current|
|---|
|<img width="118" height="336" alt="Screenshot 2026-04-30 at 11 22 35" src="https://github.com/user-attachments/assets/d1723ea9-7bc0-4f1f-b6c0-64975a512160" />|


### Resources

- https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html