### PR TITLE
Drop format_suffix_patterns from the API URLConfs

### DIFF
--- a/server/accounts/api_urls.py
+++ b/server/accounts/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import api_views
 
@@ -21,4 +20,3 @@ urlpatterns = [
         view=api_views.OIDCAPITokenIssuerAuth.as_view(),
         name="oidc_api_token_issuer_exchange")
 ]
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/server/base/api_urls.py
+++ b/server/base/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 from .api_views import TaskResultFileDownloadView, TaskResultView
 
 
@@ -10,6 +9,3 @@ urlpatterns = [
     path('task_result/<uuid:task_id>/download/',
          TaskResultFileDownloadView.as_view(), name='task_result_file_download'),
 ]
-
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/server/realms/api_urls.py
+++ b/server/realms/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 from .api_views import RealmDetail, RealmList
 
 
@@ -8,6 +7,3 @@ urlpatterns = [
     path('realms/', RealmList.as_view(), name="realms"),
     path('realms/<uuid:pk>/', RealmDetail.as_view(), name="realm"),
 ]
-
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/zentral/contrib/google_workspace/api_urls.py
+++ b/zentral/contrib/google_workspace/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 from zentral.contrib.google_workspace.api_views import (
     SyncTagsView, ConnectionList, ConnectionDetail, GroupTagMappingList, GroupTagMappingDetail)
 
@@ -16,5 +15,3 @@ urlpatterns = [
     path('group_tag_mappings/<uuid:pk>/',
          GroupTagMappingDetail.as_view(), name="group_tag_mapping"),
 ]
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/zentral/contrib/inventory/api_urls.py
+++ b/zentral/contrib/inventory/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 from .api_views import (ArchiveMachines,
                         CleanupInventory,
                         FullExport,
@@ -76,6 +75,3 @@ urlpatterns = [
     path('taxonomies/', TaxonomyList.as_view(), name="taxonomies"),
     path('taxonomies/<int:pk>/', TaxonomyDetail.as_view(), name="taxonomy"),
 ]
-
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/zentral/contrib/mdm/api_urls.py
+++ b/zentral/contrib/mdm/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 
 from .api_views import (
                         ACMEIssuerDetail,
@@ -155,6 +154,3 @@ urlpatterns = [
     path('dep_enrollment_custom_views/<uuid:pk>/', DEPEnrollmentCustomViewDetail.as_view(),
          name="dep_enrollment_custom_view")
 ]
-
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/zentral/contrib/santa/api_urls.py
+++ b/zentral/contrib/santa/api_urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 from .api_views import (IngestFileInfo, RuleList, RuleSetUpdate, TargetsExport, ConfigurationList,
                         ConfigurationDetail, EnrollmentList, EnrollmentDetail,
                         EnrollmentPlist, EnrollmentConfigurationProfile, RuleDetail)
@@ -20,6 +19,3 @@ urlpatterns = [
     path('rulesets/update/', RuleSetUpdate.as_view(), name="ruleset_update"),
     path('targets/export/', TargetsExport.as_view(), name="targets_export"),
 ]
-
-
-urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
The optional .json/.api format suffix routes are no longer wanted: JSON is already the only configured renderer.