### PR TITLE
Fix machine snapshot last commit performance

### DIFF
--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -672,7 +672,7 @@ class MachineSnapshot(AbstractMTObject):
     @cached_property
     def last_commit(self):
         try:
-            return self.machinesnapshotcommit_set.all().order_by("-id")[0]
+            return self.machinesnapshotcommit_set.all().order_by("-created_at")[0]
         except IndexError:
             pass
 


### PR DESCRIPTION
Sort by `created_at` instead of `id` which helps the PostgreSQL query planner!