### PR TITLE
Fix request-path thread-safety hazards (gthread prep)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -29,7 +29,7 @@ coverage==7.14.0
 cryptography==48.0.1
 decorator==5.1.1
 defusedxml==0.7.1
-Django==5.2.15
+Django==5.2.16
 django-filter==25.2
 django-redis==6.0.0
 django-storages==1.14.6

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -90,6 +90,7 @@ KNOWN_COMMANDS = {
     "gunicorn": ["gunicorn",
                  "--worker-tmp-dir", "/dev/shm",
                  "--error-logfile", "-",
+                 "--config", "/zentral/server/server/gunicorn_conf.py",
                  "--chdir", "/zentral/server", "server.wsgi"],
     "runworker": ["python", 'server/manage.py', 'runworker'],
     "runworkers": ["python", 'server/manage.py', 'runworkers'],

--- a/server/server/celery.py
+++ b/server/server/celery.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from celery import Celery, states
-from celery.signals import before_task_publish
+from celery.signals import before_task_publish, worker_process_shutdown, worker_shutdown
 from django.utils.functional import SimpleLazyObject
 
 
@@ -88,3 +88,18 @@ def create_task_result_on_publish(sender=None, headers=None, body=None, **kwargs
 
 
 before_task_publish.connect(create_task_result_on_publish, dispatch_uid='create_task_result_on_publish')
+
+
+# flush the event producer when a worker shuts down: the sender threads run in
+# the process that posts events (the prefork child, or the main process for the
+# solo/threads pools), so cover both shutdown signals. queues.stop() is a no-op
+# when nothing was started.
+
+
+def stop_event_queues(**kwargs):
+    from zentral.core.queues import queues
+    queues.stop()
+
+
+worker_process_shutdown.connect(stop_event_queues, dispatch_uid='stop_event_queues')
+worker_shutdown.connect(stop_event_queues, dispatch_uid='stop_event_queues')

--- a/server/server/gunicorn_conf.py
+++ b/server/server/gunicorn_conf.py
@@ -1,0 +1,14 @@
+import logging
+
+
+logger = logging.getLogger("server.gunicorn_conf")
+
+
+def worker_exit(server, worker):
+    # Flush buffered events before the worker goes away. Under threaded
+    # (gthread) workers the producer's own SIGTERM handler is never installed -
+    # post_event runs on a worker thread, not the main thread - so this hook is
+    # what stops the sender threads and drains their queues on worker recycle.
+    from zentral.core.queues import queues
+    logger.info("Worker exit: stop event queues")
+    queues.stop()

--- a/tests/core_queues/test_aws_sns_sqs.py
+++ b/tests/core_queues/test_aws_sns_sqs.py
@@ -1,6 +1,7 @@
 import json
 import os.path
 import queue
+import signal
 import threading
 from datetime import datetime
 from unittest.mock import Mock, patch
@@ -13,7 +14,7 @@ from django.utils.text import slugify
 from pyarrow.fs import LocalFileSystem
 
 from zentral.conf.config import ConfigDict
-from zentral.core.queues.backends.aws_sns_sqs.consumer import ConsumerProducerFinalThread
+from zentral.core.queues.backends.aws_sns_sqs.consumer import BaseConsumer, ConsumerProducerFinalThread
 from zentral.core.queues.backends.aws_sns_sqs.sns import SNSPublishThread
 from zentral.core.queues.backends.aws_sns_sqs.sqs import SQSSendThread
 from zentral.core.queues.backends.aws_sns_sqs import (
@@ -729,3 +730,34 @@ class AWSSNSSQSQueuesTestCase(TestCase):
         self.assertIs(args[2], eq._raw_events_queue)
         SQSSendThread.return_value.start.assert_called_once()
         self.assertEqual(eq._raw_events_queue.qsize(), 2)
+
+    @patch("zentral.core.queues.backends.aws_sns_sqs.setup_signal_handler")
+    def test_setup_graceful_stop_wires_signals_once(self, setup_signal_handler):
+        setup_signal_handler.return_value = {signal.SIGTERM: None, signal.SIGINT: None}
+        eq = self.get_queues()
+        self.assertIsNone(eq._stop_event)
+        self.assertEqual(eq._previous_signal_handlers, {})
+        eq._setup_graceful_stop()
+        self.assertIsInstance(eq._stop_event, threading.Event)
+        setup_signal_handler.assert_called_once_with(eq._graceful_stop)
+        self.assertEqual(eq._previous_signal_handlers, {signal.SIGTERM: None, signal.SIGINT: None})
+        # already set up: a second call must not re-wire the handlers
+        eq._setup_graceful_stop()
+        setup_signal_handler.assert_called_once()
+
+    # consumers
+
+    @patch("zentral.core.queues.backends.aws_sns_sqs.consumer.setup_signal_handler")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.consumer.SQSDeleteThread")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.consumer.SQSReceiveThread")
+    def test_base_consumer_run_wires_signal_handler(self, SQSReceiveThread, SQSDeleteThread, setup_signal_handler):
+        consumer = BaseConsumer("https://www.example.com/queue", {})
+        consumer.start_run_loop = Mock()
+        self.assertEqual(consumer.run(), 0)
+        setup_signal_handler.assert_called_once_with(consumer._handle_signal)
+        consumer.start_run_loop.assert_called_once()
+        # threads are started, then joined on the graceful-stop path
+        for thread in consumer._threads:
+            thread.start.assert_called_once()
+            thread.join.assert_called_once()
+        self.assertTrue(consumer.stop_event.is_set())

--- a/tests/core_queues/test_aws_sns_sqs.py
+++ b/tests/core_queues/test_aws_sns_sqs.py
@@ -688,3 +688,44 @@ class AWSSNSSQSQueuesTestCase(TestCase):
         args, kwargs = out_queue.put.call_args
         self.assertEqual(args[0][0], "receipt_handle_1")
         self.assertEqual(kwargs, {"timeout": 1})
+
+    # producers
+
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues._setup_graceful_stop")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues.setup_queue")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.SQSSendThread")
+    def test_post_event_starts_one_sender_thread(self, SQSSendThread, setup_queue, setup_graceful_stop):
+        setup_queue.return_value = "https://example.com/eq"
+        eq = self.get_queues()
+        event = Mock()
+        event.serialize.return_value = {"_zentral": {"type": "yolo"}}
+        eq.post_event(event)
+        # a second concurrent post must not start another sender thread
+        eq.post_event(event)
+        setup_graceful_stop.assert_called_once()
+        setup_queue.assert_called_once_with("events")
+        SQSSendThread.assert_called_once()
+        # the thread receives the instance queue, which is only published after
+        # the thread has been built and started
+        args, _ = SQSSendThread.call_args
+        self.assertIs(args[2], eq._events_queue)
+        SQSSendThread.return_value.start.assert_called_once()
+        self.assertEqual(eq._threads, [SQSSendThread.return_value])
+        self.assertEqual(eq._events_queue.qsize(), 2)
+
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues._setup_graceful_stop")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues.setup_queue")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.SQSSendThread")
+    def test_post_raw_event_starts_one_sender_thread(self, SQSSendThread, setup_queue, setup_graceful_stop):
+        setup_queue.return_value = "https://example.com/rq"
+        eq = self.get_queues()
+        eq.post_raw_event("routing-key", {"foo": "bar"})
+        # a second concurrent post must not start another sender thread
+        eq.post_raw_event("routing-key", {"foo": "bar"})
+        setup_graceful_stop.assert_called_once()
+        setup_queue.assert_called_once_with("raw-events")
+        SQSSendThread.assert_called_once()
+        args, _ = SQSSendThread.call_args
+        self.assertIs(args[2], eq._raw_events_queue)
+        SQSSendThread.return_value.start.assert_called_once()
+        self.assertEqual(eq._raw_events_queue.qsize(), 2)

--- a/tests/core_queues/test_google_pubsub.py
+++ b/tests/core_queues/test_google_pubsub.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock, patch
+from django.test import TestCase
+from zentral.core.queues.backends.google_pubsub import EventQueues
+
+
+class GooglePubSubQueuesTestCase(TestCase):
+    maxDiff = None
+
+    @staticmethod
+    def get_queues():
+        return EventQueues({
+            "topics": {
+                "raw_events": "projects/p/topics/raw-events",
+                "events": "projects/p/topics/events",
+                "enriched_events": "projects/p/topics/enriched-events",
+            }
+        })
+
+    def test_create_event_queues(self):
+        eq = self.get_queues()
+        self.assertEqual(eq.raw_events_topic, "projects/p/topics/raw-events")
+        self.assertEqual(eq.events_topic, "projects/p/topics/events")
+        self.assertEqual(eq.enriched_events_topic, "projects/p/topics/enriched-events")
+        self.assertIsNone(eq.credentials)
+        self.assertIsNone(eq.publisher_client)
+
+    @patch("zentral.core.queues.backends.google_pubsub.pubsub_v1.PublisherClient")
+    def test_publish_creates_publisher_client_once(self, PublisherClient):
+        eq = self.get_queues()
+        event = Mock()
+        event.event_type = "yolo"
+        event.serialize.return_value = {"_zentral": {"type": "yolo"}}
+        eq.post_event(event)
+        # concurrent publishes must reuse the single lazily-built PublisherClient
+        eq.post_raw_event("routing-key", {"foo": "bar"})
+        eq.post_event(event)
+        event.serialize.assert_called_with(machine_metadata=False)
+        PublisherClient.assert_called_once_with(credentials=None)
+        self.assertIs(eq.publisher_client, PublisherClient.return_value)
+        publish = PublisherClient.return_value.publish
+        self.assertEqual(publish.call_count, 3)
+        # topic + attributes per call; the payload is JSON-encoded bytes
+        self.assertEqual(
+            [c.args[0] for c in publish.call_args_list],
+            ["projects/p/topics/events", "projects/p/topics/raw-events", "projects/p/topics/events"]
+        )
+        self.assertIsInstance(publish.call_args_list[0].args[1], bytes)
+        self.assertEqual(publish.call_args_list[0].kwargs, {"event_type": "yolo"})
+        self.assertEqual(publish.call_args_list[1].kwargs, {"routing_key": "routing-key"})

--- a/tests/core_queues/test_google_pubsub.py
+++ b/tests/core_queues/test_google_pubsub.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 from django.test import TestCase
 from zentral.core.queues.backends.google_pubsub import EventQueues
+from zentral.core.queues.backends.google_pubsub.consumer import BaseWorker
 
 
 class GooglePubSubQueuesTestCase(TestCase):
@@ -47,3 +48,29 @@ class GooglePubSubQueuesTestCase(TestCase):
         self.assertIsInstance(publish.call_args_list[0].args[1], bytes)
         self.assertEqual(publish.call_args_list[0].kwargs, {"event_type": "yolo"})
         self.assertEqual(publish.call_args_list[1].kwargs, {"routing_key": "routing-key"})
+
+
+class GooglePubSubBaseWorkerTestCase(TestCase):
+    maxDiff = None
+
+    @patch("zentral.core.queues.backends.google_pubsub.consumer.setup_signal_handler")
+    def test_run_wires_signal_handler(self, setup_signal_handler):
+        worker = BaseWorker("projects/p/topics/events", None)
+        worker.ensure_subscription = Mock()
+        worker.start_metrics_exporter = Mock()
+        worker.do_run = Mock()
+        self.assertEqual(worker.run(), 0)
+        worker.ensure_subscription.assert_called_once()
+        setup_signal_handler.assert_called_once_with(worker.handle_signal)
+        worker.start_metrics_exporter.assert_called_once()
+        worker.do_run.assert_called_once()
+
+    @patch("zentral.core.queues.backends.google_pubsub.consumer.setup_signal_handler")
+    def test_run_skips_signal_handler_when_subscription_fails(self, setup_signal_handler):
+        worker = BaseWorker("projects/p/topics/events", None)
+        worker.ensure_subscription = Mock(side_effect=ValueError)
+        worker.start_metrics_exporter = Mock()
+        worker.do_run = Mock()
+        self.assertEqual(worker.run(), 1)
+        setup_signal_handler.assert_not_called()
+        worker.do_run.assert_not_called()

--- a/tests/server_base/test_event_queue_shutdown_hooks.py
+++ b/tests/server_base/test_event_queue_shutdown_hooks.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+from django.test import SimpleTestCase
+
+
+class EventQueueShutdownHooksTestCase(SimpleTestCase):
+    @patch("zentral.core.queues.queues.stop")
+    def test_gunicorn_worker_exit_stops_queues(self, stop):
+        from server.gunicorn_conf import worker_exit
+        worker_exit(None, None)
+        stop.assert_called_once_with()
+
+    @patch("zentral.core.queues.queues.stop")
+    def test_celery_worker_shutdown_stops_queues(self, stop):
+        from server.celery import stop_event_queues
+        stop_event_queues()
+        stop.assert_called_once_with()

--- a/tests/utils/test_signals.py
+++ b/tests/utils/test_signals.py
@@ -1,0 +1,38 @@
+import signal
+import threading
+from unittest.mock import Mock, patch
+from django.test import SimpleTestCase
+from zentral.utils.signals import setup_signal_handler
+
+
+class SetupSignalHandlerTestCase(SimpleTestCase):
+    @patch("zentral.utils.signals.signal.signal")
+    def test_wires_given_signals_on_main_thread(self, signal_signal):
+        signal_signal.return_value = "previous"
+        handler = Mock()
+        previous = setup_signal_handler(handler, signal.SIGTERM, signal.SIGINT)
+        self.assertEqual(previous, {signal.SIGTERM: "previous", signal.SIGINT: "previous"})
+        signal_signal.assert_any_call(signal.SIGTERM, handler)
+        signal_signal.assert_any_call(signal.SIGINT, handler)
+        self.assertEqual(signal_signal.call_count, 2)
+
+    @patch("zentral.utils.signals.signal.signal")
+    def test_defaults_to_sigint_and_sigterm(self, signal_signal):
+        setup_signal_handler(Mock())
+        self.assertEqual(
+            {c.args[0] for c in signal_signal.call_args_list},
+            {signal.SIGINT, signal.SIGTERM},
+        )
+
+    @patch("zentral.utils.signals.signal.signal")
+    def test_skips_wiring_off_main_thread(self, signal_signal):
+        results = {}
+
+        def worker():
+            results["previous"] = setup_signal_handler(Mock(), signal.SIGTERM)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        self.assertEqual(results["previous"], {})
+        signal_signal.assert_not_called()

--- a/zentral/contrib/inventory/compliance_checks.py
+++ b/zentral/contrib/inventory/compliance_checks.py
@@ -78,10 +78,14 @@ class JMESPathChecksCache:
             self._checks[jmespath_check.compliance_check.pk] = jmespath_check
         self._last_fetched_time = time.monotonic()
 
-    def _get_source_platform_checks(self, source_name, platform):
+    def _get_checks_and_source_platform_checks(self, source_name, platform):
+        # _load() rebinds self._checks to a fresh dict rather than mutating it in
+        # place, so returning the reference here hands process_tree a stable
+        # snapshot that a concurrent reload cannot corrupt mid-iteration.
         with self._lock:
             self._load()
-            return self._source_platform_checks.get((source_name.lower(), platform), [])
+            return (self._checks,
+                    self._source_platform_checks.get((source_name.lower(), platform), []))
 
     def process_tree(self, tree, last_seen):
         machine_tag_set = None
@@ -92,10 +96,8 @@ class JMESPathChecksCache:
         if not platform:
             logger.warning("Cannot process %s %s tree: missing platform", source_name, serial_number)
             return
-        for check_tag_set, jmespath_parsed_expr, jmespath_check in self._get_source_platform_checks(
-            source_name,
-            platform
-        ):
+        checks, source_platform_checks = self._get_checks_and_source_platform_checks(source_name, platform)
+        for check_tag_set, jmespath_parsed_expr, jmespath_check in source_platform_checks:
             if check_tag_set:
                 if machine_tag_set is None:
                     # TODO cache?
@@ -130,7 +132,7 @@ class JMESPathChecksCache:
                 continue
             if compliance_check_pk:
                 yield JMESPathCheckStatusUpdated.build_from_object_serial_number_and_statuses(
-                    self._checks[compliance_check_pk],
+                    checks[compliance_check_pk],
                     serial_number, status, last_seen, previous_status,
                 )
             else:

--- a/zentral/contrib/mdm/apps_books.py
+++ b/zentral/contrib/mdm/apps_books.py
@@ -269,27 +269,31 @@ class AppsBooksClient:
 
 
 class LocationCache:
+    # The cached client wraps a requests.Session and, on token rotation,
+    # mutates its auth header and calls refresh_from_db() on its Location.
+    # None of that is safe to share across threads, so the cache is thread-local:
+    # each thread keeps its own client, preserving the server-token decrypt and
+    # connection-pool reuse without any cross-thread mutable state.
     def __init__(self):
-        self._lock = threading.Lock()
-        self._locations = {}
+        self._local = threading.local()
 
     def get(self, mdm_info_id):
         if not isinstance(mdm_info_id, str):
             mdm_info_id = str(mdm_info_id)
-        with self._lock:
+        try:
+            locations = self._local.locations
+        except AttributeError:
+            locations = self._local.locations = {}
+        try:
+            return locations[mdm_info_id]
+        except KeyError:
             try:
-                return self._locations[mdm_info_id]
-            except KeyError:
-                location = None
-                client = None
-                try:
-                    location = Location.objects.get(mdm_info_id=mdm_info_id)
-                except Location.DoesNotExist:
-                    raise KeyError
-                else:
-                    client = AppsBooksClient.from_location(location)
-                self._locations[mdm_info_id] = location, client
-                return location, client
+                location = Location.objects.get(mdm_info_id=mdm_info_id)
+            except Location.DoesNotExist:
+                raise KeyError
+            client = AppsBooksClient.from_location(location)
+            locations[mdm_info_id] = location, client
+            return location, client
 
 
 location_cache = SimpleLazyObject(lambda: LocationCache())

--- a/zentral/contrib/mdm/cert_issuer_backends/__init__.py
+++ b/zentral/contrib/mdm/cert_issuer_backends/__init__.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 import logging
+import threading
 from django.db import models
 from zentral.contrib.inventory.conf import mac_secure_enclave_from_model
 
@@ -27,19 +28,24 @@ def get_cert_issuer_backend(cert_issuer, load=False):
 
 
 cert_issuer_cache = {}
+cert_issuer_cache_lock = threading.Lock()
 
 
 def get_cached_cert_issuer_backend(cert_issuer):
-    backend = None
-    version = 0
-    try:
-        backend, version = cert_issuer_cache[cert_issuer.pk]
-    except KeyError:
-        pass
-    if not backend or not version or version < cert_issuer.version:
-        backend = get_cert_issuer_backend(cert_issuer, load=True)
-        cert_issuer_cache[cert_issuer.pk] = (backend, cert_issuer.version)
-    return backend
+    # run the whole check-then-act under the lock: otherwise two threads can both
+    # miss and each rebuild the backend (load=True does secret-engine I/O) while
+    # racing on the shared cache dict.
+    with cert_issuer_cache_lock:
+        backend = None
+        version = 0
+        try:
+            backend, version = cert_issuer_cache[cert_issuer.pk]
+        except KeyError:
+            pass
+        if not backend or not version or version < cert_issuer.version:
+            backend = get_cert_issuer_backend(cert_issuer, load=True)
+            cert_issuer_cache[cert_issuer.pk] = (backend, cert_issuer.version)
+        return backend
 
 
 def test_acme_payload(platform, comparable_os_version, model):

--- a/zentral/core/probes/conf.py
+++ b/zentral/core/probes/conf.py
@@ -91,8 +91,12 @@ class ProbeList(ProbeView):
     def clear(self, *args, **kwargs):
         with self._lock:
             self._probes = None
-            for child in self._children:
-                child.clear()
+            children = list(self._children)
+        # cascade outside our lock: a reader holds a child's lock while iterating
+        # its parent (child -> parent), so taking a child's lock while holding
+        # ours would invert that order and can deadlock.
+        for child in children:
+            child.clear()
 
     def _load(self):
         self._start_sync()

--- a/zentral/core/queues/backends/aws_sns_sqs/__init__.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/__init__.py
@@ -15,6 +15,7 @@ from django.utils.functional import cached_property
 from zentral.conf import settings
 from zentral.conf.config import ConfigDict
 from zentral.core.queues.backends.base import BaseEventQueues
+from zentral.utils.signals import setup_signal_handler
 from zentral.utils.time import naive_utcnow
 
 from .consumer import BatchConsumer, ConcurrentConsumer, Consumer, ConsumerProducer
@@ -484,10 +485,6 @@ class EventQueues(BaseEventQueues):
         else:
             return SimpleStoreWorker(self, event_store)
 
-    def _setup_signal(self):
-        for signum in (signal.SIGTERM, signal.SIGINT):
-            signal.signal(signum, self._handle_sigterm)
-
     def _graceful_stop(self, signum, frame):
         logger.info("Received signal %s.", signal.Signals(signum).name)
         self.stop()
@@ -499,12 +496,10 @@ class EventQueues(BaseEventQueues):
     def _setup_graceful_stop(self):
         if self._stop_event is None:
             self._stop_event = threading.Event()
-            if threading.current_thread() is threading.main_thread():
-                logger.debug("Setup graceful stop.")
-                for signum in (signal.SIGINT, signal.SIGTERM):
-                    self._previous_signal_handlers[signum] = signal.signal(signum, self._graceful_stop)
-            else:
-                logger.warning("Could not setup graceful stop: not running on main thread.")
+            # off the main thread (e.g. under gthread workers) this wires nothing
+            # and returns {}; the worker_exit / celery shutdown hooks call stop()
+            # there instead.
+            self._previous_signal_handlers = setup_signal_handler(self._graceful_stop)
 
     def post_raw_event(self, routing_key, raw_event):
         # start the sender thread once even if requests post concurrently; assign

--- a/zentral/core/queues/backends/aws_sns_sqs/__init__.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/__init__.py
@@ -333,6 +333,7 @@ class EventQueues(BaseEventQueues):
         self._events_queue = None
         self._stop_event = None
         self._threads = []
+        self._producer_lock = threading.Lock()
         self._previous_signal_handlers = {}
 
     @cached_property
@@ -506,33 +507,41 @@ class EventQueues(BaseEventQueues):
                 logger.warning("Could not setup graceful stop: not running on main thread.")
 
     def post_raw_event(self, routing_key, raw_event):
-        self._setup_graceful_stop()
-        if self._raw_events_queue is None:
-            self._raw_events_queue = queue.Queue(maxsize=20)
-            thread = SQSSendThread(
-                self.setup_queue("raw-events"),
-                self._stop_event,
-                self._raw_events_queue,
-                None,
-                self.client_kwargs
-            )
-            thread.start()
-            self._threads.append(thread)
+        # start the sender thread once even if requests post concurrently; assign
+        # self._raw_events_queue last so it is only visible fully initialized, and
+        # keep the blocking put() out of the lock so a full queue can't stall other producers.
+        with self._producer_lock:
+            if self._raw_events_queue is None:
+                self._setup_graceful_stop()
+                raw_events_queue = queue.Queue(maxsize=20)
+                thread = SQSSendThread(
+                    self.setup_queue("raw-events"),
+                    self._stop_event,
+                    raw_events_queue,
+                    None,
+                    self.client_kwargs
+                )
+                thread.start()
+                self._threads.append(thread)
+                self._raw_events_queue = raw_events_queue
         self._raw_events_queue.put((None, routing_key, raw_event, time.monotonic()))
 
     def post_event(self, event):
-        self._setup_graceful_stop()
-        if self._events_queue is None:
-            self._events_queue = queue.Queue(maxsize=20)
-            thread = SQSSendThread(
-                self.setup_queue("events"),
-                self._stop_event,
-                self._events_queue,
-                None,
-                self.client_kwargs
-            )
-            thread.start()
-            self._threads.append(thread)
+        # see post_raw_event: one-time sender-thread creation under the lock, put() outside.
+        with self._producer_lock:
+            if self._events_queue is None:
+                self._setup_graceful_stop()
+                events_queue = queue.Queue(maxsize=20)
+                thread = SQSSendThread(
+                    self.setup_queue("events"),
+                    self._stop_event,
+                    events_queue,
+                    None,
+                    self.client_kwargs
+                )
+                thread.start()
+                self._threads.append(thread)
+                self._events_queue = events_queue
         self._events_queue.put((None, None, event.serialize(machine_metadata=False), time.monotonic()))
 
     def stop(self):

--- a/zentral/core/queues/backends/aws_sns_sqs/consumer.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/consumer.py
@@ -5,6 +5,7 @@ import signal
 import threading
 import time
 from zentral.core.queues.exceptions import RetryLater
+from zentral.utils.signals import setup_signal_handler
 from .sqs import SQSDeleteThread, SQSReceiveThread
 
 
@@ -35,8 +36,7 @@ class BaseConsumer:
 
     def run(self, *args, **kwargs):
         exit_status = 0
-        signal.signal(signal.SIGTERM, self._handle_signal)
-        signal.signal(signal.SIGINT, self._handle_signal)
+        setup_signal_handler(self._handle_signal)
         for thread in self._threads:
             thread.start()
         try:
@@ -99,7 +99,7 @@ class ConcurrentConsumerFinalThread(threading.Thread):
         self.delete_message_queue = concurrent_consumer.delete_message_queue
         self.stop_event = concurrent_consumer.stop_event
         self.update_metrics_cb = concurrent_consumer.update_metrics
-        super().__init__(name="ConcurrentConsumer final thread")
+        super().__init__(name="ConcurrentConsumer final thread", daemon=True)
 
     def run(self):
         while True:
@@ -224,7 +224,7 @@ class ConsumerProducerFinalThread(threading.Thread):
         self.in_queue = consumer_producer.published_message_queue
         self.out_queue = consumer_producer.delete_message_queue
         self.callback = consumer_producer.decrement_receipt_handle_unpublished_event_count
-        super().__init__(name="Consumer/Producer final thread")
+        super().__init__(name="Consumer/Producer final thread", daemon=True)
 
     def run(self):
         while True:

--- a/zentral/core/queues/backends/aws_sns_sqs/sns.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/sns.py
@@ -15,7 +15,7 @@ class SNSPublishThread(threading.Thread):
         self.stop_event = stop_event
         self.in_queue = in_queue
         self.out_queue = out_queue
-        super().__init__(name=f"SNS publish thread {thread_id}")
+        super().__init__(name=f"SNS publish thread {thread_id}", daemon=True)
 
     def run(self):
         logger.info("[%s] start on topic %s", self.name, self.topic_arn)

--- a/zentral/core/queues/backends/aws_sns_sqs/sqs.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/sqs.py
@@ -24,7 +24,7 @@ class SQSReceiveThread(threading.Thread):
         self.stop_event = stop_event
         self.out_queue = out_queue
         self.visibility_timeout = visibility_timeout
-        super().__init__(name="SQS receive thread")
+        super().__init__(name="SQS receive thread", daemon=True)
 
     def run(self):
         logger.info("[%s] start on queue %s", self.name, self.queue_url)
@@ -81,7 +81,7 @@ class SQSDeleteThread(threading.Thread):
         self.queue_url = queue_url
         self.stop_event = stop_event
         self.in_queue = in_queue
-        super().__init__(name="SQS delete thread")
+        super().__init__(name="SQS delete thread", daemon=True)
 
     def run(self):
         logger.info("[%s] start on queue %s", self.name, self.queue_url)
@@ -150,7 +150,7 @@ class SQSSendThread(threading.Thread):
         self.stop_event = stop_event
         self.in_queue = in_queue
         self.out_queue = out_queue
-        super().__init__(name="SQS send thread")
+        super().__init__(name="SQS send thread", daemon=True)
 
     def run(self):
         logger.info("[%s] start on queue %s", self.name, self.queue_url)

--- a/zentral/core/queues/backends/google_pubsub/__init__.py
+++ b/zentral/core/queues/backends/google_pubsub/__init__.py
@@ -397,11 +397,15 @@ class EventQueues(BaseEventQueues):
 
         # publisher client
         self.publisher_client = None
+        self._publisher_lock = threading.Lock()
 
     def _publish(self, topic, event_dict, **attributes):
         message = json.dumps(event_dict).encode("utf-8")
-        if self.publisher_client is None:
-            self.publisher_client = pubsub_v1.PublisherClient(credentials=self.credentials)
+        # create the PublisherClient once even under concurrent first publishes;
+        # publish() is thread-safe and must not hold the lock.
+        with self._publisher_lock:
+            if self.publisher_client is None:
+                self.publisher_client = pubsub_v1.PublisherClient(credentials=self.credentials)
         self.publisher_client.publish(topic, message, **attributes)
 
     def get_preprocess_worker(self):

--- a/zentral/core/queues/backends/google_pubsub/consumer.py
+++ b/zentral/core/queues/backends/google_pubsub/consumer.py
@@ -4,6 +4,7 @@ from kombu.utils import json
 from django.utils.functional import cached_property
 from google.api_core.exceptions import AlreadyExists
 from google.cloud import pubsub_v1
+from zentral.utils.signals import setup_signal_handler
 
 
 logger = logging.getLogger('zentral.core.queues.backends.google_pubsub.consumer')
@@ -124,8 +125,7 @@ class BaseWorker:
             self.exit_code = 1
         else:
             # signals
-            signal.signal(signal.SIGTERM, self.handle_signal)
-            signal.signal(signal.SIGINT, self.handle_signal)
+            setup_signal_handler(self.handle_signal)
 
             # metrics
             self.start_metrics_exporter(metrics_exporter)

--- a/zentral/utils/signals.py
+++ b/zentral/utils/signals.py
@@ -1,0 +1,24 @@
+import logging
+import signal
+import threading
+
+
+logger = logging.getLogger("zentral.utils.signals")
+
+
+def setup_signal_handler(handler, *signums):
+    """Install `handler` for the given OS signals, but only on the main thread.
+
+    signal.signal() only works on the main thread. Under gunicorn's threaded
+    (gthread) workers our code runs on worker threads, where wiring a handler
+    would raise ValueError, so we skip it there and rely on the worker shutdown
+    hooks instead. Returns {signum: previous handler} for the signals actually
+    wired (an empty dict when skipped) so the caller can chain to the handler
+    it replaced.
+    """
+    if not signums:
+        signums = (signal.SIGINT, signal.SIGTERM)
+    if threading.current_thread() is not threading.main_thread():
+        logger.warning("Not running on main thread: skipping signal handler setup")
+        return {}
+    return {signum: signal.signal(signum, handler) for signum in signums}


### PR DESCRIPTION
## Why

Prep for serving the web tier under gunicorn threaded (`gthread`) workers. An audit of process-global mutable state on the request path found the app is broadly thread-safe by design, but surfaced a handful of latent hazards that only become reachable once multiple requests run concurrently in one process, plus a shutdown gap for the event producer. All are no-ops under the current single-threaded `sync` worker, so this can land ahead of any worker-class change.

## Higher-severity (genuine hazards under concurrency)

**1. JMESPath compliance-check cache race — `inventory/compliance_checks.py`**
`process_tree` read `self._checks[pk]` outside the lock; the 300s reload rebinds `self._checks`, so a concurrent request could hit it mid-repopulate → transient `KeyError` (HTTP 500) on every inventory submission. Fixed by snapshotting `_checks` with the source/platform list under the same lock.

**2. Probe-cache lock-ordering deadlock — `core/probes/conf.py`**
`ProbeList.clear()` locked parent→child while reads lock child→parent; a read racing the `probes.change` notifier could deadlock. Fixed by snapshotting children and releasing the lock before cascading.

## Lower-severity (hardening; GIL-safe today)

**3. MDM cert-issuer backend cache — `mdm/cert_issuer_backends/__init__.py`** — unlocked check-then-act; wrapped in a module lock.

**4. VPP location/client cache — `mdm/apps_books.py`** — shared `AppsBooksClient`/`requests.Session` mutated on token rotation; made the cache `threading.local`.

## Event pipeline (producer)

**5. Producer lazy init — `aws_sns_sqs/__init__.py`, `google_pubsub/__init__.py`** — concurrent first-posts could each start a sender thread / build a grpc `PublisherClient`. Guarded the one-time creation with a lock; hot `put()`/`publish()` stay outside it. (Tests added.)

**6. Safe signal wiring + worker-hook shutdown — `zentral/utils/signals.py`, queue backends, `celery.py`, `gunicorn_conf.py`**
Centralized all OS-signal wiring in `setup_signal_handler()`, which wires only on the main thread (skips off it, e.g. under gthread) and returns the replaced handlers for chaining; every wiring site now routes through it, and the dead/broken `_setup_signal` is removed. Since the producer's SIGTERM handler can't be installed from a request thread, the producer is now closed from the worker lifecycle hooks instead — a gunicorn `worker_exit` hook (new `gunicorn_conf.py`, wired via `--config`) and the celery `worker_process_shutdown`/`worker_shutdown` signals all call `queues.stop()`. All AWS queue threads are now `daemon=True` so a worker can exit even if `stop()` wasn't reached.

## Dependency bump (to keep CI green)

**7. Django 5.2.15 → 5.2.16** — unrelated to the thread-safety work, but the `osv-scan` PR check flagged the pinned Django for three medium advisories (PYSEC-2026-2090/2091/2092), all fixed in 5.2.16 (also affects `main`). Backwards-compatible security patch release; folded in as its own commit so the PR's checks pass.

## Verification

`run_tests` (full suite) passes in CI; `osv-scan` is green after the Django bump. The new commits are additionally covered locally by `tests.core_queues`, `tests.utils.test_signals`, and `tests.server_base.test_event_queue_shutdown_hooks` (43 tests, OK). `py_compile` clean, no lines over 119.

## Out of scope (follow-up)

The actual `gthread` cutover — `--worker-class gthread --workers … --threads …` (+ `--preload`) in the entrypoint/`gunicorn_conf.py` — is intentionally left for a separate change; this PR only makes the code safe for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)