### PR TITLE
Fix threading issue in Jamf preprocessor

### DIFF
--- a/tests/inventory/test_utils_tags.py
+++ b/tests/inventory/test_utils_tags.py
@@ -1,9 +1,18 @@
 from unittest.mock import patch
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
 from django.utils.crypto import get_random_string
-from django.test import TestCase
 from zentral.contrib.inventory.events import MachineTagEvent
 from zentral.contrib.inventory.models import MachineTag, Tag, Taxonomy
-from zentral.contrib.inventory.utils import set_machine_taxonomy_tags
+from zentral.contrib.inventory.utils import (
+    set_machine_taxonomy_tags,
+    set_machine_taxonomy_tags_and_yield_events,
+)
+from zentral.contrib.inventory.utils.tags import (
+    iter_machine_tag_events,
+    iter_machine_tag_events_with_event_request,
+)
+from zentral.core.events.base import EventRequest
 
 
 class InventoryUtilsTagsTestCase(TestCase):
@@ -74,3 +83,138 @@ class InventoryUtilsTagsTestCase(TestCase):
              'tag': {'name': tr2.name, 'pk': tr2.pk},
              'taxonomy': {'name': tx2.name, 'pk': tx2.pk}}
         )
+
+    # iter_machine_tag_events_with_event_request
+
+    def test_iter_machine_tag_events_empty_results(self):
+        self.assertEqual(list(iter_machine_tag_events_with_event_request([], None)), [])
+        self.assertEqual(list(iter_machine_tag_events_with_event_request(None, None)), [])
+
+    def test_iter_machine_tag_events_shared_uuid_monotonic_index(self):
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        t1 = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        t2 = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        results = [
+            (sn, MachineTagEvent.Action.ADDED, t1.pk, t1.name, tx.pk, tx.name),
+            (sn, MachineTagEvent.Action.REMOVED, t2.pk, t2.name, tx.pk, tx.name),
+        ]
+        events = list(iter_machine_tag_events_with_event_request(results, None))
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].metadata.uuid, events[1].metadata.uuid)
+        self.assertEqual(events[0].metadata.index, 0)
+        self.assertEqual(events[1].metadata.index, 1)
+        self.assertEqual(events[0].payload["action"], "added")
+        self.assertEqual(events[1].payload["action"], "removed")
+        self.assertEqual(events[0].metadata.machine_serial_number, sn)
+
+    def test_iter_machine_tag_events_accepts_raw_action_string(self):
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        t1 = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        results = [(sn, "added", t1.pk, t1.name, tx.pk, tx.name)]
+        event, = list(iter_machine_tag_events_with_event_request(results, None))
+        self.assertEqual(event.payload["action"], "added")
+
+    def test_iter_machine_tag_events_passes_event_request_through(self):
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        t1 = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        results = [(sn, MachineTagEvent.Action.ADDED, t1.pk, t1.name, tx.pk, tx.name)]
+        event_request = EventRequest(user_agent="ua", ip="1.2.3.4")
+        event, = list(iter_machine_tag_events_with_event_request(results, event_request))
+        self.assertIs(event.metadata.request, event_request)
+
+    def test_iter_machine_tag_events_no_taxonomy_in_payload(self):
+        sn = get_random_string(12)
+        t1 = Tag.objects.create(name=get_random_string(12))
+        results = [(sn, MachineTagEvent.Action.ADDED, t1.pk, t1.name, None, None)]
+        event, = list(iter_machine_tag_events_with_event_request(results, None))
+        self.assertNotIn("taxonomy", event.payload)
+
+    # iter_machine_tag_events
+
+    def test_iter_machine_tag_events_builds_event_request_from_http_request(self):
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        t1 = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        results = [(sn, MachineTagEvent.Action.ADDED, t1.pk, t1.name, tx.pk, tx.name)]
+        request = RequestFactory().get("/", HTTP_USER_AGENT="ua")
+        request.user = AnonymousUser()
+        event, = list(iter_machine_tag_events(results, request=request))
+        self.assertIsNotNone(event.metadata.request)
+        self.assertEqual(event.metadata.request.user_agent, "ua")
+
+    def test_iter_machine_tag_events_no_request_no_event_request(self):
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        t1 = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        results = [(sn, MachineTagEvent.Action.ADDED, t1.pk, t1.name, tx.pk, tx.name)]
+        event, = list(iter_machine_tag_events(results, request=None))
+        self.assertIsNone(event.metadata.request)
+
+    # set_machine_taxonomy_tags_and_yield_events
+
+    def _build_taxonomy_fixture(self):
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        keep = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        remove = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        add = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        MachineTag.objects.create(serial_number=sn, tag=keep)
+        MachineTag.objects.create(serial_number=sn, tag=remove)
+        return sn, tx, keep, remove, add
+
+    @patch("zentral.contrib.inventory.utils.tags.transaction.on_commit")
+    def test_set_machine_taxonomy_tags_and_yield_events_does_not_register_on_commit(self, on_commit):
+        sn, tx, keep, _, add = self._build_taxonomy_fixture()
+        # exhausting the generator must not register an on_commit callback
+        list(set_machine_taxonomy_tags_and_yield_events(sn, tx, [keep.name, add.name]))
+        on_commit.assert_not_called()
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_set_machine_taxonomy_tags_and_yield_events_applies_changes(self, post_event):
+        sn, tx, keep, remove, add = self._build_taxonomy_fixture()
+        list(set_machine_taxonomy_tags_and_yield_events(sn, tx, [keep.name, add.name]))
+        self.assertEqual(
+            {mt.tag for mt in MachineTag.objects.filter(serial_number=sn)},
+            {keep, add},
+        )
+        # the generator yields events; nothing is posted by the helper itself
+        post_event.assert_not_called()
+
+    def test_set_machine_taxonomy_tags_and_yield_events_yields_expected_events(self):
+        sn, tx, keep, remove, add = self._build_taxonomy_fixture()
+        events = sorted(
+            set_machine_taxonomy_tags_and_yield_events(sn, tx, [keep.name, add.name]),
+            key=lambda e: (e.payload["action"], e.payload["tag"]["pk"]),
+        )
+        self.assertEqual(len(events), 2)
+        added, removed = events
+        self.assertEqual(added.payload["action"], "added")
+        self.assertEqual(added.payload["tag"]["name"], add.name)
+        self.assertEqual(added.payload["taxonomy"]["pk"], tx.pk)
+        self.assertEqual(removed.payload["action"], "removed")
+        self.assertEqual(removed.payload["tag"]["pk"], remove.pk)
+        # shared event_uuid + monotonic index across yields
+        self.assertEqual(added.metadata.uuid, removed.metadata.uuid)
+        self.assertEqual({added.metadata.index, removed.metadata.index}, {0, 1})
+
+    def test_set_machine_taxonomy_tags_and_yield_events_no_change_yields_nothing(self):
+        sn, tx, keep, *_ = self._build_taxonomy_fixture()
+        # only changing the row that already matches the desired state → no events
+        # (but the `remove` tag is currently attached, so listing only `keep` would still remove it.
+        # Use a list that matches current attached tags exactly for this taxonomy.)
+        current = list(
+            MachineTag.objects.filter(serial_number=sn, tag__taxonomy=tx).values_list("tag__name", flat=True)
+        )
+        events = list(set_machine_taxonomy_tags_and_yield_events(sn, tx, current))
+        self.assertEqual(events, [])
+
+    # parity: set_machine_taxonomy_tags still uses on_commit
+
+    @patch("zentral.contrib.inventory.utils.tags.transaction.on_commit")
+    def test_set_machine_taxonomy_tags_still_registers_on_commit(self, on_commit):
+        sn, tx, keep, _, add = self._build_taxonomy_fixture()
+        set_machine_taxonomy_tags(sn, tx, [keep.name, add.name])
+        on_commit.assert_called_once()

--- a/tests/jamf/test_preprocessor_webhook.py
+++ b/tests/jamf/test_preprocessor_webhook.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+from zentral.contrib.inventory.events import MachineTagEvent
+from zentral.contrib.inventory.models import MachineTag, Tag, Taxonomy
+from zentral.contrib.jamf.preprocessors.webhook import WebhookEventPreprocessor
+
+
+class WebhookEventPreprocessorTagsTestCase(TestCase):
+    def _make_preprocessor(self):
+        return WebhookEventPreprocessor()
+
+    def _make_mocked_client(self, serial_number, tags):
+        client = MagicMock()
+        client.source_repr = "test.example.com"
+        client.get_machine_d_and_tags.return_value = (
+            {"serial_number": serial_number},
+            tags,
+        )
+        return client
+
+    def _drain(self, preprocessor, client):
+        # consume the generator inside the same thread, mirroring the queue worker
+        return list(preprocessor._update_machine(client, "computer", 1))
+
+    @patch("zentral.contrib.jamf.preprocessors.webhook.commit_machine_snapshot_and_yield_events")
+    def test_update_machine_yields_tag_events(self, commit_machine_snapshot):
+        commit_machine_snapshot.return_value = iter([])  # focus on the tag-events path
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        existing_tag = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        stale_tag = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        MachineTag.objects.create(serial_number=sn, tag=existing_tag)
+        MachineTag.objects.create(serial_number=sn, tag=stale_tag)
+
+        new_tag_name = get_random_string(12)
+        client = self._make_mocked_client(sn, {tx.pk: [existing_tag.name, new_tag_name]})
+        events = self._drain(self._make_preprocessor(), client)
+
+        tag_events = [e for e in events if isinstance(e, MachineTagEvent)]
+        self.assertEqual(len(tag_events), 2)
+        actions = sorted((e.payload["action"], e.payload["tag"]["name"]) for e in tag_events)
+        self.assertEqual(actions, sorted([("added", new_tag_name), ("removed", stale_tag.name)]))
+        for event in tag_events:
+            self.assertEqual(event.metadata.machine_serial_number, sn)
+            self.assertEqual(event.payload["taxonomy"]["pk"], tx.pk)
+
+    @patch("zentral.contrib.inventory.utils.tags.transaction.on_commit")
+    @patch("zentral.contrib.jamf.preprocessors.webhook.commit_machine_snapshot_and_yield_events")
+    def test_update_machine_does_not_register_on_commit_for_tag_events(
+        self, commit_machine_snapshot, on_commit,
+    ):
+        # this is the regression-catcher for the original bug: tag events must NOT
+        # go through transaction.on_commit (which is what spawned the orphaned thread)
+        commit_machine_snapshot.return_value = iter([])
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        existing_tag = Tag.objects.create(taxonomy=tx, name=get_random_string(12))
+        MachineTag.objects.create(serial_number=sn, tag=existing_tag)
+        client = self._make_mocked_client(sn, {tx.pk: [existing_tag.name, get_random_string(12)]})
+        self._drain(self._make_preprocessor(), client)
+        on_commit.assert_not_called()
+
+    @patch("zentral.contrib.jamf.preprocessors.webhook.commit_machine_snapshot_and_yield_events")
+    def test_update_machine_no_tags_no_tag_events(self, commit_machine_snapshot):
+        commit_machine_snapshot.return_value = iter([])
+        sn = get_random_string(12)
+        client = self._make_mocked_client(sn, {})
+        events = self._drain(self._make_preprocessor(), client)
+        self.assertEqual([e for e in events if isinstance(e, MachineTagEvent)], [])
+
+    @patch("zentral.contrib.jamf.preprocessors.webhook.commit_machine_snapshot_and_yield_events")
+    def test_update_machine_unknown_taxonomy_skipped(self, commit_machine_snapshot):
+        commit_machine_snapshot.return_value = iter([])
+        sn = get_random_string(12)
+        client = self._make_mocked_client(sn, {999999: ["whatever"]})
+        events = self._drain(self._make_preprocessor(), client)
+        self.assertEqual([e for e in events if isinstance(e, MachineTagEvent)], [])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.jamf.preprocessors.webhook.commit_machine_snapshot_and_yield_events")
+    def test_update_machine_does_not_post_events_itself(self, commit_machine_snapshot, post_event):
+        # the preprocessor must not post events; that is the caller's responsibility.
+        # this guards against any future regression that re-introduces side-effect posting.
+        commit_machine_snapshot.return_value = iter([])
+        sn = get_random_string(12)
+        tx = Taxonomy.objects.create(name=get_random_string(12))
+        client = self._make_mocked_client(sn, {tx.pk: [get_random_string(12)]})
+        self._drain(self._make_preprocessor(), client)
+        post_event.assert_not_called()

--- a/zentral/contrib/inventory/utils/tags.py
+++ b/zentral/contrib/inventory/utils/tags.py
@@ -1,12 +1,13 @@
 import uuid
+
+import psycopg2.extras
 from django.db import connection, transaction
 from django.db.models.query import QuerySet
+from django.http import HttpRequest
 from django.utils.text import slugify
-import psycopg2.extras
+
 from zentral.contrib.inventory.events import MachineTagEvent
 from zentral.core.events.base import EventMetadata, EventRequest
-from django.http import HttpRequest
-
 
 __all__ = [
     "add_machine_tags",
@@ -14,6 +15,7 @@ __all__ = [
     "send_machine_tag_events",
     "send_machine_tag_events_with_event_request",
     "set_machine_taxonomy_tags",
+    "set_machine_taxonomy_tags_and_yield_events",
 ]
 
 
@@ -23,16 +25,7 @@ def fetch_tags_if_required(tags):
     return tags
 
 
-def send_machine_tag_events(results, request: HttpRequest = None) -> None:
-    if not results:
-        return
-    event_request = None
-    if request:
-        event_request = EventRequest.build_from_request(request)
-    return send_machine_tag_events_with_event_request(results, event_request)
-
-
-def send_machine_tag_events_with_event_request(results, event_request: EventRequest = None) -> None:
+def iter_machine_tag_events_with_event_request(results, event_request):
     if not results:
         return
     event_uuid = uuid.uuid4()
@@ -46,7 +39,7 @@ def send_machine_tag_events_with_event_request(results, event_request: EventRequ
         }
         if taxonomy_pk:
             payload["taxonomy"] = {"pk": taxonomy_pk, "name": taxonomy_name}
-        event = MachineTagEvent(
+        yield MachineTagEvent(
             EventMetadata(
                 uuid=event_uuid,
                 index=event_index,
@@ -55,8 +48,26 @@ def send_machine_tag_events_with_event_request(results, event_request: EventRequ
             ),
             payload,
         )
-        event.post()
         event_index += 1
+
+
+def iter_machine_tag_events(results, request=None):
+    if not results:
+        return
+    event_request = None
+    if request:
+        event_request = EventRequest.build_from_request(request)
+    yield from iter_machine_tag_events_with_event_request(results, event_request)
+
+
+def send_machine_tag_events(results, request: HttpRequest = None) -> None:
+    for event in iter_machine_tag_events(results, request):
+        event.post()
+
+
+def send_machine_tag_events_with_event_request(results, event_request: EventRequest = None) -> None:
+    for event in iter_machine_tag_events_with_event_request(results, event_request):
+        event.post()
 
 
 def add_machine_tags(serial_number, tags, request=None):
@@ -114,7 +125,7 @@ def remove_machine_tags(serial_number, tags, request=None):
     return len(results)
 
 
-def set_machine_taxonomy_tags(serial_number, taxonomy, tag_names, request=None):
+def _set_machine_taxonomy_tags(serial_number, taxonomy, tag_names):
     query = (
         "with taxonomy_tags(name, slug, color) as ("
         "  values %%s"
@@ -170,12 +181,22 @@ def set_machine_taxonomy_tags(serial_number, taxonomy, tag_names, request=None):
              for name in tag_names),
             fetch=True
         )
+    return [
+        (sn, action, tag_id, tag_name, taxonomy.pk, taxonomy.name)
+        for (sn, action, tag_id, tag_name) in results
+    ]
+
+
+def set_machine_taxonomy_tags(serial_number, taxonomy, tag_names, request=None):
+    results = _set_machine_taxonomy_tags(serial_number, taxonomy, tag_names)
 
     def send_machine_tag_updated_events():
-        send_machine_tag_events(
-            [(serial_number, action, tag_id, tag_name, taxonomy.pk, taxonomy.name)
-             for (serial_number, action, tag_id, tag_name) in results],
-            request
-        )
+        send_machine_tag_events(results, request)
 
     transaction.on_commit(send_machine_tag_updated_events)
+
+
+def set_machine_taxonomy_tags_and_yield_events(serial_number, taxonomy, tag_names, request=None):
+    results = _set_machine_taxonomy_tags(serial_number, taxonomy, tag_names)
+
+    yield from iter_machine_tag_events(results, request)

--- a/zentral/contrib/jamf/preprocessors/webhook.py
+++ b/zentral/contrib/jamf/preprocessors/webhook.py
@@ -1,8 +1,11 @@
 import logging
+
 from django.core.cache import cache
 from django.db import transaction
+
 from zentral.contrib.inventory.models import MachineGroup, MachineSnapshot, MachineSnapshotCommit, Taxonomy
-from zentral.contrib.inventory.utils import commit_machine_snapshot_and_yield_events, set_machine_taxonomy_tags
+from zentral.contrib.inventory.utils import (commit_machine_snapshot_and_yield_events,
+                                             set_machine_taxonomy_tags_and_yield_events)
 from zentral.contrib.jamf.api_client import APIClient, APIClientError
 from zentral.core.events import event_cls_from_type
 from zentral.core.secret_engines import decrypt_str, DecryptionError
@@ -87,7 +90,7 @@ class WebhookEventPreprocessor(object):
                     taxonomy = self._get_taxonomy(taxonomy_id)
                     if taxonomy:
                         # TODO: serialize and deserialize request for MachineTagEvent
-                        set_machine_taxonomy_tags(serial_number, taxonomy, tag_names)
+                        yield from set_machine_taxonomy_tags_and_yield_events(serial_number, taxonomy, tag_names)
 
     def get_inventory_groups(self, client, device_type, jamf_id, is_smart):
         kwargs = {"reference": client.group_reference(device_type, jamf_id, is_smart)}


### PR DESCRIPTION
Do not start an extra thread to send the tagging events.