### PR TITLE
Fix EventRequestUser.serialize mutating shared session token expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2026.5
+
+
+### Bug fixes
+
+Fixed a 500 error on bulk machine tag changes made through the API with an expiring token.
+
+
 ## 2026.4
 
 

--- a/tests/core_events/test_serialization.py
+++ b/tests/core_events/test_serialization.py
@@ -143,3 +143,49 @@ class EventSerializationTestCase(TestCase):
         self.assertIsInstance(er.user, EventRequestUser)
         self.assertEqual(er.geo.city_name, 'Hamburg')
         self.assertEqual(er.user.session["token"]["expiry"], datetime(1990, 2, 11))
+
+    @staticmethod
+    def _token_authenticated_user(expiry=datetime(1990, 2, 11), with_expiry=True):
+        token = {"pk": "00000000-0000-0000-0000-000000000001", "name": "token name"}
+        if with_expiry:
+            token["expiry"] = expiry
+        return EventRequestUser(
+            id=17, username="godzilla", email="godzilla@zentral.io",
+            is_remote=False, is_service_account=False, is_superuser=False,
+            session={"token_authenticated": True, "is_remote": False,
+                     "mfa_authenticated": False, "token": token},
+        )
+
+    def test_event_request_user_serialize_token_expiry(self):
+        user = self._token_authenticated_user()
+        d = user.serialize()
+        self.assertEqual(d["session"]["token"]["expiry"], "1990-02-11T00:00:00")
+        # the source session dict must not be mutated: it is shared by every
+        # event built from a single request, so serialize() must leave the
+        # datetime in place for the next event to serialize
+        self.assertEqual(user.session["token"]["expiry"], datetime(1990, 2, 11))
+
+    def test_event_request_user_serialize_is_idempotent(self):
+        # a single request builds one EventRequest and shares it across every
+        # event it emits (e.g. bulk machine tag changes); each event serializes
+        # the same user, so a second serialize() must not raise or differ
+        user = self._token_authenticated_user()
+        first = user.serialize()
+        second = user.serialize()
+        self.assertEqual(first, second)
+        self.assertEqual(second["session"]["token"]["expiry"], "1990-02-11T00:00:00")
+
+    def test_event_request_user_serialize_token_without_expiry(self):
+        user = self._token_authenticated_user(with_expiry=False)
+        d = user.serialize()
+        self.assertNotIn("expiry", d["session"]["token"])
+
+    def test_event_request_user_serialize_session_without_token(self):
+        user = EventRequestUser(
+            id=17, username="godzilla", email="godzilla@zentral.io",
+            is_remote=False, is_service_account=False, is_superuser=False,
+            session={"token_authenticated": False, "is_remote": False, "mfa_authenticated": True},
+        )
+        d = user.serialize()
+        self.assertNotIn("token", d["session"])
+        self.assertEqual(d["session"]["mfa_authenticated"], True)

--- a/zentral/core/events/base.py
+++ b/zentral/core/events/base.py
@@ -141,10 +141,16 @@ class EventRequestUser(object):
             val = getattr(self, attr)
             if val is not None:
                 if attr == "session":
-                    try:
-                        val["token"]["expiry"] = val["token"]["expiry"].isoformat()
-                    except KeyError:
-                        pass
+                    token = val.get("token")
+                    if token and isinstance(token.get("expiry"), datetime):
+                        # copy before converting: this session dict is shared by
+                        # every event built from a single request, so serialize()
+                        # must not mutate it in place (the next event serializes it
+                        # again and would choke on the already-stringified expiry)
+                        val = val.copy()
+                        token = token.copy()
+                        token["expiry"] = token["expiry"].isoformat()
+                        val["token"] = token
                 d[attr] = val
         return d
 


### PR DESCRIPTION
A single request builds one EventRequest and shares it across every event it emits (e.g. bulk machine tag changes through the API). serialize() turned the API token expiry into an ISO string by writing back into the live session dict, so the first event mutated expiry to a str and the next event raised AttributeError ("'str' object has no attribute 'isoformat'") -> HTTP 500. The tag change was already committed and the first event posted, so the client got a 500 for a request that had partly succeeded and the remaining tag events were lost.

Copy the session and token dicts instead of mutating in place, and only call isoformat() on a datetime, so serialize() is idempotent.