### PR TITLE
Add deletion of queued MDM device commands

### DIFF
--- a/tests/mdm/test_api_commands_views.py
+++ b/tests/mdm/test_api_commands_views.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 import uuid
+from unittest.mock import patch
 from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils.crypto import get_random_string
@@ -11,7 +12,8 @@ from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import DeviceInformation, DeviceLock, InstallProfile
-from zentral.contrib.mdm.models import Channel
+from zentral.contrib.mdm.models import Artifact, Channel, DeviceCommand
+from zentral.core.events.base import AuditEvent
 from .utils import force_artifact, force_dep_enrollment_session, force_enrolled_user
 
 
@@ -219,6 +221,90 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'time': db_cmd.time.isoformat(),
              'updated_at': db_cmd.updated_at.isoformat(),
              'uuid': str(cmd.uuid)}
+        )
+
+    def test_enrolled_device_command_delete_unauthorized(self):
+        cmd = DeviceLock.create_for_device(self.enrolled_device, queue=True)
+        response = self.delete(reverse("mdm_api:enrolled_device_command", args=(cmd.uuid,)), include_token=False)
+        self.assertEqual(response.status_code, 401)
+
+    def test_enrolled_device_command_delete_permission_denied(self):
+        cmd = DeviceLock.create_for_device(self.enrolled_device, queue=True)
+        self.set_permissions("mdm.view_devicecommand")
+        response = self.delete(reverse("mdm_api:enrolled_device_command", args=(cmd.uuid,)))
+        self.assertEqual(response.status_code, 403)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_enrolled_device_command_delete_queued(self, post_event):
+        cmd = DeviceLock.create_for_device(self.enrolled_device, queue=True)
+        prev_value = cmd.db_command.serialize_for_event()
+        self.set_permissions("mdm.delete_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("mdm_api:enrolled_device_command", args=(cmd.uuid,)))
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(DeviceCommand.objects.filter(uuid=cmd.uuid).count(), 0)
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "deleted",
+             "object": {
+                 "model": "mdm.devicecommand",
+                 "pk": str(cmd.db_command.pk),
+                 "prev_value": prev_value,
+             }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(sorted(metadata["tags"]), ["mdm", "zentral"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_enrolled_device_command_delete_already_sent(self, post_event):
+        cmd = DeviceInformation.create_for_device(self.enrolled_device)
+        self.assertIsNotNone(cmd.db_command.time)
+        self.set_permissions("mdm.delete_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("mdm_api:enrolled_device_command", args=(cmd.uuid,)))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            ["This command has already been sent to the device and cannot be deleted"]
+        )
+        self.assertEqual(DeviceCommand.objects.filter(uuid=cmd.uuid).count(), 1)
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
+
+    def test_device_command_serialize_for_event(self):
+        a, (av,) = force_artifact(version_count=1)
+        cmd = DeviceLock.create_for_device(self.enrolled_device, queue=True)
+        db_command = cmd.db_command
+        db_command.artifact_version = av
+        db_command.artifact_operation = Artifact.Operation.INSTALLATION
+        db_command.not_before = db_command.created_at
+        db_command.time = db_command.created_at
+        db_command.result_time = db_command.created_at
+        db_command.status = DeviceCommand.Status.ACKNOWLEDGED
+        db_command.save()
+        db_command.refresh_from_db()
+        self.assertEqual(
+            db_command.serialize_for_event(),
+            {"pk": db_command.pk,
+             "uuid": str(cmd.uuid),
+             "name": "DeviceLock",
+             "artifact_version": av.serialize_for_event(),
+             "artifact_operation": "Installation",
+             "not_before": db_command.created_at,
+             "time": db_command.created_at,
+             "result_time": db_command.created_at,
+             "status": "Acknowledged",
+             "created_at": db_command.created_at,
+             "updated_at": db_command.updated_at,
+             "enrolled_device": self.enrolled_device.serialize_for_event(keys_only=True)}
+        )
+        self.assertEqual(
+            db_command.serialize_for_event(keys_only=True),
+            {"pk": db_command.pk, "uuid": str(cmd.uuid), "name": "DeviceLock"}
         )
 
     # user commands

--- a/tests/mdm/test_api_commands_views.py
+++ b/tests/mdm/test_api_commands_views.py
@@ -256,7 +256,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(sorted(metadata["tags"]), ["mdm", "zentral"])
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -305,6 +305,12 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             db_command.serialize_for_event(keys_only=True),
             {"pk": db_command.pk, "uuid": str(cmd.uuid), "name": "DeviceLock"}
+        )
+        self.assertEqual(
+            db_command.linked_objects_keys_for_event(),
+            {"mdm_device_command": [(str(cmd.uuid),)],
+             "mdm_artifact_version": [(str(av.pk),)],
+             "mdm_artifact": [(str(a.pk),)]}
         )
 
     # user commands

--- a/zentral/contrib/mdm/api_views/commands.py
+++ b/zentral/contrib/mdm/api_views/commands.py
@@ -1,8 +1,14 @@
 from django_filters import rest_framework as filters
-from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.exceptions import ValidationError
+from rest_framework.generics import ListAPIView, RetrieveAPIView, RetrieveDestroyAPIView
+from django.db import transaction
+from rest_framework.authentication import SessionAuthentication
+from accounts.api_authentication import APITokenAuthentication
+
 from zentral.contrib.mdm.models import DeviceCommand, UserCommand
 from zentral.contrib.mdm.serializers import DeviceCommandSerializer, UserCommandSerializer
 from zentral.utils.drf import DefaultDjangoModelPermissions, MaxLimitOffsetPagination
+from zentral.core.events.base import AuditEvent
 
 
 class EnrolledDeviceCommandList(ListAPIView):
@@ -14,11 +20,30 @@ class EnrolledDeviceCommandList(ListAPIView):
     pagination_class = MaxLimitOffsetPagination
 
 
-class EnrolledDeviceCommand(RetrieveAPIView):
+class EnrolledDeviceCommand(RetrieveDestroyAPIView):
+    authentication_classes = [APITokenAuthentication, SessionAuthentication]
     queryset = DeviceCommand.objects.all()
     serializer_class = DeviceCommandSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     lookup_field = "uuid"
+
+    def perform_destroy(self, instance):
+        command = DeviceCommand.objects.select_for_update().get(pk=instance.pk)
+        if not command.can_be_deleted():
+            raise ValidationError("This command has already been sent to the device and cannot be deleted")
+        prev_value = command.serialize_for_event()
+        prev_pk = command.pk
+        command.delete()
+
+        def on_commit_callback():
+            command.pk = prev_pk  # re-hydrate the primary key
+            AuditEvent.build_from_request_and_instance(
+                self.request, command,
+                action=AuditEvent.Action.DELETED,
+                prev_value=prev_value,
+            ).post()
+
+        transaction.on_commit(on_commit_callback)
 
 
 class EnrolledUserCommandList(ListAPIView):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3372,7 +3372,11 @@ class Command(models.Model):
         return d
 
     def linked_objects_keys_for_event(self):
-        return {"mdm_command": [(str(self.uuid),)]}
+        keys = {}
+        if self.artifact_version:
+            keys["mdm_artifact_version"] = [(str(self.artifact_version.pk),)]
+            keys["mdm_artifact"] = [(str(self.artifact_version.artifact.pk),)]
+        return keys
 
     class Meta:
         abstract = True
@@ -3380,6 +3384,13 @@ class Command(models.Model):
 
 class DeviceCommand(Command):
     enrolled_device = models.ForeignKey(EnrolledDevice, on_delete=models.CASCADE, related_name="commands")
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["enrolled_device_id"],
+                         condition=Q(time__isnull=True) | Q(result_time__isnull=True),
+                         name="apns_device_opti")
+        ]
 
     def can_be_deleted(self):
         return self.time is None
@@ -3390,12 +3401,10 @@ class DeviceCommand(Command):
             d["enrolled_device"] = self.enrolled_device.serialize_for_event(keys_only=True)
         return d
 
-    class Meta:
-        indexes = [
-            models.Index(fields=["enrolled_device_id"],
-                         condition=Q(time__isnull=True) | Q(result_time__isnull=True),
-                         name="apns_device_opti")
-        ]
+    def linked_objects_keys_for_event(self):
+        keys = super().linked_objects_keys_for_event()
+        keys["mdm_device_command"] = [(str(self.uuid),)]
+        return keys
 
 
 class UserCommand(Command):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3353,12 +3353,42 @@ class Command(models.Model):
     def __str__(self):
         return " - ".join(s for s in (self.name, str(self.uuid), self.status) if s)
 
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "uuid": str(self.uuid), "name": self.name}
+        if keys_only:
+            return d
+        if self.artifact_version:
+            d["artifact_version"] = self.artifact_version.serialize_for_event()
+        if self.artifact_operation:
+            d["artifact_operation"] = self.artifact_operation
+        for attr in ("not_before", "time", "result_time"):
+            value = getattr(self, attr)
+            if value:
+                d[attr] = value
+        if self.status:
+            d["status"] = self.status
+        d["created_at"] = self.created_at
+        d["updated_at"] = self.updated_at
+        return d
+
+    def linked_objects_keys_for_event(self):
+        return {"mdm_command": [(str(self.uuid),)]}
+
     class Meta:
         abstract = True
 
 
 class DeviceCommand(Command):
     enrolled_device = models.ForeignKey(EnrolledDevice, on_delete=models.CASCADE, related_name="commands")
+
+    def can_be_deleted(self):
+        return self.time is None
+
+    def serialize_for_event(self, keys_only=False):
+        d = super().serialize_for_event(keys_only)
+        if not keys_only:
+            d["enrolled_device"] = self.enrolled_device.serialize_for_event(keys_only=True)
+        return d
 
     class Meta:
         indexes = [

--- a/zentral/contrib/mdm/templates/mdm/enrolleddevice_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/enrolleddevice_detail.html
@@ -699,7 +699,7 @@
                   {% url 'mdm:download_enrolled_device_command_result' command.uuid as url %}
                   {% button 'DOWNLOAD' url "Download Result" %}
                 {% endif %}
-                {% if not command.time and perms.mdm.delete_devicecommand %}
+                {% if command.can_be_deleted and perms.mdm.delete_devicecommand %}
                   <button type="button"
                           class="btn btn-link text-danger delete-command"
                           data-url="{% url 'mdm_api:enrolled_device_command' command.uuid %}"

--- a/zentral/contrib/mdm/templates/mdm/enrolleddevice_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/enrolleddevice_detail.html
@@ -661,7 +661,8 @@
           <th>Artifact</th>
           <th>Time</th>
           <th>Result time</th>
-          <th>Status</th>
+          <th style="width:150px">Status</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -692,9 +693,21 @@
               <td>{{ command.result_time|date:"SHORT_DATETIME_FORMAT"|default:"-" }}</td>
               <td>
                 {{ command.get_status_display|default:"-" }}
+              </td>
+              <td>
                 {% if command.result %}
                   {% url 'mdm:download_enrolled_device_command_result' command.uuid as url %}
                   {% button 'DOWNLOAD' url "Download Result" %}
+                {% endif %}
+                {% if not command.time and perms.mdm.delete_devicecommand %}
+                  <button type="button"
+                          class="btn btn-link text-danger delete-command"
+                          data-url="{% url 'mdm_api:enrolled_device_command' command.uuid %}"
+                          data-bs-toggle="tooltip"
+                          data-bs-placement="bottom"
+                          data-bs-title="Delete queued command">
+                    <i class="bi bi-trash"></i>
+                  </button>
                 {% endif %}
               </td>
             </tr>
@@ -778,6 +791,30 @@
     }
   }
 
+  var csrfToken = "{{ csrf_token }}";
+
+  function deleteCommand($btn) {
+    $.ajax({
+      url: $btn.data("url"),
+      type: "DELETE",
+      headers: {"X-CSRFToken": csrfToken},
+      success: function () {
+        $btn.tooltip("hide");
+        $btn.closest("tr").remove();
+      },
+      error: function (xhr) {
+        var msg = "The command could not be deleted. Please reload the page.";
+        var data = xhr.responseJSON;
+        if (Array.isArray(data) && data.length) {
+          msg = data.join(" ");
+        } else if (data && data.detail) {
+          msg = data.detail;
+        }
+        window.alert(msg);
+      }
+    });
+  }
+
   $(document).ready(function () {
     $(".show-ed-secret").click(function() {
       toggleEDSecret($(this));
@@ -786,6 +823,10 @@
     $(".copy-ed-secret").click(function() {
       copyEDSecret($(this));
     });
+
+    $(".delete-command").click(function() {
+      deleteCommand($(this));
+    });
   });
-  </script>
+</script>
 {% endblock %}


### PR DESCRIPTION
A queued command (no time set) can now be removed before it is handed to the device, both through the API and the admin UI.

The row is locked with select_for_update so we never delete a command the device is being handed mid-checkin. A command that has already been sent is refused (API 400, UI 409).

Deleting a command emits a zentral_audit "deleted" event: Command gains serialize_for_event() (excluding kwargs/result to avoid leaking command payloads) and linked_objects_keys_for_event() keyed on mdm_command by uuid, matching the existing command events; DeviceCommand adds the enrolled_device reference.