### PR TITLE
2026-05-29 Prevent role escalation in user/service-account forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Tags cannot be applied to all the machines in a business unit anymore.
 
 The API endpoint for the monolith catalog list is paginated now. Remember to upgrade the Terraform Provider.
 
+#### 🧨 Role grants restricted to the actor's own roles
+
+Non-superusers can no longer grant a user or service account a role they don't belong to themselves — the rule covers every UI path that assigns roles: editing a user, creating a service account, and editing a service account. Removing existing memberships is unaffected. Operators who delegated user management without granting the underlying roles will need to either add those roles to the delegate or perform the assignment as a superuser.
+
 ### Bug fixes
 
 Replaced slow Santa `zentral_santa_targets_*`  metrics with `zentral_santa_target_states` metrics.

--- a/server/accounts/forms.py
+++ b/server/accounts/forms.py
@@ -1,29 +1,33 @@
 import json
 import logging
 from urllib.parse import urlparse
+
 import celpy
+import pyotp
 from celpy import celtypes
 from django import forms
 from django.conf import settings as django_settings
-from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm as DjangoPasswordResetForm,  UsernameField
+from django.contrib.auth.forms import AuthenticationForm, UsernameField
+from django.contrib.auth.forms import PasswordResetForm as DjangoPasswordResetForm
 from django.contrib.auth.models import Group
 from django.core import signing, validators
 from django.core.exceptions import ValidationError
 from django.db.models import Q
-from django.utils.crypto import get_random_string
 from django.utils import timezone
+from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
-import pyotp
 from webauthn import generate_authentication_options, options_to_json, verify_authentication_response
 from webauthn.helpers import parse_authentication_credential_json
 from webauthn.helpers.structs import PublicKeyCredentialDescriptor
+
 from zentral.conf import settings as zentral_settings
 from zentral.conf.config import ConfigList
 from zentral.utils.base64 import trimmed_urlsafe_b64decode
+from zentral.utils.forms import SelectMultipleWithDisabledOptions
 from zentral.utils.oidc import get_openid_configuration_from_issuer_uri
+
 from .models import APIToken, OIDCAPITokenIssuer, Policy, User, UserTOTP, UserWebAuthn
 from .password_reset import handler as password_reset_handler
-
 
 logger = logging.getLogger("zentral.accounts.forms")
 
@@ -98,7 +102,94 @@ class ServiceAccountNameValidator(validators.RegexValidator):
     flags = 0
 
 
-class ServiceAccountForm(forms.ModelForm):
+class RoleMembershipGrantMixin:
+    """Form mixin for ModelForms that expose a ``groups`` field on the User
+    model. Captures the requesting user from form kwargs, relabels the field
+    to match Zentral's "Roles" terminology, hides rule-violating choices in
+    the rendered widget, and provides a validation hook that rejects
+    role-membership grants the requester isn't entitled to make.
+
+    Place it before the ``forms.ModelForm`` (or any other form base) in the
+    MRO so its ``__init__`` runs first and pops ``request_user`` before the
+    underlying form sees the kwargs.
+    """
+
+    GROUPS_WIDGET_SIZE = 10
+
+    def __init__(self, *args, **kwargs):
+        self.request_user = kwargs.pop("request_user", None)
+        super().__init__(*args, **kwargs)
+        self._disable_ungrantable_group_options()
+        self._prepare_groups_field()
+
+    def _prepare_groups_field(self, field_name="groups"):
+        if field_name not in self.fields:
+            return
+        field = self.fields[field_name]
+        field.label = "Roles"
+        field.help_text = "The roles this user belongs to."
+        field.widget.attrs["size"] = self.GROUPS_WIDGET_SIZE
+
+    def _disable_ungrantable_group_options(self, field_name="groups"):
+        """Mark groups the requester can't grant as ``disabled`` in the
+        rendered widget. The set we *can't* disable is groups the target user
+        already belongs to — those must stay selectable so the actor can
+        leave them on (or remove them; removals are unrestricted). Superusers
+        and the no-requester case are exempt — the full choice set renders
+        normally.
+        """
+        if self.request_user is None or self.request_user.is_superuser:
+            return
+        if field_name not in self.fields:
+            return
+        field = self.fields[field_name]
+        all_pks = set(field.queryset.values_list("pk", flat=True))
+        current_pks = (
+            set(self.instance.groups.values_list("pk", flat=True))
+            if self.instance.pk else set()
+        )
+        actor_pks = set(self.request_user.groups.values_list("pk", flat=True))
+        disabled = all_pks - current_pks - actor_pks
+        if not disabled:
+            return
+        field.widget = SelectMultipleWithDisabledOptions(disabled_values=disabled)
+        # Reassigning the widget `choices`
+        field.widget.choices = field.choices
+
+    def _validate_group_additions(self, field_name="groups"):
+        """Reject group additions the requester isn't entitled to make.
+
+        A non-superuser editing another user's group set may only add groups
+        they themselves belong to — the in-code expression of escalation
+        prevention: you can't grant memberships you don't have. Superusers
+        (and forms instantiated without a request_user, e.g. management
+        commands or tests) are exempt.
+
+        Removals are intentionally unrestricted — escalation risk is granting,
+        not revoking.
+        """
+        if self.request_user is None or self.request_user.is_superuser:
+            return
+        new_groups = self.cleaned_data.get(field_name)
+        if not new_groups:
+            return
+        current_pks = (
+            set(self.instance.groups.values_list("pk", flat=True))
+            if self.instance.pk else set()
+        )
+        actor_pks = set(self.request_user.groups.values_list("pk", flat=True))
+        disallowed = sorted(
+            g.name for g in new_groups
+            if g.pk not in current_pks and g.pk not in actor_pks
+        )
+        if disallowed:
+            self.add_error(
+                field_name,
+                "You cannot grant role membership you don't have: " + ", ".join(disallowed) + ".",
+            )
+
+
+class ServiceAccountForm(RoleMembershipGrantMixin, forms.ModelForm):
     name_validator = ServiceAccountNameValidator()
     username = forms.CharField(
         label="Name",
@@ -127,16 +218,16 @@ class ServiceAccountForm(forms.ModelForm):
                     self.add_error("username", "A user with this name already exists.")
             self.instance.email = email
         self.instance.is_service_account = True
+        self._validate_group_additions()
 
 
-class UpdateUserForm(forms.ModelForm):
+class UpdateUserForm(RoleMembershipGrantMixin, forms.ModelForm):
     class Meta:
         model = User
         fields = ("username", "email", "is_superuser", "groups", "items_per_page")
         field_classes = {'username': UsernameField}
 
     def __init__(self, *args, **kwargs):
-        self.request_user = kwargs.pop("request_user", None)
         self.request_session_is_remote = kwargs.pop("request_session_is_remote", True)
         super().__init__(*args, **kwargs)
         if not self.instance.username_and_email_editable():
@@ -156,6 +247,11 @@ class UpdateUserForm(forms.ModelForm):
             and self.request_user.is_superuser
             and not self.request_session_is_remote
         )
+
+    def clean(self):
+        cleaned = super().clean()
+        self._validate_group_additions()
+        return cleaned
 
 
 class UpdateProfileForm(forms.Form):

--- a/server/accounts/views/users.py
+++ b/server/accounts/views/users.py
@@ -56,6 +56,11 @@ class CreateServiceAccountView(PermissionRequiredMixin, CreateViewWithAudit):
         ctx["title"] = "Create service account"
         return ctx
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request_user"] = self.request.user
+        return kwargs
+
 
 class UserView(PermissionRequiredMixin, DetailView):
     permission_required = "accounts.view_user"
@@ -109,8 +114,8 @@ class UpdateUserView(PermissionRequiredMixin, UpdateViewWithAudit):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
+        kwargs["request_user"] = self.request.user
         if not self.object.is_service_account:
-            kwargs["request_user"] = self.request.user
             kwargs["request_session_is_remote"] = self.request.realm_authentication_session.is_remote
         return kwargs
 

--- a/tests/server_accounts/views/test_users_views.py
+++ b/tests/server_accounts/views/test_users_views.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import re
 from unittest.mock import patch
 
 import pyotp
@@ -766,6 +767,228 @@ class AccountUsersViewsTestCase(TestCase, LoginCase, EventAssertions):
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["objects"], {"accounts_user": [str(self.service_account.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["accounts", "zentral"])
+
+    # role-membership grant restrictions
+
+    def test_user_update_groups_field_labeled_as_roles(self):
+        # Zentral UI uses "Roles", not Django's auto-generated "Groups".
+        self.login("accounts.change_user")
+        response = self.client.get(reverse("accounts:update_user", args=(self.user.id,)))
+        field = response.context["form"].fields["groups"]
+        self.assertEqual(field.label, "Roles")
+        self.assertEqual(field.help_text, "The roles this user belongs to.")
+        self.assertEqual(field.widget.attrs.get("size"), 10)
+
+    def test_service_account_create_groups_field_labeled_as_roles(self):
+        self.login("accounts.add_user")
+        response = self.client.get(reverse("accounts:create_service_account"))
+        field = response.context["form"].fields["groups"]
+        self.assertEqual(field.label, "Roles")
+        self.assertEqual(field.help_text, "The roles this user belongs to.")
+        self.assertEqual(field.widget.attrs.get("size"), 10)
+
+    def test_mixin_methods_noop_when_groups_field_is_absent(self):
+        # Defensive guards: if a form using the mixin doesn't expose a "groups"
+        # field, _prepare_groups_field and _disable_ungrantable_group_options
+        # must early-return cleanly instead of raising KeyError. Triggered by
+        # calling them with a field_name that isn't present on the form.
+        from accounts.forms import ServiceAccountForm
+        form = ServiceAccountForm(request_user=self.ui_user)
+        form._prepare_groups_field(field_name="not_a_field")
+        form._disable_ungrantable_group_options(field_name="not_a_field")
+        # If we got here without raising, the guards did their job.
+        self.assertNotIn("not_a_field", form.fields)
+
+    def _role_option_tag(self, html, pk):
+        """Return the rendered ``<option>`` tag for a role/group pk in the
+        roles ``<select>``, or None if it isn't rendered at all. Asserting on
+        the real HTML — not just ``widget.disabled_values`` — is what catches
+        the choices-not-wired-up regression: the widget can carry the correct
+        disabled_values yet render zero options (so nothing is disabled because
+        nothing is rendered).
+        """
+        match = re.search(r'<option value="{}"[^>]*>'.format(pk), html)
+        return match.group(0) if match else None
+
+    def test_user_update_widget_disables_ungrantable_groups(self):
+        # The widget mirrors the validation rule so operators see upfront
+        # which groups they can't grant. Groups the target already belongs to
+        # stay selectable (so the actor can remove or keep them).
+        ungrantable = Group.objects.create(name=get_random_string(12))
+        already_assigned = Group.objects.create(name=get_random_string(12))
+        self.user.groups.add(already_assigned)
+        self.login("accounts.change_user")
+        response = self.client.get(reverse("accounts:update_user", args=(self.user.id,)))
+        widget = response.context["form"].fields["groups"].widget
+        self.assertIn(ungrantable.pk, widget.disabled_values)
+        self.assertNotIn(self.ui_group.pk, widget.disabled_values)  # actor's own group
+        self.assertNotIn(already_assigned.pk, widget.disabled_values)  # already on target
+        # the disabled_values attribute must actually reach the rendered HTML
+        html = response.content.decode()
+        ungrantable_option = self._role_option_tag(html, ungrantable.pk)
+        self.assertIsNotNone(ungrantable_option)
+        self.assertIn("disabled", ungrantable_option)
+        own_option = self._role_option_tag(html, self.ui_group.pk)
+        self.assertIsNotNone(own_option)
+        self.assertNotIn("disabled", own_option)
+        assigned_option = self._role_option_tag(html, already_assigned.pk)
+        self.assertIsNotNone(assigned_option)
+        self.assertNotIn("disabled", assigned_option)
+
+    def test_user_update_widget_not_filtered_for_superuser(self):
+        # Superusers see the unmodified default widget — no disabled options.
+        self.ui_user.is_superuser = True
+        self.ui_user.save()
+        group = Group.objects.create(name=get_random_string(12))
+        self.login("accounts.change_user")
+        response = self.client.get(reverse("accounts:update_user", args=(self.user.id,)))
+        widget = response.context["form"].fields["groups"].widget
+        self.assertFalse(hasattr(widget, "disabled_values"))
+        # the option still renders, just without the disabled attribute
+        html = response.content.decode()
+        option = self._role_option_tag(html, group.pk)
+        self.assertIsNotNone(option)
+        self.assertNotIn("disabled", option)
+
+    def test_service_account_create_widget_disables_ungrantable_groups(self):
+        # Same rule applies on the creation path — without it, "create a SA
+        # in role X" is the escalation vector.
+        ungrantable = Group.objects.create(name=get_random_string(12))
+        self.login("accounts.add_user")
+        response = self.client.get(reverse("accounts:create_service_account"))
+        widget = response.context["form"].fields["groups"].widget
+        self.assertIn(ungrantable.pk, widget.disabled_values)
+        self.assertNotIn(self.ui_group.pk, widget.disabled_values)
+        # the disabled_values attribute must actually reach the rendered HTML
+        html = response.content.decode()
+        ungrantable_option = self._role_option_tag(html, ungrantable.pk)
+        self.assertIsNotNone(ungrantable_option)
+        self.assertIn("disabled", ungrantable_option)
+        own_option = self._role_option_tag(html, self.ui_group.pk)
+        self.assertIsNotNone(own_option)
+        self.assertNotIn("disabled", own_option)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_user_update_cannot_add_group_actor_is_not_member_of(self, post_event):
+        # Non-superuser must not grant memberships they don't have themselves.
+        other_group = Group.objects.create(name=get_random_string(12))
+        self.login("accounts.change_user", "accounts.view_user")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("accounts:update_user", args=(self.user.id,)),
+                {"username": self.user.username,
+                 "email": self.user.email,
+                 "items_per_page": 10,
+                 "groups": [other_group.pk]},
+            )
+        self.assertFormError(
+            response.context["form"], "groups",
+            f"You cannot grant role membership you don't have: {other_group.name}.",
+        )
+        self.user.refresh_from_db()
+        self.assertNotIn(other_group, self.user.groups.all())
+        self.assertEqual(len(callbacks), 0)
+        self.assertEqual(len(post_event.call_args_list), 0)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_user_update_can_add_group_actor_is_member_of(self, post_event):
+        # Granting a group the actor already belongs to is fine.
+        self.login("accounts.change_user", "accounts.view_user")
+        self.assertNotIn(self.ui_group, self.user.groups.all())
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("accounts:update_user", args=(self.user.id,)),
+                {"username": self.user.username,
+                 "email": self.user.email,
+                 "items_per_page": 10,
+                 "groups": [self.ui_group.pk]},
+                follow=True,
+            )
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertIn(self.ui_group, self.user.groups.all())
+        self.assertEqual(len(callbacks), 1)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_user_update_can_remove_group_actor_is_not_member_of(self, post_event):
+        # Removal is intentionally not restricted by the rule — escalation risk
+        # is granting, not revoking. The actor here is not in other_group, but
+        # the target user is, and the actor is allowed to take them out.
+        other_group = Group.objects.create(name=get_random_string(12))
+        self.user.groups.add(other_group)
+        self.login("accounts.change_user", "accounts.view_user")
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(
+                reverse("accounts:update_user", args=(self.user.id,)),
+                {"username": self.user.username,
+                 "email": self.user.email,
+                 "items_per_page": 10,
+                 "groups": []},
+                follow=True,
+            )
+        self.user.refresh_from_db()
+        self.assertNotIn(other_group, self.user.groups.all())
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_superuser_update_can_add_any_group(self, post_event):
+        # Superusers are exempt from the grant-without-hold check.
+        self.ui_user.is_superuser = True
+        self.ui_user.save()
+        other_group = Group.objects.create(name=get_random_string(12))
+        self.assertNotIn(other_group, self.ui_user.groups.all())
+        self.login("accounts.change_user", "accounts.view_user")
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(
+                reverse("accounts:update_user", args=(self.user.id,)),
+                {"username": self.user.username,
+                 "email": self.user.email,
+                 "items_per_page": 10,
+                 "groups": [other_group.pk]},
+                follow=True,
+            )
+        self.user.refresh_from_db()
+        self.assertIn(other_group, self.user.groups.all())
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_service_account_update_cannot_add_group_actor_is_not_member_of(self, post_event):
+        # Same rule for the service-account form.
+        other_group = Group.objects.create(name=get_random_string(12))
+        self.login("accounts.change_user", "accounts.view_user")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("accounts:update_user", args=(self.service_account.id,)),
+                {"username": self.service_account.username,
+                 "description": "",
+                 "groups": [other_group.pk]},
+            )
+        self.assertFormError(
+            response.context["form"], "groups",
+            f"You cannot grant role membership you don't have: {other_group.name}.",
+        )
+        self.service_account.refresh_from_db()
+        self.assertNotIn(other_group, self.service_account.groups.all())
+        self.assertEqual(len(callbacks), 0)
+        self.assertEqual(len(post_event.call_args_list), 0)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_service_account_create_cannot_assign_group_actor_is_not_member_of(self, post_event):
+        # Creation path — the rule must apply at creation time too, otherwise
+        # "create a service account in role X" becomes the escalation vector.
+        other_group = Group.objects.create(name=get_random_string(12))
+        self.login("accounts.add_user")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("accounts:create_service_account"),
+                {"username": "ci-bot-" + get_random_string(6),
+                 "description": "",
+                 "groups": [other_group.pk]},
+            )
+        self.assertFormError(
+            response.context["form"], "groups",
+            f"You cannot grant role membership you don't have: {other_group.name}.",
+        )
+        self.assertEqual(len(callbacks), 0)
+        self.assertEqual(len(post_event.call_args_list), 0)
 
     # delete
 

--- a/tests/utils/test_forms.py
+++ b/tests/utils/test_forms.py
@@ -1,0 +1,51 @@
+from django.test import SimpleTestCase
+
+from zentral.utils.forms import SelectMultipleWithDisabledOptions
+
+
+class _FakeIteratorValue:
+    """Mimics Django's ModelChoiceIteratorValue, which wraps the raw pk and
+    exposes it on a ``value`` attribute. The widget has to unwrap it before
+    looking up in ``disabled_values``.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+
+class SelectMultipleWithDisabledOptionsTests(SimpleTestCase):
+    def test_init_without_disabled_values(self):
+        widget = SelectMultipleWithDisabledOptions()
+        self.assertEqual(widget.disabled_values, set())
+
+    def test_init_coerces_iterable_to_set(self):
+        widget = SelectMultipleWithDisabledOptions(disabled_values=[1, 2, 2, 3])
+        self.assertEqual(widget.disabled_values, {1, 2, 3})
+
+    def test_create_option_disables_matching_value(self):
+        widget = SelectMultipleWithDisabledOptions(disabled_values={42})
+        option = widget.create_option("g", 42, "label", False, 0)
+        self.assertTrue(option["attrs"].get("disabled"))
+
+    def test_create_option_leaves_non_matching_value_enabled(self):
+        widget = SelectMultipleWithDisabledOptions(disabled_values={42})
+        option = widget.create_option("g", 7, "label", False, 0)
+        self.assertNotIn("disabled", option["attrs"])
+
+    def test_create_option_unwraps_model_choice_iterator_value(self):
+        # Django >= 4.x wraps option values; the widget must unwrap before
+        # consulting disabled_values, otherwise nothing ever matches.
+        widget = SelectMultipleWithDisabledOptions(disabled_values={42})
+        option = widget.create_option("g", _FakeIteratorValue(42), "label", False, 0)
+        self.assertTrue(option["attrs"].get("disabled"))
+
+    def test_render_emits_disabled_attribute(self):
+        # End-to-end: rendering a select must put ``disabled`` on the right
+        # <option>s. ``Select.render`` calls ``create_option`` for each choice,
+        # so this is the smallest test that exercises the full path.
+        widget = SelectMultipleWithDisabledOptions(disabled_values={2})
+        widget.choices = [(1, "one"), (2, "two"), (3, "three")]
+        html = widget.render("groups", [])
+        self.assertIn('<option value="2" disabled', html)
+        self.assertNotIn('<option value="1" disabled', html)
+        self.assertNotIn('<option value="3" disabled', html)

--- a/zentral/utils/forms.py
+++ b/zentral/utils/forms.py
@@ -1,6 +1,7 @@
 from django import forms
-from .text import split_comma_separated_quoted_string
 from django.forms.renderers import TemplatesSetting
+
+from .text import split_comma_separated_quoted_string
 
 
 class CommaSeparatedQuotedStringField(forms.CharField):
@@ -17,6 +18,25 @@ class CommaSeparatedQuotedStringField(forms.CharField):
     def to_python(self, value):
         value = super(CommaSeparatedQuotedStringField, self).to_python(value)
         return split_comma_separated_quoted_string(value)
+
+
+class SelectMultipleWithDisabledOptions(forms.SelectMultiple):
+    """SelectMultiple that renders options in ``disabled_values`` with the
+    HTML ``disabled`` attribute. Not a security boundary — the disabled attribute is
+    client-side only; the server still has to reject smuggled values.
+    """
+
+    def __init__(self, *args, disabled_values=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disabled_values = set(disabled_values or [])
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex, attrs)
+        # In Django 4.x+, ``value`` is wrapped in ModelChoiceIteratorValue.
+        raw = getattr(value, "value", value)
+        if raw in self.disabled_values:
+            option["attrs"]["disabled"] = True
+        return option
 
 
 class ZentralFormRenderer(TemplatesSetting):


### PR DESCRIPTION
## Summary

- Block non-superusers from adding groups to other users (or themselves) that they aren't already members of — the K8s-RBAC / AWS-permission-boundary escalation-prevention pattern. Removals stay unrestricted by design.
- Shared `RoleMembershipGrantMixin` on `UpdateUserForm` and `ServiceAccountForm` covers both update and create paths; rejection happens in `clean()` and the multi-select renders ungrantable groups as disabled options.
- Side polish: the `groups` field is now labeled "Roles" with help text aligned to PBAC (no more "user will get all permissions granted to each group"), the multi-select is taller (10 rows), and the disabled-options widget moved to `zentral/utils/forms.py` for reuse.

The widget filter is UX only — `disabled` is client-side; the server validation is what enforces the rule. Documented inline.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.tests.yml run --rm -e ZENTRAL_CONF_DIR=/zentral/tests/conf -e ZENTRAL_FORCE_ES_OS_INDEX_REFRESH=1 -e ZENTRAL_POLICIES_SYNC=0 -e ZENTRAL_PROBES_SYNC=0 -e ZENTRAL_QUIET=1 -e ZENTRAL_STORES_SYNC=0 web python server/manage.py test --keepdb tests.server_accounts.views.test_users_views` — 104 tests pass (11 new for this PR).
- [x] As a non-superuser with `accounts.change_user`, edit another user: confirm the form labels the field "Roles", that groups you don't belong to render as disabled in the multi-select, and that POST-ing a smuggled value gets rejected with `You cannot grant role membership you don't have: <name>`.
- [x] As a non-superuser, confirm you *can* remove the target from a group you aren't in (asymmetry by design).
- [x] As a superuser, confirm no options are disabled and any group can be added.
- [x] Same checks against `Create service account` (the create path uses the same form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)