### PR TITLE
Fix multiprocessing / runworkers

### DIFF
--- a/server/base/management/commands/runworkers.py
+++ b/server/base/management/commands/runworkers.py
@@ -1,10 +1,13 @@
 import json
 import logging
+import multiprocessing
 from multiprocessing import Process
 import random
 import time
-import yaml
+
 from django.core.management.base import BaseCommand
+import yaml
+
 from zentral.core.queues.workers import get_workers
 
 
@@ -20,6 +23,8 @@ class Command(BaseCommand):
         self.processes = {}
         self.prometheus_targets = {}
         self.processes_to_restart = {}
+        multiprocessing.set_start_method('forkserver')
+        multiprocessing.set_forkserver_preload(["server.multiprocessing_preload"])
 
     def add_arguments(self, parser):
         parser.add_argument('--list-workers', action='store_true', dest='list_workers', default=False,

--- a/server/server/multiprocessing_preload.py
+++ b/server/server/multiprocessing_preload.py
@@ -1,0 +1,8 @@
+"""Preloaded into the multiprocessing forkserver process so that child
+processes have Django's app registry ready.
+
+See server/base/management/commands/runworkers.py
+"""
+import django
+
+django.setup()

--- a/zentral/utils/leaky_bucket.py
+++ b/zentral/utils/leaky_bucket.py
@@ -9,6 +9,19 @@ class LeakyBucket:
         self._lock = threading.Lock()
         self._state = (time.monotonic(), self.capacity)
 
+    # multiprocessing fix
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
+    # end multiprocessing fix
+
     def _unsafe_update_state(self):
         last_updated_at, last_volume = self._state
         updated_at = time.monotonic()


### PR DESCRIPTION
Runworkers is only recommended in docker-compose dev environments, to run all workers in one containers.