### PR TITLE
Answer the santactl doctor preflight probe gracefully

### DIFF
--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -21,6 +21,7 @@ from zentral.contrib.santa.models import (
     Target,
     TargetCounter,
 )
+from zentral.contrib.santa.public_views import BaseSyncView
 from zentral.core.incidents.models import Severity
 from zentral.utils.time import naive_utcnow
 
@@ -231,6 +232,40 @@ class SantaAPIViewsTestCase(TestCase):
         url = reverse("santa_public:deprecated_preflight", args=("bad_secret", hardware_uuid))
         response = self.client.post(url, data=data, content_type="application/json")
         self.assertEqual(response.status_code, 403)
+
+    # doctor preflight probe (santactl doctor)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_preflight_doctor_test(self, post_event):
+        response = self.post_as_json("preflight", "santactl-doctor-test", {})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {})
+        # the probe is not a real machine: nothing enrolled, no event posted
+        post_event.assert_not_called()
+        self.assertEqual(EnrolledMachine.objects.count(), 1)  # only the one from setUpTestData
+
+    def test_preflight_doctor_test_no_auth(self):
+        response = self.client.post(reverse("santa_public:preflight", args=("santactl-doctor-test",)))
+        self.assertEqual(response.status_code, 401)
+
+    def test_preflight_doctor_test_bad_secret(self):
+        response = self.post_as_json("preflight", "santactl-doctor-test", {}, enrollment_secret="bad_secret")
+        self.assertEqual(response.status_code, 403)
+
+    def test_preflight_doctor_test_no_mtls(self):
+        self.configuration.client_certificate_auth = True
+        self.configuration.save()
+        response = self.post_as_json("preflight", "santactl-doctor-test", {})
+        self.assertEqual(response.status_code, 403)
+
+    def test_doctor_test_machine_id_rejected_outside_preflight(self):
+        # the exception is scoped to preflight; other sync endpoints still reject the sentinel id
+        response = self.post_as_json("ruledownload", "santactl-doctor-test", {})
+        self.assertEqual(response.status_code, 403)
+
+    def test_base_sync_view_doctor_test_response_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            BaseSyncView().doctor_test_response()
 
     def test_preflight_default_usb_options(self):
         data, serial_number, hardware_uuid = self._get_preflight_data()

--- a/zentral/contrib/santa/public_views.py
+++ b/zentral/contrib/santa/public_views.py
@@ -25,6 +25,8 @@ logger = logging.getLogger('zentral.contrib.santa.views.api')
 
 class BaseSyncView(View):
     use_enrolled_machine_cache = True
+    allow_doctor_test = False
+    doctor_test_machine_id = "santactl-doctor-test"
 
     def _get_enrollment_secret_secret(self):
         try:
@@ -79,19 +81,25 @@ class BaseSyncView(View):
                 raise PermissionDenied("Missing client certificate")
             return enrolled_machine
 
+    def doctor_test_response(self):
+        raise NotImplementedError
+
     def post(self, request, *args, **kwargs):
         # secret
         self.enrollment_secret_secret = self._get_enrollment_secret_secret()
         if not self.enrollment_secret_secret:
             return JsonResponse({"detail": "Unauthorized"}, status=401)
 
+        self.client_cert_dn = self._get_client_cert_dn()
+
+        if self.allow_doctor_test and kwargs["machine_id"] == self.doctor_test_machine_id:
+            return self.doctor_test_response()
+
         # machine ID
         try:
             self.hardware_uuid = str(UUID(kwargs["machine_id"]))
         except ValueError:
             raise PermissionDenied("Invalid machine id")
-
-        self.client_cert_dn = self._get_client_cert_dn()
 
         self.user_agent, self.ip = user_agent_and_ip_address_from_request(request)
 
@@ -121,6 +129,21 @@ class BaseSyncView(View):
 
 class PreflightView(BaseSyncView):
     use_enrolled_machine_cache = False
+    allow_doctor_test = True
+
+    def doctor_test_response(self):
+        # The probe uses a sentinel machine id that is never enrolled, so we cannot validate a
+        # machine. We do confirm the enrollment secret (and client certificate, if required) so
+        # that a misconfigured client still gets a meaningful failure from doctor.
+        try:
+            enrollment = Enrollment.objects.select_related("configuration").get(
+                secret__secret=self.enrollment_secret_secret
+            )
+        except Enrollment.DoesNotExist:
+            raise PermissionDenied("Unknown enrollment secret")
+        if enrollment.configuration.client_certificate_auth and not self.client_cert_dn:
+            raise PermissionDenied("Missing client certificate")
+        return JsonResponse({})
 
     def _get_primary_user(self):
         # primary user


### PR DESCRIPTION
## Summary

`santactl doctor` validates the sync connection by sending a `POST` to `preflight/santactl-doctor-test` — a fixed sentinel machine id that is **not** a real machine UUID — and judges the result purely by HTTP status (200 or 400 → success). See northpolesec/santa: [`SNTSyncManager.mm`](https://github.com/northpolesec/santa/blob/main/Source/santasyncservice/SNTSyncManager.mm) (builds the request) and [`SNTCommandDoctor.mm`](https://github.com/northpolesec/santa/blob/main/Source/santactl/Commands/SNTCommandDoctor.mm) (`validateSync`, status handling).

The probe is sent through the configured sync session, so it carries our `Zentral-Authorization: Bearer <secret>` header and routes to `PreflightView`. But `BaseSyncView.post` parses the machine id as a UUID before anything else, so the sentinel raised `PermissionDenied` → **HTTP 403**. Santa treats 403 as a failure, so `santactl doctor` reported a broken sync connection even against a healthy, correctly-authenticated server.

## Change

- Intercept the `santactl-doctor-test` sentinel in the preflight view **before** the UUID parse (gated to preflight only via `allow_doctor_test`).
- `doctor_test_response()` still validates the enrollment secret — and the client certificate when mTLS is required — then returns **HTTP 200 `{}`**. No enrollment, no machine snapshot, no event is produced (the sentinel is never a real machine).
- Result: a correctly configured client passes (`[+] Preflight request succeeded`); a misconfigured one still gets a meaningful failure (401/403) rather than a false OK.
- The other sync endpoints (ruledownload/eventupload/postflight) keep rejecting the sentinel.

## Tests

Added 5 tests to `tests/santa/test_santa_api_views.py`:
- probe with valid secret → 200 `{}`, no machine created, no event posted
- probe with no auth → 401
- probe with bad secret → 403
- probe with mTLS required but no client cert → 403
- sentinel rejected on a non-preflight endpoint (ruledownload → 403)

Full module passes (`tests.santa.test_santa_api_views`, 52 tests OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)