### PR TITLE
Skip the Munki enrollment package when Turbo is installed

### DIFF
--- a/zentral/contrib/monolith/utils.py
+++ b/zentral/contrib/monolith/utils.py
@@ -22,6 +22,8 @@ def make_package_info(builder, manifest_enrollment_package, package_content):
     installed_size = installer_item_size * 10  # TODO: bug
     installcheck_script = (
         '#!/bin/bash\n'
+        # do not install if the Turbo agent is present
+        '[[ -d "/opt/zentral/lib/Turbo.app" ]] && exit 1\n'
         f'ENROLLMENT_PLIST="/usr/local/zentral/{builder.local_subfolder}/enrollment.plist"\n'
         'PLUTIL="/usr/bin/plutil"\n'
         # if no enrollment, install


### PR DESCRIPTION
## What

Adds a guard to the Munki manifest enrollment package's `installcheck_script` (generated in `make_package_info`, [`zentral/contrib/monolith/utils.py`](https://github.com/zentralopensource/zentral/blob/main/zentral/contrib/monolith/utils.py)) so Munki does **not** install the enrollment package when the Turbo agent is already on disk at `/opt/zentral/lib/Turbo.app`.

## How

A single line is inserted as the first executable statement of the script, right after the shebang:

```bash
[[ -d "/opt/zentral/lib/Turbo.app" ]] && exit 1
```

Munki's `installcheck_script` convention is **exit 0 = install needed**, **non-zero = skip**. Placing the check before the existing "no enrollment plist → exit 0" line ensures Turbo's presence short-circuits every other path, including machines that were never enrolled. `-d` is used because `Turbo.app` is an app bundle (a directory).

## Impact

- Applies to all monolith manifest enrollment packages, but is inert wherever `Turbo.app` is absent — no behavior change for non-Turbo fleets.
- `pkg_info` is stored per `ManifestEnrollmentPackage`; existing packages keep their old installcheck script until rebuilt (`build_manifest_enrollment_package`, e.g. via a version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)