### PR TITLE
Add viewMachineTag to the Viewer action group

### DIFF
--- a/tests/server_accounts/test_pbac_engine.py
+++ b/tests/server_accounts/test_pbac_engine.py
@@ -797,3 +797,28 @@ class PBACEngineSingletonAppliesToTestCase(TestCase):
         self.assertIsNotNone(action.applies_to)
         resource_names = {r.name for r in action.applies_to.resources}
         self.assertEqual(resource_names, {"Machine", "System"})
+
+    def test_view_machine_tag_action_belongs_to_admin_user_and_viewer_groups(self):
+        # viewMachineTag is read-only, so — like every model-default view*
+        # action the engine auto-registers — it must sit in the Viewer group,
+        # at both the namespace-scoped and global level. A viewer-only policy
+        # has to grant it.
+        action = engine.legacy_perm_actions["inventory.view_machinetag"]
+        namespace = engine.get_namespace("Inventory")
+        for basename in (ActionGroupBasename.ADMIN, ActionGroupBasename.USER, ActionGroupBasename.VIEWER):
+            self.assertIn(engine.get_action_group(basename, namespace), action.parents)
+            self.assertIn(engine.get_action_group(basename), action.parents)
+
+    def test_mutating_machine_tag_actions_excluded_from_viewer_group(self):
+        # The flip side of the fix: create/deleteMachineTag mutate, so a viewer
+        # must never reach them. Guards against someone copy-pasting the viewer
+        # basename onto the wrong action.
+        namespace = engine.get_namespace("Inventory")
+        viewer_groups = (
+            engine.get_action_group(ActionGroupBasename.VIEWER, namespace),
+            engine.get_action_group(ActionGroupBasename.VIEWER),
+        )
+        for legacy_perm in ("inventory.add_machinetag", "inventory.delete_machinetag"):
+            action = engine.legacy_perm_actions[legacy_perm]
+            for group in viewer_groups:
+                self.assertNotIn(group, action.parents)

--- a/zentral/contrib/inventory/pbac.py
+++ b/zentral/contrib/inventory/pbac.py
@@ -1,16 +1,16 @@
 from pbac.engine import ActionGroupBasename, engine
 from pbac.entities import Namespace, Principal, Request, Resource
 from pbac.types import (
-    AppliesTo,
-    AttrSpec,
     LEGACY_PERM_APPLIES_TO,
-    ResourceType,
     SERVICE_ACCOUNT,
     SYSTEM,
     USER,
+    AppliesTo,
+    AttrSpec,
+    ResourceType,
 )
-from .models import MetaBusinessUnit, MetaMachine, Tag
 
+from .models import MetaBusinessUnit, MetaMachine, Tag
 
 # namespace
 
@@ -78,7 +78,7 @@ delete_machine_tag_action = engine.register_action(
 view_machine_tag_action = engine.register_action(
     "viewMachineTag",
     get_namespace(),
-    [ActionGroupBasename.ADMIN, ActionGroupBasename.USER],
+    [ActionGroupBasename.ADMIN, ActionGroupBasename.USER, ActionGroupBasename.VIEWER],
     applies_to=LEGACY_PERM_APPLIES_TO,
     legacy_perm="inventory.view_machinetag",
 )


### PR DESCRIPTION
viewMachineTag is custom-registered in inventory/pbac.py, so unlike the model-default view* actions the engine auto-assigns to the Viewer group (_register_model_default_legacy_perm_actions), it only carried Admin and User. A viewer-only role therefore couldn't see machine tags even though the action is read-only. Add ActionGroupBasename.VIEWER so it lands in both the namespace-scoped and global Viewer groups, matching every other view action.