### PR TITLE
Add pluggable osquery distributed query result stores

### DIFF
--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -6,6 +6,41 @@
 
 To activate the osquery module, you need to add a `zentral.contrib.osquery` section to the `apps` section in `base.json`.
 
+### Distributed query result store
+
+The distributed query results are posted to the queue by the `distributed_write` endpoint, and stored asynchronously by the preprocess workers. Small result sets are posted inline. Larger ones are written to the default Django storage under the `osquery/distributed_query_results/` prefix, and only referenced in the queue messages, to stay within the broker message size limits. The files are deleted once the results are stored. It is recommended to set up a lifecycle policy on this prefix to remove the files that could be left over if the processing of some of the messages fails.
+
+By default, the results are stored in PostgreSQL. No configuration is required. To reduce the load on PostgreSQL, a ClickHouse store can be configured instead, with the optional `distributed_query_result_store` section:
+
+```json
+{
+  "apps": {
+    "zentral.contrib.osquery": {
+      "distributed_query_results_ttl_days": 90,
+      "distributed_query_result_store": {
+        "backend": "CLICKHOUSE",
+        "clickhouse_kwargs": {
+          "host": "clickhouse.example.com",
+          "username": "zentral",
+          "password": "{{ secret:ZENTRAL_CLICKHOUSE_PASSWORD }}",
+          "database": "zentral",
+          "table_name": "osquery_distributed_query_results"
+        }
+      }
+    }
+  }
+}
+```
+
+Only `host` is required in `clickhouse_kwargs`. `port` (default `8443`), `secure` (default `true`), `verify` (default `true`), `compress` (default `true`), `access_token`, `connect_timeout` and `send_receive_timeout` can also be set. The table is created automatically. Existing results are not migrated when switching backends.
+
+#### Results retention
+
+The `distributed_query_results_ttl_days` app setting (default `90`, minimum `1`) controls the results retention for both store backends:
+
+* In the ClickHouse store, it is applied as a table TTL: the results are automatically removed after that many days. The TTL is only applied when the table is created. To change it afterwards, use [`ALTER TABLE … MODIFY TTL`](https://clickhouse.com/docs/sql-reference/statements/alter/ttl) directly on the table.
+* In the PostgreSQL store, it is enforced by the `cleanup_osquery_distributed_query_results` management command, to be scheduled for example with a cron job. The command deletes the results of the runs that are no longer collecting results and were created more than that many days ago. Use the `--days` argument to override the app setting.
+
 ## HTTP API
 
 ### Requests

--- a/tests/core_stores/test_clickhouse.py
+++ b/tests/core_stores/test_clickhouse.py
@@ -300,7 +300,7 @@ class TestClickHouseStore(TestCase):
 
     # event storage
 
-    @patch("zentral.core.stores.backends.clickhouse.clickhouse_connect.get_client")
+    @patch("zentral.utils.clickhouse.clickhouse_connect.get_client")
     def test_store(self, get_client):
         mocked_client = Mock()
         get_client.return_value = mocked_client
@@ -310,7 +310,7 @@ class TestClickHouseStore(TestCase):
         mocked_client.command.assert_called()
         mocked_client.insert.assert_called_once()
 
-    @patch("zentral.core.stores.backends.clickhouse.clickhouse_connect.get_client")
+    @patch("zentral.utils.clickhouse.clickhouse_connect.get_client")
     def test_bulk_store(self, get_client):
         mocked_client = Mock()
         get_client.return_value = mocked_client
@@ -323,7 +323,7 @@ class TestClickHouseStore(TestCase):
 
     # get_app_hist_data with timezones
 
-    @patch("zentral.core.stores.backends.clickhouse.clickhouse_connect.get_client")
+    @patch("zentral.utils.clickhouse.clickhouse_connect.get_client")
     def test_get_app_hist_data_with_timezones(self, get_client):
         mocked_client = Mock()
         get_client.return_value = mocked_client

--- a/tests/osquery/test_distributed_query_result_stores.py
+++ b/tests/osquery/test_distributed_query_result_stores.py
@@ -1,0 +1,468 @@
+import csv
+import io
+import json
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import default_storage
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import IntegrityError
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from zentral.contrib.osquery.distributed_query_result_stores import _load_distributed_query_result_store
+from zentral.contrib.osquery.distributed_query_result_stores.base import (
+    BaseDistributedQueryResultStore,
+    DistributedQueryResultRow,
+)
+from zentral.contrib.osquery.distributed_query_result_stores.clickhouse import (
+    DistributedQueryResultStore as ClickHouseDistributedQueryResultStore,
+)
+from zentral.contrib.osquery.distributed_query_result_stores.postgres import (
+    DistributedQueryResultStore as PostgresDistributedQueryResultStore,
+)
+from zentral.contrib.osquery.events import post_distributed_query_result_rows
+from zentral.contrib.osquery.models import DistributedQuery, DistributedQueryResult
+from zentral.contrib.osquery.preprocessors import DistributedQueryResultsPreprocessor, get_preprocessors
+from zentral.contrib.osquery.tasks import _export_distributed_query_results
+from zentral.utils.time import naive_utcnow
+
+
+def force_distributed_query():
+    return DistributedQuery.objects.create(
+        sql="select username from users;",
+        valid_from=naive_utcnow(),
+        query_version=1
+    )
+
+
+def force_expired_distributed_query(days=100):
+    distributed_query = DistributedQuery.objects.create(
+        sql="select username from users;",
+        valid_from=naive_utcnow() - timedelta(days=days),
+        valid_until=naive_utcnow() - timedelta(days=days - 1),
+        query_version=1
+    )
+    DistributedQuery.objects.filter(pk=distributed_query.pk).update(
+        created_at=naive_utcnow() - timedelta(days=days)
+    )
+    return distributed_query
+
+
+class DistributedQueryResultStoreFactoryTestCase(TestCase):
+    def _load_store(self, app_config_d):
+        with patch(
+            "zentral.contrib.osquery.distributed_query_result_stores.settings",
+            {"apps": {"zentral.contrib.osquery": app_config_d}}
+        ):
+            return _load_distributed_query_result_store()
+
+    def test_default_store(self):
+        store = self._load_store({})
+        self.assertIsInstance(store, PostgresDistributedQueryResultStore)
+        self.assertEqual(store.ttl_days, 90)
+
+    def test_invalid_ttl(self):
+        for ttl_days in (0, -1, None, "yolo"):
+            with self.assertRaises(ImproperlyConfigured) as cm:
+                self._load_store({"distributed_query_results_ttl_days": ttl_days})
+            self.assertEqual(cm.exception.args[0], "Invalid distributed_query_results_ttl_days app setting")
+
+    def test_clickhouse_store(self):
+        store = self._load_store({
+            "distributed_query_results_ttl_days": 17,
+            "distributed_query_result_store": {
+                "backend": "CLICKHOUSE",
+                "clickhouse_kwargs": {"host": "clickhouse"}
+            }
+        })
+        self.assertIsInstance(store, ClickHouseDistributedQueryResultStore)
+        self.assertEqual(store.ttl_days, 17)
+        self.assertEqual(store.config_d, {"host": "clickhouse"})
+
+    def test_clickhouse_store_invalid_identifier(self):
+        with self.assertRaises(ValueError) as cm:
+            ClickHouseDistributedQueryResultStore({"host": "clickhouse", "table_name": "yolo;fomo"}, 90)
+        self.assertEqual(cm.exception.args[0], "Invalid identifier: yolo;fomo")
+
+
+class BaseDistributedQueryResultStoreTestCase(TestCase):
+    def test_not_implemented(self):
+        store = BaseDistributedQueryResultStore({}, 90)
+        for method, args in (
+            (store.bulk_create, (1, "0123456789", [])),
+            (store.get_result_count, (1,)),
+            (store.get_result_counts, ([1],)),
+            (store.get_results, (1, None, 0, 10)),
+            (store.get_result_columns, (1,)),
+            (store.iter_results, (1,)),
+            (store.delete_results, (1,)),
+            (store.delete_expired_results, (naive_utcnow(),)),
+        ):
+            with self.assertRaises(NotImplementedError):
+                method(*args)
+
+    def test_result_row_not_a_dict(self):
+        result_row = DistributedQueryResultRow("0123456789", ["not", "a", "dict"])
+        self.assertEqual(list(result_row.iter_row_kv()), [])
+
+
+class DistributedQueryResultPostingTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.distributed_query = force_distributed_query()
+
+    def _post_rows(self, rows, inline=True):
+        with patch("zentral.contrib.osquery.events.queues.post_raw_event") as post_raw_event:
+            post_distributed_query_result_rows(self.distributed_query.pk, "0123456789", rows, inline)
+        return [call_args.args for call_args in post_raw_event.call_args_list]
+
+    def test_inline(self):
+        calls = self._post_rows([{"username": "godzilla"}, {"username": "mothra"}])
+        self.assertEqual(len(calls), 1)
+        routing_key, raw_event = calls[0]
+        self.assertEqual(routing_key, "osquery_distributed_query_results")
+        self.assertEqual(
+            raw_event,
+            {"distributed_query_pk": self.distributed_query.pk,
+             "serial_number": "0123456789",
+             "rows": [{"username": "godzilla"}, {"username": "mothra"}]}
+        )
+
+    def test_null_character_removed(self):
+        calls = self._post_rows([{"username": "god\u0000zilla"}])
+        self.assertEqual(calls[0][1]["rows"], [{"username": "godzilla"}])
+
+    @patch("zentral.contrib.osquery.events.default_storage")
+    def test_file(self, default_storage):
+        default_storage.save.return_value = "osquery/distributed_query_results/yolo.json"
+        calls = self._post_rows([{"username": "godzilla"}], inline=False)
+        self.assertEqual(len(calls), 1)
+        routing_key, raw_event = calls[0]
+        self.assertEqual(routing_key, "osquery_distributed_query_results")
+        self.assertEqual(
+            raw_event,
+            {"distributed_query_pk": self.distributed_query.pk,
+             "serial_number": "0123456789",
+             "filepath": "osquery/distributed_query_results/yolo.json"}
+        )
+        filepath, content = default_storage.save.call_args.args
+        self.assertTrue(filepath.startswith(f"osquery/distributed_query_results/{self.distributed_query.pk}/"))
+        self.assertTrue(filepath.endswith(".json"))
+        self.assertEqual(json.load(content), [{"username": "godzilla"}])
+
+
+class DistributedQueryResultsPreprocessorTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.distributed_query = force_distributed_query()
+
+    def _build_raw_event(self, **kwargs):
+        raw_event = {
+            "distributed_query_pk": self.distributed_query.pk,
+            "serial_number": "0123456789",
+            "rows": [{"username": "godzilla"}],
+        }
+        raw_event.update(**kwargs)
+        return {k: v for k, v in raw_event.items() if v is not None}
+
+    def test_store_inline_rows(self):
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(self._build_raw_event())), [])
+        dqr_qs = DistributedQueryResult.objects.filter(distributed_query=self.distributed_query)
+        self.assertEqual(dqr_qs.count(), 1)
+        self.assertEqual(dqr_qs.first().row, {"username": "godzilla"})
+
+    def test_invalid_raw_event_dropped(self):
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event({"yolo": "fomo"})), [])
+        self.assertEqual(DistributedQueryResult.objects.count(), 0)
+
+    @patch("zentral.contrib.osquery.preprocessors.default_storage")
+    def test_store_file(self, default_storage):
+        default_storage.open.return_value.__enter__.return_value = io.BytesIO(
+            json.dumps([{"username": "godzilla"}]).encode("utf-8")
+        )
+        raw_event = self._build_raw_event(rows=None, filepath="osquery/distributed_query_results/yolo.json")
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(raw_event)), [])
+        dqr_qs = DistributedQueryResult.objects.filter(distributed_query=self.distributed_query)
+        self.assertEqual(dqr_qs.count(), 1)
+        self.assertEqual(dqr_qs.first().row, {"username": "godzilla"})
+        default_storage.open.assert_called_once_with("osquery/distributed_query_results/yolo.json")
+        default_storage.delete.assert_called_once_with("osquery/distributed_query_results/yolo.json")
+
+    @patch("zentral.contrib.osquery.preprocessors.default_storage")
+    def test_missing_file_dropped(self, default_storage):
+        default_storage.open.side_effect = FileNotFoundError
+        raw_event = self._build_raw_event(rows=None, filepath="osquery/distributed_query_results/yolo.json")
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(raw_event)), [])
+        self.assertEqual(DistributedQueryResult.objects.count(), 0)
+        default_storage.delete.assert_not_called()
+
+    def test_missing_rows_and_filepath_dropped(self):
+        raw_event = self._build_raw_event(rows=None)
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(raw_event)), [])
+        self.assertEqual(DistributedQueryResult.objects.count(), 0)
+
+    @patch("zentral.contrib.osquery.preprocessors.default_storage")
+    def test_unreadable_file_dropped(self, default_storage):
+        default_storage.open.side_effect = OSError("boom")
+        raw_event = self._build_raw_event(rows=None, filepath="osquery/distributed_query_results/yolo.json")
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(raw_event)), [])
+        self.assertEqual(DistributedQueryResult.objects.count(), 0)
+        default_storage.delete.assert_not_called()
+
+    @patch("zentral.contrib.osquery.preprocessors.default_storage")
+    def test_file_delete_error(self, default_storage):
+        default_storage.open.return_value.__enter__.return_value = io.BytesIO(
+            json.dumps([{"username": "godzilla"}]).encode("utf-8")
+        )
+        default_storage.delete.side_effect = OSError("boom")
+        raw_event = self._build_raw_event(rows=None, filepath="osquery/distributed_query_results/yolo.json")
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(raw_event)), [])
+        self.assertEqual(DistributedQueryResult.objects.count(), 1)
+
+    def test_get_preprocessors(self):
+        preprocessors = list(get_preprocessors())
+        self.assertEqual(len(preprocessors), 1)
+        self.assertEqual(preprocessors[0].routing_key, "osquery_distributed_query_results")
+
+    @patch("zentral.contrib.osquery.preprocessors.get_distributed_query_result_store")
+    def test_store_error_dropped(self, get_store):
+        get_store.return_value = Mock(bulk_create=Mock(side_effect=ValueError("boom")))
+        preprocessor = DistributedQueryResultsPreprocessor()
+        self.assertEqual(list(preprocessor.process_raw_event(self._build_raw_event())), [])
+        self.assertEqual(DistributedQueryResult.objects.count(), 0)
+
+
+class PostgresDistributedQueryResultStoreTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.store = PostgresDistributedQueryResultStore({}, 90)
+        cls.distributed_query = force_distributed_query()
+        cls.store.bulk_create(
+            cls.distributed_query.pk, "0123456789",
+            [{"username": "godzilla"}, {"username": "mothra"}]
+        )
+
+    def test_get_result_count(self):
+        self.assertEqual(self.store.get_result_count(self.distributed_query.pk), 2)
+        self.assertEqual(self.store.get_result_count(self.distributed_query.pk, "godz"), 1)
+        self.assertEqual(self.store.get_result_count(self.distributed_query.pk, "ghidorah"), 0)
+
+    def test_get_result_counts(self):
+        self.assertEqual(
+            self.store.get_result_counts([self.distributed_query.pk, 0]),
+            {self.distributed_query.pk: 2}
+        )
+
+    def test_get_results(self):
+        results = self.store.get_results(self.distributed_query.pk, None, 0, 10)
+        self.assertEqual(len(results), 2)
+        results = self.store.get_results(self.distributed_query.pk, "mothra", 0, 10)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].serial_number, "0123456789")
+        self.assertEqual(results[0].row, {"username": "mothra"})
+        self.assertEqual(list(results[0].iter_row_kv()), [("username", "mothra")])
+
+    def test_get_result_columns(self):
+        self.assertEqual(self.store.get_result_columns(self.distributed_query.pk), ["username"])
+
+    def test_iter_results(self):
+        self.assertEqual(
+            sorted(row["username"] for _, row in self.store.iter_results(self.distributed_query.pk)),
+            ["godzilla", "mothra"]
+        )
+
+    def test_bulk_create_deleted_distributed_query(self):
+        distributed_query = force_distributed_query()
+        distributed_query_pk = distributed_query.pk
+        distributed_query.delete()
+        self.store.bulk_create(distributed_query_pk, "0123456789", [{"username": "godzilla"}])
+        self.assertEqual(self.store.get_result_count(distributed_query_pk), 0)
+
+    @patch("zentral.contrib.osquery.models.DistributedQueryResult.objects.bulk_create")
+    def test_bulk_create_integrity_error_reraised(self, orm_bulk_create):
+        orm_bulk_create.side_effect = IntegrityError("boom")
+        with self.assertRaises(IntegrityError):
+            self.store.bulk_create(self.distributed_query.pk, "0123456789", [{"username": "godzilla"}])
+
+    @patch("zentral.contrib.osquery.models.DistributedQuery.objects.filter")
+    @patch("zentral.contrib.osquery.models.DistributedQueryResult.objects.bulk_create")
+    def test_bulk_create_distributed_query_deleted_during_insert(self, orm_bulk_create, dq_filter):
+        orm_bulk_create.side_effect = IntegrityError("boom")
+        dq_filter.return_value = Mock(exists=Mock(side_effect=[True, False]))
+        self.store.bulk_create(self.distributed_query.pk, "0123456789", [{"username": "godzilla"}])
+
+    def test_delete_expired_results(self):
+        expired_distributed_query = force_expired_distributed_query()
+        self.store.bulk_create(expired_distributed_query.pk, "0123456789", [{"username": "ghidorah"}])
+        open_ended_distributed_query = force_distributed_query()
+        DistributedQuery.objects.filter(pk=open_ended_distributed_query.pk).update(
+            created_at=naive_utcnow() - timedelta(days=100)
+        )
+        self.store.bulk_create(open_ended_distributed_query.pk, "0123456789", [{"username": "rodan"}])
+        deleted = self.store.delete_expired_results(naive_utcnow() - timedelta(days=90))
+        self.assertEqual(deleted, 1)
+        self.assertEqual(self.store.get_result_count(expired_distributed_query.pk), 0)
+        # the run without an end of validity may still collect results, they are kept
+        self.assertEqual(self.store.get_result_count(open_ended_distributed_query.pk), 1)
+        # the recent results are kept
+        self.assertEqual(self.store.get_result_count(self.distributed_query.pk), 2)
+
+
+class ClickHouseDistributedQueryResultStoreTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.database = "zentral_tests"
+        cls.store = ClickHouseDistributedQueryResultStore({
+            "host": "clickhouse",
+            "port": 8123,
+            "secure": False,
+            "database": cls.database,
+            "username": cls.database,
+            "password": cls.database,
+            "table_name": f"test_dqr_{get_random_string(8).lower()}",
+        }, ttl_days=15)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.store.client.command(f"DROP TABLE IF EXISTS `{cls.database}`.`{cls.store.table_name}`;")
+
+    def setUp(self):
+        self.distributed_query_pk = force_distributed_query().pk
+        self.store.bulk_create(
+            self.distributed_query_pk, "0123456789",
+            [{"username": "godzilla"}, {"username": "mothra"}]
+        )
+
+    def test_get_result_count(self):
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk), 2)
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk, "GODZ"), 1)
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk, "ghidorah"), 0)
+
+    def test_duplicated_results_deduplicated(self):
+        self.store.bulk_create(
+            self.distributed_query_pk, "0123456789",
+            [{"username": "godzilla"}, {"username": "mothra"}]
+        )
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk), 2)
+        self.assertEqual(len(self.store.get_results(self.distributed_query_pk, None, 0, 10)), 2)
+
+    def test_get_result_counts(self):
+        self.assertEqual(
+            self.store.get_result_counts([self.distributed_query_pk, 0]),
+            {self.distributed_query_pk: 2}
+        )
+
+    def test_get_results(self):
+        results = self.store.get_results(self.distributed_query_pk, None, 0, 10)
+        self.assertEqual(len(results), 2)
+        results = self.store.get_results(self.distributed_query_pk, "mothra", 0, 10)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].serial_number, "0123456789")
+        self.assertEqual(results[0].row, {"username": "mothra"})
+        self.assertEqual(list(results[0].iter_row_kv()), [("username", "mothra")])
+
+    def test_get_result_columns(self):
+        self.assertEqual(self.store.get_result_columns(self.distributed_query_pk), ["username"])
+
+    def test_iter_results(self):
+        self.assertEqual(
+            sorted(row["username"] for _, row in self.store.iter_results(self.distributed_query_pk)),
+            ["godzilla", "mothra"]
+        )
+
+    def test_delete_results(self):
+        self.store.delete_results(self.distributed_query_pk)
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk), 0)
+
+    def test_delete_expired_results(self):
+        self.assertIsNone(self.store.delete_expired_results(naive_utcnow() - timedelta(days=1)))
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk), 2)
+        self.assertIsNone(self.store.delete_expired_results(naive_utcnow() + timedelta(days=1)))
+        self.assertEqual(self.store.get_result_count(self.distributed_query_pk), 0)
+
+
+class CleanupDistributedQueryResultsCommandTestCase(TestCase):
+    def test_cleanup(self):
+        expired_distributed_query = force_expired_distributed_query()
+        store = PostgresDistributedQueryResultStore({}, 90)
+        store.bulk_create(expired_distributed_query.pk, "0123456789", [{"username": "ghidorah"}])
+        out = io.StringIO()
+        call_command("cleanup_osquery_distributed_query_results", "--days", "90", stdout=out)
+        self.assertIn("1 result deleted", out.getvalue())
+        self.assertEqual(store.get_result_count(expired_distributed_query.pk), 0)
+
+    def test_cleanup_quiet(self):
+        out = io.StringIO()
+        call_command("cleanup_osquery_distributed_query_results", "-q", "--days", "90", stdout=out)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_cleanup_invalid_days(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command("cleanup_osquery_distributed_query_results", days=-1)
+        self.assertEqual(cm.exception.args[0], "No number of days to keep")
+
+    @patch("zentral.contrib.osquery.management.commands"
+           ".cleanup_osquery_distributed_query_results.get_distributed_query_result_store")
+    def test_cleanup_async_store(self, get_store):
+        get_store.return_value = Mock(ttl_days=90, delete_expired_results=Mock(return_value=None))
+        out = io.StringIO()
+        call_command("cleanup_osquery_distributed_query_results", stdout=out)
+        self.assertIn("results deletion submitted", out.getvalue())
+
+
+class ExportDistributedQueryResultsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.distributed_query = force_distributed_query()
+        store = PostgresDistributedQueryResultStore({}, 90)
+        store.bulk_create(
+            cls.distributed_query.pk, "0123456789",
+            [{"username": "godzilla", "uid": 501, "admin": True, "shell": None}]
+        )
+
+    def _export(self, extension):
+        result = _export_distributed_query_results(self.distributed_query, extension)
+        filepath = result["filepath"]
+        self.assertTrue(default_storage.exists(filepath))
+        with default_storage.open(filepath) as f:
+            content = f.read()
+        default_storage.delete(filepath)
+        return result, content
+
+    def test_export_csv(self):
+        result, content = self._export(".csv")
+        self.assertEqual(result["headers"]["Content-Type"], "text/csv")
+        rows = list(csv.reader(io.StringIO(content.decode("utf-8"))))
+        self.assertEqual(rows[0], ["serial number", "admin", "shell", "uid", "username"])
+        self.assertEqual(rows[1], ["0123456789", "True", "", "501", "godzilla"])
+
+    def test_export_ndjson(self):
+        result, content = self._export(".ndjson")
+        self.assertEqual(result["headers"]["Content-Type"], "application/x-ndjson")
+        self.assertEqual(
+            json.loads(content.decode("utf-8").strip()),
+            {"serial_number": "0123456789",
+             "row": {"username": "godzilla", "uid": 501, "admin": True, "shell": None}}
+        )
+
+    def test_export_xlsx(self):
+        result, content = self._export(".xlsx")
+        self.assertEqual(result["headers"]["Content-Type"],
+                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        self.assertTrue(content.startswith(b"PK"))
+
+    def test_export_unsupported_extension(self):
+        with self.assertRaises(ValueError):
+            _export_distributed_query_results(self.distributed_query, ".yolo")

--- a/tests/osquery/test_osquery_api.py
+++ b/tests/osquery/test_osquery_api.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import uuid
 from datetime import datetime
@@ -22,6 +23,7 @@ from zentral.contrib.osquery.events import (
     OsqueryRequestEvent,
     OsqueryResultEvent,
 )
+from zentral.contrib.osquery.preprocessors import DistributedQueryResultsPreprocessor
 from zentral.contrib.osquery.models import (
     Configuration,
     ConfigurationPack,
@@ -943,6 +945,13 @@ class OsqueryAPIViewsTestCase(TestCase):
         self.assertEqual(json_response, {"queries": {}})
         self.assertEqual(dqm_qs.count(), 2)
 
+    def _process_dqr_raw_events(self, post_raw_event):
+        preprocessor = DistributedQueryResultsPreprocessor()
+        for call_args in post_raw_event.call_args_list:
+            routing_key, raw_event = call_args.args
+            self.assertEqual(routing_key, preprocessor.routing_key)
+            list(preprocessor.process_raw_event(raw_event))
+
     def test_distributed_write_405(self):
         response = self.client.get(reverse("osquery_public:distributed_write"))
         self.assertEqual(response.status_code, 405)
@@ -956,7 +965,30 @@ class OsqueryAPIViewsTestCase(TestCase):
         response = self.post_as_json("distributed_write", {"node_key": "godzilla"})
         self.assertContains(response, '{"node_invalid": true}', status_code=200)
 
-    def test_distributed_write_no_compliance_check(self):
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
+    def test_distributed_write_gzip(self, post_raw_event):
+        em = self.force_enrolled_machine()
+        dq = DistributedQuery.objects.create(sql="select username from users;",
+                                             valid_from=naive_utcnow(),
+                                             query_version=1)
+        dqm = DistributedQueryMachine.objects.create(distributed_query=dq, serial_number=em.serial_number)
+        response = self.client.post(
+            reverse("osquery_public:distributed_write"),
+            gzip.compress(json.dumps({"node_key": em.node_key,
+                                      "queries": {str(dqm.pk): [{"username": "godzilla"}]},
+                                      "statuses": {str(dqm.pk): 0}}).encode("utf-8")),
+            content_type="application/json",
+            headers={"content-encoding": "gzip"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {})
+        self._process_dqr_raw_events(post_raw_event)
+        dqr_qs = DistributedQueryResult.objects.filter(distributed_query=dq, serial_number=em.serial_number)
+        self.assertEqual(dqr_qs.count(), 1)
+        self.assertEqual(dqr_qs.first().row, {"username": "godzilla"})
+
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
+    def test_distributed_write_no_compliance_check(self, post_raw_event):
         em = self.force_enrolled_machine()
         dq = DistributedQuery.objects.create(sql="select username from users;",
                                              valid_from=naive_utcnow(),
@@ -970,14 +1002,16 @@ class OsqueryAPIViewsTestCase(TestCase):
         self.assertEqual(response.json(), {})
         dqm.refresh_from_db()
         self.assertEqual(dqm.status, 0)
+        self._process_dqr_raw_events(post_raw_event)
         dqr_qs = DistributedQueryResult.objects.filter(distributed_query=dq, serial_number=em.serial_number)
         self.assertEqual(dqr_qs.count(), 1)
         self.assertEqual(dqr_qs.first().row, {"username": "godzilla"})
         ms_qs = MachineStatus.objects.filter(serial_number=em.serial_number)
         self.assertEqual(ms_qs.count(), 0)
 
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    def test_distributed_write_one_carve(self, post_event):
+    def test_distributed_write_one_carve(self, post_event, post_raw_event):
         query, _, distributed_query = self.force_query(force_distributed_query=True)
         em = self.force_enrolled_machine()
         dqm = DistributedQueryMachine.objects.create(distributed_query=distributed_query,
@@ -1018,8 +1052,9 @@ class OsqueryAPIViewsTestCase(TestCase):
         self.assertEqual(file_carving_event.payload["action"], "schedule")
         self.assertEqual(file_carving_event.payload["session_id"], str(fcs.pk))
 
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    def test_distributed_write_two_distributed_queries_one_compliance_check(self, post_event):
+    def test_distributed_write_two_distributed_queries_one_compliance_check(self, post_event, post_raw_event):
         query1, _, distributed_query1 = self.force_query(force_distributed_query=True, force_compliance_check=True)
         query2, _, distributed_query2 = self.force_query(force_distributed_query=True, force_compliance_check=False)
         em = self.force_enrolled_machine()
@@ -1076,8 +1111,11 @@ class OsqueryAPIViewsTestCase(TestCase):
         self.assertEqual(machine_compliance_event.metadata.machine_serial_number, em.serial_number)
         self.assertEqual(machine_compliance_event.payload, {"status": Status.OK.name})
 
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    def test_distributed_write_two_distributed_queries_one_outdated_version_compliance_check(self, post_event):
+    def test_distributed_write_two_distributed_queries_one_outdated_version_compliance_check(
+        self, post_event, post_raw_event
+    ):
         query1, _, distributed_query1 = self.force_query(force_distributed_query=True, force_compliance_check=True)
         query1.version = 127
         query1.save()
@@ -1101,8 +1139,9 @@ class OsqueryAPIViewsTestCase(TestCase):
         self.assertIsInstance(request_event, OsqueryRequestEvent)
         self.assertEqual(request_event.payload["request_type"], "distributed_write")
 
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    def test_distributed_write_two_distributed_queries_add_one_tag(self, post_event):
+    def test_distributed_write_two_distributed_queries_add_one_tag(self, post_event, post_raw_event):
         query1, _, distributed_query1 = self.force_query(force_distributed_query=True, force_tag=True)
         query2, _, distributed_query2 = self.force_query(force_distributed_query=True, force_tag=False)
         em = self.force_enrolled_machine()
@@ -1135,8 +1174,9 @@ class OsqueryAPIViewsTestCase(TestCase):
             {"action": "added", "tag": {"pk": query1.tag.pk, "name": query1.tag.name}},
         )
 
+    @patch("zentral.contrib.osquery.events.queues.post_raw_event")
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    def test_distributed_write_two_distributed_queries_remove_one_tag(self, post_event):
+    def test_distributed_write_two_distributed_queries_remove_one_tag(self, post_event, post_raw_event):
         query1, _, distributed_query1 = self.force_query(force_distributed_query=True, force_tag=True)
         query2, _, distributed_query2 = self.force_query(force_distributed_query=True, force_tag=False)
         em = self.force_enrolled_machine()

--- a/zentral/contrib/osquery/distributed_query_result_stores/__init__.py
+++ b/zentral/contrib/osquery/distributed_query_result_stores/__init__.py
@@ -1,0 +1,43 @@
+from importlib import import_module
+
+from django.core.exceptions import ImproperlyConfigured
+
+from zentral.conf import settings
+
+DEFAULT_TTL_DAYS = 90
+
+
+def _serialize_config(config):
+    serialize = getattr(config, "serialize", None)
+    return serialize() if serialize else dict(config)
+
+
+def _load_distributed_query_result_store():
+    app_config_d = settings["apps"]["zentral.contrib.osquery"]
+    ttl_days = app_config_d.get("distributed_query_results_ttl_days", DEFAULT_TTL_DAYS)
+    try:
+        ttl_days = int(ttl_days)
+        if ttl_days < 1:
+            raise ValueError
+    except (TypeError, ValueError):
+        raise ImproperlyConfigured("Invalid distributed_query_results_ttl_days app setting")
+    store_config_d = app_config_d.get("distributed_query_result_store")
+    if store_config_d:
+        backend = store_config_d["backend"].lower()
+        backend_config_d = store_config_d.get(f"{backend}_kwargs")
+        config_d = _serialize_config(backend_config_d) if backend_config_d else {}
+    else:
+        backend = "postgres"
+        config_d = {}
+    module = import_module(f"zentral.contrib.osquery.distributed_query_result_stores.{backend}")
+    return module.DistributedQueryResultStore(config_d, ttl_days)
+
+
+_store = None
+
+
+def get_distributed_query_result_store():
+    global _store
+    if _store is None:
+        _store = _load_distributed_query_result_store()
+    return _store

--- a/zentral/contrib/osquery/distributed_query_result_stores/base.py
+++ b/zentral/contrib/osquery/distributed_query_result_stores/base.py
@@ -1,0 +1,42 @@
+class DistributedQueryResultRow:
+    __slots__ = ("serial_number", "row")
+
+    def __init__(self, serial_number, row):
+        self.serial_number = serial_number
+        self.row = row
+
+    def iter_row_kv(self):
+        if not isinstance(self.row, dict):
+            return
+        for k in sorted(self.row.keys()):
+            yield k, self.row.get(k)
+
+
+class BaseDistributedQueryResultStore:
+    def __init__(self, config_d, ttl_days):
+        self.config_d = config_d
+        self.ttl_days = ttl_days
+
+    def bulk_create(self, distributed_query_pk, serial_number, rows):
+        raise NotImplementedError
+
+    def delete_expired_results(self, cutoff):
+        raise NotImplementedError
+
+    def get_result_count(self, distributed_query_pk, q=None):
+        raise NotImplementedError
+
+    def get_result_counts(self, distributed_query_pks):
+        raise NotImplementedError
+
+    def get_results(self, distributed_query_pk, q, offset, limit):
+        raise NotImplementedError
+
+    def get_result_columns(self, distributed_query_pk):
+        raise NotImplementedError
+
+    def iter_results(self, distributed_query_pk):
+        raise NotImplementedError
+
+    def delete_results(self, distributed_query_pk):
+        raise NotImplementedError

--- a/zentral/contrib/osquery/distributed_query_result_stores/clickhouse/0001_initial.sql
+++ b/zentral/contrib/osquery/distributed_query_result_stores/clickhouse/0001_initial.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS {database}.{table_name} (
+    distributed_query_id  UInt64,
+    serial_number         String,
+    row_index             UInt64,
+    received_at           DateTime64(6),
+    row                   String
+)
+ENGINE = ReplacingMergeTree(received_at)
+ORDER BY (distributed_query_id, serial_number, row_index)
+TTL received_at + toIntervalDay({ttl_days})
+SETTINGS non_replicated_deduplication_window = 1000;

--- a/zentral/contrib/osquery/distributed_query_result_stores/clickhouse/__init__.py
+++ b/zentral/contrib/osquery/distributed_query_result_stores/clickhouse/__init__.py
@@ -1,0 +1,185 @@
+import json
+import logging
+import os
+import re
+
+import clickhouse_connect
+from django.utils.functional import cached_property
+
+from zentral.utils.time import naive_utcnow
+
+from ..base import BaseDistributedQueryResultStore, DistributedQueryResultRow
+
+logger = logging.getLogger("zentral.contrib.osquery.distributed_query_result_stores.clickhouse")
+
+
+class DistributedQueryResultStore(BaseDistributedQueryResultStore):
+    identifier_regex = re.compile(r"^[a-zA-Z_][0-9a-zA-Z_]*$")
+    client_kwargs_keys = (
+        # connection
+        "host",
+        "port",
+        "secure",
+        "verify",
+        "compress",
+        # auth
+        "username",
+        "database",
+        "password",
+        # timeouts
+        "connect_timeout",
+        "send_receive_timeout",
+    )
+    default_database = "default"
+    default_table_name = "osquery_distributed_query_results"
+    column_names = (
+        "distributed_query_id",
+        "serial_number",
+        "row_index",
+        "received_at",
+        "row",
+    )
+
+    def __init__(self, config_d, ttl_days):
+        super().__init__(config_d, ttl_days)
+        self.client_kwargs = {
+            k: config_d[k]
+            for k in self.client_kwargs_keys
+            if config_d.get(k) is not None
+        }
+        self.client_kwargs.setdefault("database", self.default_database)
+        self.database = self.client_kwargs["database"]
+        self.table_name = config_d.get("table_name", self.default_table_name)
+        for identifier in (self.database, self.table_name):
+            if not self.identifier_regex.match(identifier):
+                raise ValueError(f"Invalid identifier: {identifier}")
+        self._configured = False
+
+    @cached_property
+    def client(self):
+        return clickhouse_connect.get_client(
+            autogenerate_session_id=False,
+            **self.client_kwargs
+        )
+
+    def migrate(self):
+        migration_filepath = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "0001_initial.sql"
+        )
+        with open(migration_filepath) as f:
+            sql = f.read()
+        sql = sql.format(
+            database=self.database,
+            table_name=self.table_name,
+            ttl_days=self.ttl_days,
+        )
+        for statement in (s.strip() for s in sql.split(";")):
+            if not statement:
+                continue
+            self.client.command(statement)
+
+    def _migrate_if_necessary(self):
+        if not self._configured:
+            self.migrate()
+            self._configured = True
+
+    def bulk_create(self, distributed_query_pk, serial_number, rows):
+        self._migrate_if_necessary()
+        received_at = naive_utcnow()
+        data = [
+            (distributed_query_pk,
+             serial_number,
+             row_index,
+             received_at,
+             json.dumps(row))
+            for row_index, row in enumerate(rows)
+        ]
+        self.client.insert(
+            self.table_name,
+            data,
+            column_names=self.column_names,
+            settings={"insert_deduplication_token": f"{distributed_query_pk}:{serial_number}"},
+        )
+
+    @staticmethod
+    def _search_where(q, params):
+        where = "distributed_query_id = {distributed_query_pk:UInt64}"
+        if q:
+            where += (
+                " AND (positionCaseInsensitiveUTF8(serial_number, {q:String}) > 0"
+                " OR positionCaseInsensitiveUTF8(row, {q:String}) > 0)"
+            )
+            params["q"] = q
+        return where
+
+    def get_result_count(self, distributed_query_pk, q=None):
+        self._migrate_if_necessary()
+        params = {"distributed_query_pk": distributed_query_pk}
+        where = self._search_where(q, params)
+        result = self.client.query(
+            f"SELECT uniqExact((serial_number, row_index)) FROM `{self.table_name}` WHERE {where}",
+            parameters=params,
+        )
+        return result.result_rows[0][0]
+
+    def get_result_counts(self, distributed_query_pks):
+        self._migrate_if_necessary()
+        result = self.client.query(
+            f"SELECT distributed_query_id, uniqExact((serial_number, row_index)) "
+            f"FROM `{self.table_name}` "
+            "WHERE distributed_query_id IN {distributed_query_pks:Array(UInt64)} "
+            "GROUP BY distributed_query_id",
+            parameters={"distributed_query_pks": list(distributed_query_pks)},
+        )
+        return {dq_pk: count for dq_pk, count in result.result_rows}
+
+    def get_results(self, distributed_query_pk, q, offset, limit):
+        self._migrate_if_necessary()
+        params = {"distributed_query_pk": distributed_query_pk, "offset": offset, "limit": limit}
+        where = self._search_where(q, params)
+        result = self.client.query(
+            f"SELECT serial_number, row FROM `{self.table_name}` FINAL WHERE {where} "
+            "ORDER BY serial_number, row_index LIMIT {limit:UInt64} OFFSET {offset:UInt64}",
+            parameters=params,
+        )
+        return [
+            DistributedQueryResultRow(serial_number, json.loads(row))
+            for serial_number, row in result.result_rows
+        ]
+
+    def get_result_columns(self, distributed_query_pk):
+        self._migrate_if_necessary()
+        result = self.client.query(
+            f"SELECT DISTINCT arrayJoin(JSONExtractKeys(row)) AS col FROM `{self.table_name}` "
+            "WHERE distributed_query_id = {distributed_query_pk:UInt64} ORDER BY col",
+            parameters={"distributed_query_pk": distributed_query_pk},
+        )
+        return [t[0] for t in result.result_rows]
+
+    def iter_results(self, distributed_query_pk):
+        self._migrate_if_necessary()
+        with self.client.query_rows_stream(
+            f"SELECT serial_number, row FROM `{self.table_name}` FINAL "
+            "WHERE distributed_query_id = {distributed_query_pk:UInt64} "
+            "ORDER BY serial_number, row_index",
+            parameters={"distributed_query_pk": distributed_query_pk},
+        ) as stream:
+            for serial_number, row in stream:
+                yield serial_number, json.loads(row)
+
+    def delete_results(self, distributed_query_pk):
+        self._migrate_if_necessary()
+        self.client.command(
+            f"DELETE FROM `{self.database}`.`{self.table_name}` "
+            "WHERE distributed_query_id = {distributed_query_pk:UInt64}",
+            parameters={"distributed_query_pk": distributed_query_pk},
+        )
+
+    def delete_expired_results(self, cutoff):
+        self._migrate_if_necessary()
+        self.client.command(
+            f"DELETE FROM `{self.database}`.`{self.table_name}` "
+            "WHERE received_at < toDateTime64({cutoff:String}, 6, 'UTC')",
+            parameters={"cutoff": cutoff.isoformat()},
+        )

--- a/zentral/contrib/osquery/distributed_query_result_stores/clickhouse/__init__.py
+++ b/zentral/contrib/osquery/distributed_query_result_stores/clickhouse/__init__.py
@@ -3,9 +3,9 @@ import logging
 import os
 import re
 
-import clickhouse_connect
 from django.utils.functional import cached_property
 
+from zentral.utils.clickhouse import get_clickhouse_client
 from zentral.utils.time import naive_utcnow
 
 from ..base import BaseDistributedQueryResultStore, DistributedQueryResultRow
@@ -15,21 +15,6 @@ logger = logging.getLogger("zentral.contrib.osquery.distributed_query_result_sto
 
 class DistributedQueryResultStore(BaseDistributedQueryResultStore):
     identifier_regex = re.compile(r"^[a-zA-Z_][0-9a-zA-Z_]*$")
-    client_kwargs_keys = (
-        # connection
-        "host",
-        "port",
-        "secure",
-        "verify",
-        "compress",
-        # auth
-        "username",
-        "database",
-        "password",
-        # timeouts
-        "connect_timeout",
-        "send_receive_timeout",
-    )
     default_database = "default"
     default_table_name = "osquery_distributed_query_results"
     column_names = (
@@ -42,25 +27,21 @@ class DistributedQueryResultStore(BaseDistributedQueryResultStore):
 
     def __init__(self, config_d, ttl_days):
         super().__init__(config_d, ttl_days)
-        self.client_kwargs = {
-            k: config_d[k]
-            for k in self.client_kwargs_keys
-            if config_d.get(k) is not None
-        }
-        self.client_kwargs.setdefault("database", self.default_database)
-        self.database = self.client_kwargs["database"]
+        self.database = config_d.get("database") or self.default_database
         self.table_name = config_d.get("table_name", self.default_table_name)
         for identifier in (self.database, self.table_name):
             if not self.identifier_regex.match(identifier):
                 raise ValueError(f"Invalid identifier: {identifier}")
         self._configured = False
 
+    def _get_client_kwarg(self, key):
+        if key == "database":
+            return self.database
+        return self.config_d.get(key)
+
     @cached_property
     def client(self):
-        return clickhouse_connect.get_client(
-            autogenerate_session_id=False,
-            **self.client_kwargs
-        )
+        return get_clickhouse_client(self._get_client_kwarg)
 
     def migrate(self):
         migration_filepath = os.path.join(

--- a/zentral/contrib/osquery/distributed_query_result_stores/postgres.py
+++ b/zentral/contrib/osquery/distributed_query_result_stores/postgres.py
@@ -1,0 +1,100 @@
+import logging
+
+from django.db import IntegrityError, connection, transaction
+from django.db.models import Count, Q
+
+from zentral.utils.time import naive_utcnow
+
+from .base import BaseDistributedQueryResultStore
+
+logger = logging.getLogger("zentral.contrib.osquery.distributed_query_result_stores.postgres")
+
+
+class DistributedQueryResultStore(BaseDistributedQueryResultStore):
+    insert_batch_size = 100
+    delete_batch_size = 10000
+
+    @staticmethod
+    def _result_qs(distributed_query_pk, q=None):
+        from zentral.contrib.osquery.models import DistributedQueryResult
+        qs = DistributedQueryResult.objects.filter(distributed_query_id=distributed_query_pk)
+        if q:
+            qs = qs.filter(Q(serial_number__icontains=q) | Q(row__icontains=q))
+        return qs
+
+    def bulk_create(self, distributed_query_pk, serial_number, rows):
+        from zentral.contrib.osquery.models import DistributedQuery, DistributedQueryResult
+        # the distributed query may have been deleted before the results were processed
+        if not DistributedQuery.objects.filter(pk=distributed_query_pk).exists():
+            logger.warning("Distributed query %s not found, dropping results for machine %s",
+                           distributed_query_pk, serial_number)
+            return
+        results = [
+            DistributedQueryResult(
+                distributed_query_id=distributed_query_pk,
+                serial_number=serial_number,
+                row=row
+            )
+            for row in rows
+        ]
+        try:
+            with transaction.atomic():
+                DistributedQueryResult.objects.bulk_create(results, self.insert_batch_size)
+        except IntegrityError:
+            # the distributed query may have been deleted while the results were being inserted.
+            # the FK constraint is deferred, so the error surfaces when exiting the atomic block.
+            if DistributedQuery.objects.filter(pk=distributed_query_pk).exists():
+                raise
+            logger.warning("Distributed query %s deleted, dropping results for machine %s",
+                           distributed_query_pk, serial_number)
+
+    def get_result_count(self, distributed_query_pk, q=None):
+        return self._result_qs(distributed_query_pk, q).count()
+
+    def get_result_counts(self, distributed_query_pks):
+        from zentral.contrib.osquery.models import DistributedQueryResult
+        return dict(
+            DistributedQueryResult.objects.filter(distributed_query_id__in=distributed_query_pks)
+                                          .values_list("distributed_query_id")
+                                          .annotate(count=Count("pk"))
+        )
+
+    def get_results(self, distributed_query_pk, q, offset, limit):
+        return list(self._result_qs(distributed_query_pk, q).order_by("-pk")[offset:offset + limit])
+
+    def get_result_columns(self, distributed_query_pk):
+        query = (
+            "select distinct jsonb_object_keys(row) as col "
+            "from osquery_distributedqueryresult where distributed_query_id = %s "
+            "order by col"
+        )
+        cursor = connection.cursor()
+        cursor.execute(query, [distributed_query_pk])
+        return [t[0] for t in cursor.fetchall()]
+
+    def iter_results(self, distributed_query_pk):
+        for result in self._result_qs(distributed_query_pk).iterator():
+            yield result.serial_number, result.row
+
+    def delete_results(self, distributed_query_pk):
+        # results are deleted with the distributed query via the FK cascade
+        pass
+
+    def delete_expired_results(self, cutoff):
+        from zentral.contrib.osquery.models import DistributedQuery, DistributedQueryResult
+        # only the results of the runs that are no longer collecting results are deleted
+        distributed_query_pks = list(
+            DistributedQuery.objects.filter(created_at__lt=cutoff, valid_until__lt=naive_utcnow())
+                                    .values_list("pk", flat=True)
+        )
+        total_deleted = 0
+        while True:
+            result_pks = list(
+                DistributedQueryResult.objects.filter(distributed_query__in=distributed_query_pks)
+                                              .values_list("pk", flat=True)[:self.delete_batch_size]
+            )
+            if not result_pks:
+                break
+            deleted, _ = DistributedQueryResult.objects.filter(pk__in=result_pks).delete()
+            total_deleted += deleted
+        return total_deleted

--- a/zentral/contrib/osquery/events/__init__.py
+++ b/zentral/contrib/osquery/events/__init__.py
@@ -1,10 +1,16 @@
+import json
 import logging
 import uuid
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 
 from zentral.contrib.osquery.compliance_checks import ComplianceCheckStatusAggregator
 from zentral.contrib.osquery.models import EnrolledMachine, PackQuery, QueryType, parse_result_name
 from zentral.contrib.osquery.tags import TagUpdateAggregator
 from zentral.core.events.base import BaseEvent, EventMetadata, EventRequest, register_event_type
+from zentral.core.queues import queues
+from zentral.utils.json import remove_null_character
 from zentral.utils.time import naive_utcfromtimestamp
 
 logger = logging.getLogger('zentral.contrib.osquery.events')
@@ -277,6 +283,33 @@ def post_results(msn, results, request):
                 tag_update_agg.add_result(query_pk, query_version, event_time, snapshot)
     cc_status_agg.commit_and_post_events()
     tag_update_agg.commit()
+
+
+# Distributed query results
+
+
+DISTRIBUTED_QUERY_RESULTS_ROUTING_KEY = "osquery_distributed_query_results"
+# conservative inline limit: the SQS send thread posts batches of up to 10 messages with a 1MiB
+# total payload limit, and the JSON escaping of the non-ASCII characters can inflate the posted
+# message up to ~3x compared to the raw request body used to make the inline decision
+DISTRIBUTED_QUERY_RESULT_INLINE_MAX_SIZE = 32 * 2**10
+
+
+def post_distributed_query_result_rows(distributed_query_pk, serial_number, rows, inline):
+    # a machine answers a distributed query only once, and an osquery agent re-sends the same
+    # results unchanged, so (distributed_query_pk, serial_number, row index) identifies a row,
+    # and the duplicates can be eliminated by the result store.
+    raw_event = {"distributed_query_pk": distributed_query_pk,
+                 "serial_number": serial_number}
+    rows = remove_null_character(rows)
+    if inline:
+        raw_event["rows"] = rows
+    else:
+        raw_event["filepath"] = default_storage.save(
+            f"osquery/distributed_query_results/{distributed_query_pk}/{uuid.uuid4()}.json",
+            ContentFile(json.dumps(rows).encode("utf-8"))
+        )
+    queues.post_raw_event(DISTRIBUTED_QUERY_RESULTS_ROUTING_KEY, raw_event)
 
 
 # Utility function for the audit trail

--- a/zentral/contrib/osquery/management/commands/cleanup_osquery_distributed_query_results.py
+++ b/zentral/contrib/osquery/management/commands/cleanup_osquery_distributed_query_results.py
@@ -1,0 +1,38 @@
+import logging
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+
+from zentral.contrib.osquery.distributed_query_result_stores import get_distributed_query_result_store
+from zentral.utils.time import naive_utcnow
+
+logger = logging.getLogger(
+    "zentral.contrib.osquery.management.commands.cleanup_osquery_distributed_query_results"
+)
+
+
+class Command(BaseCommand):
+    help = "Cleanup the expired osquery distributed query results"
+
+    def add_arguments(self, parser):
+        parser.add_argument("-q", "--quiet", action="store_true", help="no output if no errors")
+        parser.add_argument(
+            "--days", type=int,
+            help="number of days to keep, defaults to the distributed_query_results_ttl_days app setting"
+        )
+
+    def handle(self, *args, **options):
+        quiet = options["quiet"] or options["verbosity"] == 0
+        store = get_distributed_query_result_store()
+        days = options.get("days") or store.ttl_days
+        if not days or days < 1:
+            raise CommandError("No number of days to keep")
+        cutoff = naive_utcnow() - timedelta(days=days)
+        if not quiet:
+            self.stdout.write(f"cutoff: {cutoff.isoformat()}")
+        deleted = store.delete_expired_results(cutoff)
+        if not quiet:
+            if deleted is None:
+                self.stdout.write("results deletion submitted")
+            else:
+                self.stdout.write(f"{deleted} result{'' if deleted == 1 else 's'} deleted")

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -3,7 +3,7 @@ import logging
 import os.path
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MinValueValidator, MaxValueValidator, RegexValidator
-from django.db import models, connection
+from django.db import models
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
@@ -649,14 +649,15 @@ class DistributedQuery(models.Model):
             return (0, 0, 0)
 
     def result_columns(self):
-        query = (
-            "select distinct jsonb_object_keys(row) as col "
-            "from osquery_distributedqueryresult where distributed_query_id = %s "
-            "order by col"
-        )
-        cursor = connection.cursor()
-        cursor.execute(query, [self.pk])
-        return [t[0] for t in cursor.fetchall()]
+        from zentral.contrib.osquery.distributed_query_result_stores import get_distributed_query_result_store
+        return get_distributed_query_result_store().get_result_columns(self.pk)
+
+    def delete(self, *args, **kwargs):
+        from zentral.contrib.osquery.distributed_query_result_stores import get_distributed_query_result_store
+        distributed_query_pk = self.pk
+        result = super().delete(*args, **kwargs)
+        get_distributed_query_result_store().delete_results(distributed_query_pk)
+        return result
 
 
 class DistributedQueryMachine(models.Model):

--- a/zentral/contrib/osquery/preprocessors.py
+++ b/zentral/contrib/osquery/preprocessors.py
@@ -1,0 +1,55 @@
+import json
+import logging
+
+from django.core.files.storage import default_storage
+
+from .distributed_query_result_stores import get_distributed_query_result_store
+from .events import DISTRIBUTED_QUERY_RESULTS_ROUTING_KEY
+
+logger = logging.getLogger("zentral.contrib.osquery.preprocessors")
+
+
+class DistributedQueryResultsPreprocessor:
+    routing_key = DISTRIBUTED_QUERY_RESULTS_ROUTING_KEY
+
+    def process_raw_event(self, raw_event):
+        try:
+            distributed_query_pk = int(raw_event["distributed_query_pk"])
+            serial_number = raw_event["serial_number"]
+            rows = raw_event.get("rows")
+            filepath = raw_event.get("filepath")
+            if rows is None and not filepath:
+                raise KeyError("missing rows and filepath")
+        except (KeyError, TypeError, ValueError):
+            logger.exception("Invalid distributed query result raw event")
+            return []
+        if rows is None:
+            try:
+                with default_storage.open(filepath) as f:
+                    rows = json.load(f)
+            except FileNotFoundError:
+                # the file may have already been processed and deleted (queue re-delivery)
+                logger.error("Missing distributed query %s result file %s", distributed_query_pk, filepath)
+                return []
+            except Exception:
+                logger.exception("Could not read distributed query %s result file %s",
+                                 distributed_query_pk, filepath)
+                return []
+        try:
+            get_distributed_query_result_store().bulk_create(distributed_query_pk, serial_number, rows)
+        except Exception:
+            logger.exception("Could not store distributed query %s results for machine %s",
+                             distributed_query_pk, serial_number)
+            return []
+        if filepath:
+            try:
+                default_storage.delete(filepath)
+            except Exception:
+                # the bucket lifecycle policy is the fallback
+                logger.exception("Could not delete distributed query %s result file %s",
+                                 distributed_query_pk, filepath)
+        return []
+
+
+def get_preprocessors():
+    yield DistributedQueryResultsPreprocessor()

--- a/zentral/contrib/osquery/public_views.py
+++ b/zentral/contrib/osquery/public_views.py
@@ -22,6 +22,8 @@ from zentral.contrib.inventory.utils import (
 from zentral.contrib.osquery.compliance_checks import ComplianceCheckStatusAggregator
 from zentral.contrib.osquery.conf import INVENTORY_QUERY_NAME, build_osquery_conf
 from zentral.contrib.osquery.events import (
+    DISTRIBUTED_QUERY_RESULT_INLINE_MAX_SIZE,
+    post_distributed_query_result_rows,
     post_enrollment_event,
     post_file_carve_events,
     post_request_event,
@@ -31,7 +33,6 @@ from zentral.contrib.osquery.events import (
 from zentral.contrib.osquery.models import (
     DistributedQuery,
     DistributedQueryMachine,
-    DistributedQueryResult,
     EnrolledMachine,
     FileCarvingBlock,
     FileCarvingSession,
@@ -42,7 +43,6 @@ from zentral.contrib.osquery.tags import TagUpdateAggregator
 from zentral.contrib.osquery.tasks import build_file_carving_session_archive
 from zentral.core.events.base import post_machine_conflict_event
 from zentral.utils.http import user_agent_and_ip_address_from_request
-from zentral.utils.json import remove_null_character
 from zentral.utils.time import naive_utcfromtimestamp, naive_utcnow
 
 from .views.utils import (
@@ -65,10 +65,12 @@ class BaseJsonPostView(View):
     def post(self, request, *args, **kwargs):
         try:
             if request.META.get("HTTP_CONTENT_ENCODING") == "gzip":
-                self.data = json.load(GzipFile(fileobj=request))
+                payload = GzipFile(fileobj=request).read()
             else:
-                self.data = json.loads(request.body)
-        except ValueError:
+                payload = request.body
+            self.data_size = len(payload)
+            self.data = json.loads(payload)
+        except (OSError, ValueError):
             raise SuspiciousOperation("Could not read JSON data")
         self.user_agent, self.ip = user_agent_and_ip_address_from_request(request)
         try:
@@ -363,21 +365,16 @@ class DistributedWriteView(BaseNodeView):
                             setattr(dqm, stat_attr, val)
             dqm.save()
 
-        # save_results
-        dq_results = (
-            DistributedQueryResult(
-                distributed_query=dqm.distributed_query,
-                serial_number=self.machine.serial_number,
-                row=remove_null_character(row)
-            )
-            for dqm_pk, dqm in dqm_cache.items()
-            for row in results.get(dqm_pk, [])
-        )
-        while True:
-            batch = list(islice(dq_results, self.batch_size))
-            if not batch:
-                break
-            DistributedQueryResult.objects.bulk_create(batch, self.batch_size)
+        # post results to the queue, they are stored asynchronously by the preprocess workers.
+        # the decompressed request body size is an upper bound on the serialized size of each
+        # result set, so all of them can be posted inline when it is small enough.
+        inline_results = self.data_size <= DISTRIBUTED_QUERY_RESULT_INLINE_MAX_SIZE
+        for dqm_pk, dqm in dqm_cache.items():
+            dqm_results = results.get(dqm_pk)
+            if dqm_results:
+                post_distributed_query_result_rows(
+                    dqm.distributed_query_id, self.machine.serial_number, dqm_results, inline_results
+                )
 
         # process file carving
         for dqm_pk, dqm_results in results.items():

--- a/zentral/contrib/osquery/tasks.py
+++ b/zentral/contrib/osquery/tasks.py
@@ -14,6 +14,7 @@ from zentral.core.events import event_cls_from_type
 from zentral.utils.time import naive_utcnow
 from zentral.utils.xlsx import add_worksheet
 
+from .distributed_query_result_stores import get_distributed_query_result_store
 from .models import DistributedQuery, FileCarvingSession
 
 logger = logging.getLogger("zentral.contrib.osquery.tasks")
@@ -62,10 +63,11 @@ def _export_dqr_to_tmp_csv_file(distributed_query):
         csv_w = csv.writer(tmp_f)
         columns = distributed_query.result_columns()
         csv_w.writerow(["serial number"] + columns)
-        for dqr in distributed_query.distributedqueryresult_set.iterator():
-            row = [dqr.serial_number]
+        store = get_distributed_query_result_store()
+        for serial_number, dqr_row in store.iter_results(distributed_query.pk):
+            row = [serial_number]
             for column in columns:
-                row.append(dqr.row.get(column) or "")
+                row.append(dqr_row.get(column) or "")
             csv_w.writerow(row)
     return tmp_fp
 
@@ -73,8 +75,9 @@ def _export_dqr_to_tmp_csv_file(distributed_query):
 def _export_dqr_to_tmp_ndjson_file(distributed_query):
     tmp_fh, tmp_fp = tempfile.mkstemp()
     with os.fdopen(tmp_fh, "w") as tmp_f:
-        for dqr in distributed_query.distributedqueryresult_set.iterator():
-            json.dump({"serial_number": dqr.serial_number, "row": dqr.row}, tmp_f)
+        store = get_distributed_query_result_store()
+        for serial_number, dqr_row in store.iter_results(distributed_query.pk):
+            json.dump({"serial_number": serial_number, "row": dqr_row}, tmp_f)
             tmp_f.write("\n")
     return tmp_fp
 
@@ -91,13 +94,14 @@ def _export_dqr_to_tmp_xlsx_file(distributed_query):
             col_idx += 1
             worksheet.write_string(row_idx, col_idx, column)
         worksheet.freeze_panes(1, 0)
-        for dqr in distributed_query.distributedqueryresult_set.iterator():
+        store = get_distributed_query_result_store()
+        for serial_number, dqr_row in store.iter_results(distributed_query.pk):
             row_idx += 1
             col_idx = 0
-            worksheet.write_string(row_idx, col_idx, dqr.serial_number)
+            worksheet.write_string(row_idx, col_idx, serial_number)
             for column in columns:
                 col_idx += 1
-                val = dqr.row.get(column)
+                val = dqr_row.get(column)
                 if not val:
                     worksheet.write_blank(row_idx, col_idx, "")
                 elif isinstance(val, (int, float)):

--- a/zentral/contrib/osquery/views/distributed_queries.py
+++ b/zentral/contrib/osquery/views/distributed_queries.py
@@ -4,13 +4,14 @@ import math
 from urllib.parse import urlencode
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import connection
-from django.db.models import Count, Q
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from zentral.utils.sql import tables_in_query
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView, TemplateView
+from zentral.contrib.osquery.distributed_query_result_stores import get_distributed_query_result_store
 from zentral.contrib.osquery.forms import DistributedQueryForm, DistributedQueryMachineSearchForm
-from zentral.contrib.osquery.models import (DistributedQuery, DistributedQueryMachine, DistributedQueryResult,
+from zentral.contrib.osquery.models import (DistributedQuery, DistributedQueryMachine,
                                             FileCarvingSession, Query)
 from zentral.utils.views import UserPaginationListView, UserPaginationMixin
 
@@ -31,8 +32,6 @@ class DistributedQueryListView(PermissionRequiredMixin, UserPaginationMixin, Tem
                 "select dq.id, dq.sql, dq.query_id, q.name as query_name,"
                 "(select count(*) from osquery_distributedquerymachine where distributed_query_id=dq.id) "
                 "as machine_count,"
-                "(select count(*) from osquery_distributedqueryresult where distributed_query_id=dq.id) "
-                "as result_count,"
                 "(select count(*) from osquery_filecarvingsession where distributed_query_id=dq.id) "
                 "as file_carving_session_count "
                 "from osquery_distributedquery dq "
@@ -41,10 +40,17 @@ class DistributedQueryListView(PermissionRequiredMixin, UserPaginationMixin, Tem
                 [self.get_paginate_by(), offset]
             )
             columns = [col.name for col in c.description]
+            distributed_queries = []
             for row in c.fetchall():
                 dq = dict(zip(columns, row))
                 dq["tables"] = sorted(tables_in_query(dq["sql"]))
-                yield dq
+                distributed_queries.append(dq)
+        result_counts = get_distributed_query_result_store().get_result_counts(
+            [dq["id"] for dq in distributed_queries]
+        )
+        for dq in distributed_queries:
+            dq["result_count"] = result_counts.get(dq["id"], 0)
+            yield dq
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -109,7 +115,7 @@ class DistributedQueryView(PermissionRequiredMixin, DetailView):
         ctx = super().get_context_data(**kwargs)
         ctx["query"] = self.object.query
         ctx["dqm_count"] = self.object.distributedquerymachine_set.count()
-        ctx["result_count"] = self.object.distributedqueryresult_set.count()
+        ctx["result_count"] = get_distributed_query_result_store().get_result_count(self.object.pk)
         ctx["file_carving_session_count"] = self.object.filecarvingsession_set.count()
         return ctx
 
@@ -133,7 +139,7 @@ class DeleteDistributedQueryView(PermissionRequiredMixin, DeleteView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["machine_count"] = self.object.distributedquerymachine_set.count()
-        ctx["result_count"] = self.object.distributedqueryresult_set.count()
+        ctx["result_count"] = get_distributed_query_result_store().get_result_count(self.object.pk)
         ctx["file_carving_session_count"] = self.object.filecarvingsession_set.count()
         return ctx
 
@@ -165,18 +171,30 @@ class DistributedQueryMachineListView(PermissionRequiredMixin, UserPaginationLis
         return ctx
 
 
+class DistributedQueryResultList:
+    def __init__(self, store, distributed_query_pk, q):
+        self.store = store
+        self.distributed_query_pk = distributed_query_pk
+        self.q = q
+        self._count = None
+
+    def count(self):
+        if self._count is None:
+            self._count = self.store.get_result_count(self.distributed_query_pk, self.q)
+        return self._count
+
+    def __getitem__(self, k):
+        offset = k.start or 0
+        return self.store.get_results(self.distributed_query_pk, self.q, offset, k.stop - offset)
+
+
 class DistributedQueryResultListView(PermissionRequiredMixin, UserPaginationListView):
     permission_required = "osquery.view_distributedqueryresult"
-    model = DistributedQueryResult
+    template_name = "osquery/distributedqueryresult_list.html"
 
     def get_queryset(self):
         self.distributed_query = get_object_or_404(
             DistributedQuery.objects.select_related("query"), pk=self.kwargs["pk"]
-        )
-        qs = (
-            super().get_queryset()
-                   .filter(distributed_query=self.distributed_query)
-                   .order_by("-pk")
         )
         self.is_search = False
         self.search_q = None
@@ -186,8 +204,9 @@ class DistributedQueryResultListView(PermissionRequiredMixin, UserPaginationList
             if q:
                 self.search_q = q
                 self.is_search = True
-                qs = qs.filter(Q(serial_number__icontains=q) | Q(row__icontains=q))
-        return qs
+        return DistributedQueryResultList(
+            get_distributed_query_result_store(), self.distributed_query.pk, self.search_q
+        )
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)

--- a/zentral/core/stores/backends/clickhouse/__init__.py
+++ b/zentral/core/stores/backends/clickhouse/__init__.py
@@ -2,7 +2,6 @@ import logging
 import os
 from datetime import timedelta
 
-import clickhouse_connect
 from django.utils.functional import cached_property
 from django.utils.timezone import is_naive, make_aware, make_naive
 from kombu.utils import json
@@ -10,28 +9,14 @@ from rest_framework import serializers
 
 from zentral.core.events import event_from_event_d, event_types
 from zentral.core.stores.backends.base import BaseStore, serialize_needles
+from zentral.utils.clickhouse import CLIENT_KWARGS_KEYS, get_clickhouse_client
 from zentral.utils.time import naive_utcnow
 
 logger = logging.getLogger('zentral.core.stores.backends.clickhouse')
 
 
 class ClickHouseStore(BaseStore):
-    client_kwargs_keys = (
-        # connection
-        "host",
-        "port",
-        "secure",
-        "verify",
-        "compress",
-        # auth
-        "username",
-        "database",
-        "password",
-        "access_token",
-        # timeouts
-        "connect_timeout",
-        "send_receive_timeout",
-    )
+    client_kwargs_keys = CLIENT_KWARGS_KEYS
     kwargs_keys = client_kwargs_keys + (
         # storage
         "table_engine",
@@ -69,11 +54,7 @@ class ClickHouseStore(BaseStore):
 
     @cached_property
     def client(self):
-        return clickhouse_connect.get_client(
-            autogenerate_session_id=False,  # we do run queries concurrently when querying the database
-            **{k: getattr(self, k)
-               for k in self.client_kwargs_keys}
-        )
+        return get_clickhouse_client(lambda k: getattr(self, k))
 
     def migrate(self):
         # TODO: much to be done here in the future!

--- a/zentral/utils/clickhouse.py
+++ b/zentral/utils/clickhouse.py
@@ -1,0 +1,30 @@
+import clickhouse_connect
+
+CLIENT_KWARGS_KEYS = (
+    # connection
+    "host",
+    "port",
+    "secure",
+    "verify",
+    "compress",
+    # auth
+    "username",
+    "database",
+    "password",
+    "access_token",
+    # timeouts
+    "connect_timeout",
+    "send_receive_timeout",
+)
+
+
+def get_clickhouse_client(get_kwarg):
+    client_kwargs = {}
+    for key in CLIENT_KWARGS_KEYS:
+        val = get_kwarg(key)
+        if val is not None:
+            client_kwargs[key] = val
+    return clickhouse_connect.get_client(
+        autogenerate_session_id=False,  # we do run queries concurrently
+        **client_kwargs
+    )


### PR DESCRIPTION
## What

The osquery distributed query results are no longer written synchronously to PostgreSQL by the `distributed_write` view. They are posted to the queue as raw events, and stored asynchronously by the preprocess workers in a configurable store:

* **PostgreSQL** (default) — the existing table, no schema change, no configuration change required. Existing deployments and their stored results are unaffected.
* **ClickHouse** — a new backend to take the load off PostgreSQL.

Based on the decompressed request body size (≤ 32KiB), the result rows are either inlined in the raw events, or written to the default Django storage under the `osquery/distributed_query_results/` prefix and referenced in the raw events, to stay within the broker message size limits (SQS posts batches of up to 10 messages with a 1MiB total limit, and JSON escaping can inflate the messages vs. the raw body). The files are deleted once processed; a lifecycle policy on the prefix is the recommended fallback.

## Deduplication

A machine answers a distributed query only once (`DistributedQueryMachine` unique constraint), and an osquery agent re-sends the same results unchanged when a write fails (verified in the osquery source: results are kept in memory and re-posted in full, no chunking, no size limit). So `(distributed_query, serial_number, row_index)` identifies a result row, and duplicates from re-sent payloads or re-delivered queue messages are eliminated by the store: insert deduplication token + ReplacingMergeTree in ClickHouse.

## Retention

The `distributed_query_results_ttl_days` app setting (default `90`, minimum `1` — mandatory, keep-forever is not sustainable) drives both backends:

* ClickHouse: table TTL, applied at table creation (static DDL, same idiom as the `zentral_events` table).
* PostgreSQL: new `cleanup_osquery_distributed_query_results` management command (batched deletes, run-age semantics, to be scheduled with cron).

## Also included

* `Factor out the ClickHouse client building`: the event store backend and the new store share the connection options and client construction in `zentral.utils.clickhouse`.
* App config follows the store provisioning convention: `backend` + `<backend>_kwargs`.
* Docs in `docs/apps/osquery.md`.

## Notes for the reviewer

* Failed result messages are dropped with an error log (no retry): distributed query results are point-in-time and re-runnable, and retry loops on poison messages are worse.
* The preprocess workers must be updated before or with the web processes when deploying: older workers ack and drop the new routing key (handled operationally, deliberately not in the public docs).
* A configured ClickHouse store is a hard read dependency for the osquery run pages (same status as PostgreSQL today).
* Existing results are not migrated when switching backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)