### PR TITLE
Bump jwt to v2.13.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -121,7 +121,7 @@ pyasn1_modules==0.4.2
 pycparser==3.0
 pycurl==7.45.3
 Pygments==2.20.0
-PyJWT==2.12.0
+PyJWT==2.13.0
 pyOpenSSL==26.0.0
 pyotp==2.9.0
 pyparsing==3.2.5

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,4 +1,0 @@
-[[IgnoredVulns]]
-id = "PYSEC-2025-183"
-ignoreUntil = 2026-06-01
-reason = "We only accept a subset of encryption & signature alogorithms, and key lengths."

--- a/zentral/utils/oidc.py
+++ b/zentral/utils/oidc.py
@@ -53,6 +53,7 @@ def verify_jws(token, issuer, audience, openid_configuration, exception_class=No
             leeway=TIMESTAMP_LEEWAY,
             options={
                 "require": ["iss", "aud", "exp"],
+                "enforce_minimum_key_length": True,
             },
         )
     except jwt.PyJWTError:


### PR DESCRIPTION
Enforce minimum key lengths. See PYSEC-2025-183.