### PR TITLE
Add script check name to munki job details payload

### DIFF
--- a/tests/munki/test_compliance_checks.py
+++ b/tests/munki/test_compliance_checks.py
@@ -67,6 +67,7 @@ class MunkiComplianceChecksTestCase(TestCase):
         self.assertEqual(
             serialize_script_check_for_job(sc),
             {"pk": sc.pk,
+             "name": sc.compliance_check.name,
              "type": "ZSH_INT",
              "version": sc.compliance_check.version,
              "source": "echo 10",
@@ -83,6 +84,7 @@ class MunkiComplianceChecksTestCase(TestCase):
         self.assertEqual(
             serialize_script_check_for_job(sc),
             {"pk": sc.pk,
+             "name": sc.compliance_check.name,
              "type": "ZSH_BOOL",
              "version": sc.compliance_check.version,
              "source": "echo 1",
@@ -99,6 +101,7 @@ class MunkiComplianceChecksTestCase(TestCase):
         self.assertEqual(
             serialize_script_check_for_job(sc),
             {"pk": sc.pk,
+             "name": sc.compliance_check.name,
              "type": "ZSH_STR",
              "version": sc.compliance_check.version,
              "source": "echo un",

--- a/tests/munki/test_pre_post_flight_api_views.py
+++ b/tests/munki/test_pre_post_flight_api_views.py
@@ -481,6 +481,7 @@ class MunkiAPIViewsTestCase(TestCase):
         self.assertEqual(
             response.json()["script_checks"],
             [{'pk': sc.pk,
+              'name': sc.compliance_check.name,
               'version': 1,
               'type': 'ZSH_BOOL',
               'source': 'echo true',
@@ -506,6 +507,7 @@ class MunkiAPIViewsTestCase(TestCase):
         self.assertEqual(
             response.json()["script_checks"],
             [{'pk': sc.pk,
+              'name': sc.compliance_check.name,
               'version': 1,
               'type': 'ZSH_BOOL',
               'source': 'echo true',
@@ -550,7 +552,9 @@ class MunkiAPIViewsTestCase(TestCase):
                                       HTTP_AUTHORIZATION="MunkiEnrolledMachine {}".format(enrolled_machine.token))
         self.assertEqual(
             response.json()["script_checks"],
-            [{'pk': sc.pk, 'version': 1,
+            [{'pk': sc.pk,
+              'name': sc.compliance_check.name,
+              'version': 1,
               'type': 'ZSH_BOOL',
               'source': 'echo true',
               'expected_bool_result': True,
@@ -597,7 +601,9 @@ class MunkiAPIViewsTestCase(TestCase):
         self.assertEqual(len(callbacks), 1)
         self.assertEqual(
             response.json()["script_checks"],
-            [{'pk': sc.pk, 'version': 1,
+            [{'pk': sc.pk,
+              'name': sc.compliance_check.name,
+              'version': 1,
               'type': 'ZSH_INT',
               'source': 'echo 10',
               'expected_int_result': 10,

--- a/zentral/contrib/munki/compliance_checks.py
+++ b/zentral/contrib/munki/compliance_checks.py
@@ -44,6 +44,7 @@ def validate_expected_result(script_check_type, expected_result):
 def serialize_script_check_for_job(script_check):
     d = {
         "pk": script_check.pk,
+        "name": script_check.compliance_check.name,
         "version": script_check.compliance_check.version,
         "type": str(script_check.type),
         "source": script_check.source,


### PR DESCRIPTION
## Summary

The munki `job_details` view returns the list of in-scope script checks for a machine. The serialized payload included the `pk`, `version`, `type`, `source` and expected result — but not the script check's name.

This adds the compliance check `name` to the payload so agents/clients can identify a script check by name without a separate lookup.

## Changes

- `serialize_script_check_for_job` now emits `"name"` from the related compliance check. The name lives on the `ComplianceCheck`, which `ScriptCheck.objects.iter_in_scope` already `select_related`s, so no extra queries.
- Updated the affected assertions in `tests/munki/test_compliance_checks.py` and `tests/munki/test_pre_post_flight_api_views.py`.

## Testing

```
manage.py test tests.munki.test_compliance_checks tests.munki.test_pre_post_flight_api_views
```

77 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)