### PR TITLE
Fix three unhandled 500s: cert extension parse, DDM status-report dedup, snapshot-commit race

### DIFF
--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -1,8 +1,10 @@
 import copy
 from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
 
 from dateutil import parser
 from django.core.cache import cache
+from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.utils.timezone import is_aware, make_naive
 
@@ -15,6 +17,7 @@ from zentral.contrib.inventory.conf import (
     VM,
     os_version_display,
     os_version_version_display,
+    update_ms_tree_platform,
     update_ms_tree_type,
 )
 from zentral.contrib.inventory.models import (
@@ -171,6 +174,45 @@ class MachineSnapshotTestCase(TestCase):
         tree = copy.deepcopy(self.machine_snapshot)
         msc, ms, _ = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(tree)
         self.assertIsNone(msc.get_system_update_display())
+
+    def test_machine_snapshot_commit_different_snapshot_race_skips(self):
+        # a concurrent commit took the version with a different snapshot -> skip, don't 500
+        msc1, ms1, _ = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(
+            copy.deepcopy(self.machine_snapshot))
+
+        def losing_create(**kwargs):
+            raise IntegrityError("duplicate key value violates unique constraint")
+
+        with patch.object(MachineSnapshotCommit.objects, "create", side_effect=losing_create), \
+             patch.object(MachineSnapshotCommit.objects, "get",
+                          return_value=Mock(machine_snapshot=ms1, last_seen=msc1.last_seen)):
+            msc2, ms2, _ = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(
+                copy.deepcopy(self.machine_snapshot5))
+        self.assertIsNone(msc2)
+        self.assertNotEqual(ms2, ms1)
+        self.assertEqual(
+            MachineSnapshotCommit.objects.filter(serial_number=self.serial_number, source=ms1.source).count(),
+            1,
+        )
+
+    def test_machine_snapshot_commit_same_snapshot_race_skips(self):
+        msc1, ms1, _ = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(
+            copy.deepcopy(self.machine_snapshot))
+        tree = copy.deepcopy(self.machine_snapshot5)
+        update_ms_tree_platform(tree)
+        update_ms_tree_type(tree)
+        ms2 = MachineSnapshot.objects.commit(tree)[0]
+
+        def losing_create(**kwargs):
+            raise IntegrityError("duplicate key value violates unique constraint")
+
+        with patch.object(MachineSnapshotCommit.objects, "create", side_effect=losing_create), \
+             patch.object(MachineSnapshotCommit.objects, "get",
+                          return_value=Mock(machine_snapshot=ms2, last_seen=msc1.last_seen)):
+            msc2, ms, _ = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(
+                copy.deepcopy(self.machine_snapshot5))
+        self.assertIsNone(msc2)
+        self.assertEqual(ms, ms2)
 
     def test_machine_snapshot_commit_source_error(self):
         tree = copy.deepcopy(self.machine_snapshot_source_error)

--- a/tests/mdm/test_declarations_utils.py
+++ b/tests/mdm/test_declarations_utils.py
@@ -9,7 +9,9 @@ from zentral.contrib.mdm.declarations import (
     get_artifact_identifier,
     get_artifact_version_server_token,
 )
-from zentral.contrib.mdm.models import Artifact, Declaration
+from zentral.contrib.mdm.declarations.status_report import get_status_report_target_artifacts_info
+from zentral.contrib.mdm.models import Artifact, Declaration, TargetArtifact
+from zentral.utils.payloads import get_payload_identifier
 
 
 class MDMDeclarationUtilsTestCase(TestCase):
@@ -84,3 +86,71 @@ class MDMDeclarationUtilsTestCase(TestCase):
             0
         )
         self.assertEqual(server_token, f"{av_pk}.ri-1")
+
+
+class MDMStatusReportTargetArtifactsInfoTestCase(TestCase):
+    @staticmethod
+    def _report(items):
+        return {"StatusItems": {"management": {"declarations": {
+            "activations": [], "assets": [], "configurations": items, "management": [],
+        }}}}
+
+    @staticmethod
+    def _item(artifact_pk, server_token, active, valid):
+        return {"identifier": get_payload_identifier("declaration", str(artifact_pk)),
+                "server-token": server_token, "active": active, "valid": valid}
+
+    def test_dedup_same_version_keeps_most_present(self):
+        # same artifact version reported under two server-tokens (a re-push) -> one entry
+        artifact_pk, av_pk = uuid.uuid4(), uuid.uuid4()
+        report = self._report([
+            self._item(artifact_pk, str(av_pk), True, "unknown"),     # AwaitingConfirmation
+            self._item(artifact_pk, f"{av_pk}.rc-1", True, "valid"),  # Installed
+        ])
+        with self.assertLogs("zentral.contrib.mdm.declarations.status_report", level="WARNING") as cm:
+            info = get_status_report_target_artifacts_info(report)
+        self.assertEqual(len(info), 1)
+        self.assertEqual(info[0][1], str(av_pk))
+        self.assertEqual(info[0][2], TargetArtifact.Status.INSTALLED)
+        self.assertTrue(any(f"Duplicate artifact version {av_pk}" in m
+                            and f"server tokens {av_pk} and {av_pk}.rc-1" in m for m in cm.output))
+
+    def test_dedup_most_present_is_order_independent(self):
+        artifact_pk, av_pk = uuid.uuid4(), uuid.uuid4()
+        info = get_status_report_target_artifacts_info(self._report([
+            self._item(artifact_pk, str(av_pk), True, "valid"),        # Installed
+            self._item(artifact_pk, f"{av_pk}.rc-1", True, "unknown"),  # AwaitingConfirmation
+        ]))
+        self.assertEqual(len(info), 1)
+        self.assertEqual(info[0][2], TargetArtifact.Status.INSTALLED)
+
+    def test_dedup_three_occurrences_keeps_most_present(self):
+        # same version reported 3x, most present (Installed) in the middle -> one entry, most present
+        artifact_pk, av_pk = uuid.uuid4(), uuid.uuid4()
+        with self.assertLogs("zentral.contrib.mdm.declarations.status_report", level="WARNING") as cm:
+            info = get_status_report_target_artifacts_info(self._report([
+                self._item(artifact_pk, str(av_pk), False, "unknown"),      # Uninstalled
+                self._item(artifact_pk, f"{av_pk}.rc-1", True, "valid"),    # Installed
+                self._item(artifact_pk, f"{av_pk}.rc-2", True, "unknown"),  # AwaitingConfirmation
+            ]))
+        self.assertEqual(len(info), 1)
+        self.assertEqual(info[0][1], str(av_pk))
+        self.assertEqual(info[0][2], TargetArtifact.Status.INSTALLED)
+        self.assertEqual(len(cm.output), 2)  # one warning per duplicate after the first
+
+    def test_distinct_versions_not_deduped(self):
+        artifact_pk = uuid.uuid4()
+        info = get_status_report_target_artifacts_info(self._report([
+            self._item(artifact_pk, str(uuid.uuid4()), True, "valid"),
+            self._item(artifact_pk, str(uuid.uuid4()), True, "valid"),
+        ]))
+        self.assertEqual(len(info), 2)
+
+    def test_status_presence_rank_ordering(self):
+        Status = TargetArtifact.Status
+        self.assertGreater(Status.INSTALLED.presence_rank, Status.AWAITING_CONFIRMATION.presence_rank)
+        self.assertGreater(Status.AWAITING_CONFIRMATION.presence_rank, Status.UNINSTALLED.presence_rank)
+        self.assertGreater(Status.UNINSTALLED.presence_rank, Status.FAILED.presence_rank)
+        # every present status outranks every non-present one
+        self.assertGreater(min(s.presence_rank for s in Status if s.present),
+                           max(s.presence_rank for s in Status if not s.present))

--- a/tests/utils/test_certificates.py
+++ b/tests/utils/test_certificates.py
@@ -1,9 +1,32 @@
 import datetime
 import os
+from types import SimpleNamespace
 from asn1crypto.core import UTF8String
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
 from django.test import SimpleTestCase
 from zentral.utils.certificates import (is_ca, iter_cert_trees, iter_certificates, parse_apple_dev_id,
                                         parse_dn, parse_text_dn)
+
+
+class _FakeCert:
+    """Stand-in exposing .extensions.get_extension_for_oid for is_ca(); missing oids raise
+    ExtensionNotFound like cryptography does."""
+    def __init__(self, extensions):
+        self._extensions = extensions
+
+    @property
+    def extensions(self):
+        extensions = self._extensions
+
+        class _Extensions:
+            def get_extension_for_oid(self, oid):
+                try:
+                    return extensions[oid]
+                except KeyError:
+                    raise x509.ExtensionNotFound("not found", oid)
+
+        return _Extensions()
 
 
 class CertificatesTestCate(SimpleTestCase):
@@ -22,6 +45,25 @@ class CertificatesTestCate(SimpleTestCase):
         cert, ca_cert = list(iter_certificates(self.fullchain))
         self.assertEqual(is_ca(cert), False)
         self.assertEqual(is_ca(ca_cert), True)
+
+    def test_is_ca_unparseable_extensions(self):
+        class Cert:
+            @property
+            def extensions(self):
+                raise ValueError('error parsing asn1 value: ParseError { kind: EncodedDefault, '
+                                 'location: ["BasicConstraints::ca"] }')
+        self.assertEqual(is_ca(Cert()), False)
+
+    def test_is_ca_key_usage_fallback(self):
+        # no BasicConstraints -> fall back to KeyUsage.key_cert_sign
+        for key_cert_sign in (True, False):
+            cert = _FakeCert({ExtensionOID.KEY_USAGE:
+                              SimpleNamespace(value=SimpleNamespace(key_cert_sign=key_cert_sign))})
+            self.assertEqual(is_ca(cert), key_cert_sign)
+
+    def test_is_ca_no_relevant_extensions(self):
+        # neither BasicConstraints nor KeyUsage -> not a CA
+        self.assertEqual(is_ca(_FakeCert({})), False)
 
     def test_dev_id_match(self):
         self.assertEqual(

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -27,7 +27,7 @@ from zentral.conf import settings
 from zentral.core.compliance_checks.utils import get_machine_compliance_check_statuses
 from zentral.core.incidents.models import MachineIncident, Status
 from zentral.utils.model_extras import find_all_related_objects
-from zentral.utils.mt_models import AbstractMTObject, MTObjectManager, MTOError, prepare_commit_tree
+from zentral.utils.mt_models import AbstractMTObject, MTObjectManager, prepare_commit_tree
 from zentral.utils.time import naive_utcnow
 
 from .conf import (
@@ -727,16 +727,19 @@ class MachineSnapshotCommitManager(models.Manager):
                                                                           'last_seen': last_seen})
                 return new_msc, machine_snapshot, last_seen
         except IntegrityError:
+            # A concurrent commit for the same machine took this version. Skip rather than fail the
+            # request: the current snapshot is already up to date and the next check-in reconciles
+            # (a differing snapshot just means a tree field changed inside the race window).
             msc = MachineSnapshotCommit.objects.get(serial_number=serial_number,
                                                     source=source,
                                                     version=new_version)
-            if msc.machine_snapshot == machine_snapshot:
+            if msc.machine_snapshot != machine_snapshot:
+                logger.warning("MachineSnapshotCommit race with a different snapshot for "
+                               "source {} and serial_number {}".format(source, serial_number))
+            else:
                 logger.warning("MachineSnapshotCommit race with same snapshot for "
                                "source {} and serial_number {}".format(source, serial_number))
-                return None, machine_snapshot, msc.last_seen
-            else:
-                raise MTOError("MachineSnapshotCommit race for "
-                               "source {} and serial_number {}".format(source, serial_number))
+            return None, machine_snapshot, msc.last_seen
 
 
 class MachineSnapshotCommit(models.Model):

--- a/zentral/contrib/mdm/declarations/status_report.py
+++ b/zentral/contrib/mdm/declarations/status_report.py
@@ -38,20 +38,24 @@ def get_status_report_target_artifacts_info(status_report):
     except KeyError:
         logger.debug("Status report without declarations section")
         return
-    target_artifacts_info = []
+    # A re-pushed artifact version can be reported under two server-tokens in one report; both
+    # map to one artifact_version_pk, which the target-artifact upsert can't accept twice. Keep
+    # one entry per version, the most present.
+    info_by_artifact_version = {}
     for section in ("activations", "assets", "configurations", "management"):
         for item in declarations.get(section, []):
             try:
                 _, artifact_pk = parse_artifact_identifier(item["identifier"])
             except ValueError:
-                pass
-            else:
-                artifact_version_pk, status, extra_info, server_token = get_target_artifact_info(item)
-                target_artifacts_info.append((
-                    artifact_pk,
-                    artifact_version_pk,
-                    status,
-                    extra_info,
-                    server_token,
-                ))
-    return target_artifacts_info
+                continue
+            artifact_version_pk, status, extra_info, server_token = get_target_artifact_info(item)
+            existing = info_by_artifact_version.get(artifact_version_pk)
+            if existing is not None:
+                logger.warning("Duplicate artifact version %s in status report (server tokens %s and %s)",
+                               artifact_version_pk, existing[4], server_token)
+                if status.presence_rank <= existing[2].presence_rank:
+                    continue
+            info_by_artifact_version[artifact_version_pk] = (
+                artifact_pk, artifact_version_pk, status, extra_info, server_token,
+            )
+    return list(info_by_artifact_version.values())

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3271,6 +3271,14 @@ class TargetArtifact(models.Model):
         def present(self):
             return self.value in (self.ACKNOWLEDGED, self.INSTALLED)
 
+        @property
+        def presence_rank(self):
+            # higher wins when a device reports the same artifact version more than once in a
+            # status report (see get_status_report_target_artifacts_info)
+            return (self.FAILED, self.REMOVAL_FAILED, self.UNINSTALLED,
+                    self.AWAITING_CONFIRMATION, self.FORCE_REINSTALL,
+                    self.ACKNOWLEDGED, self.INSTALLED).index(self)
+
     artifact_version = models.ForeignKey(ArtifactVersion, on_delete=models.PROTECT)
     status = models.CharField(
         max_length=64,

--- a/zentral/utils/certificates.py
+++ b/zentral/utils/certificates.py
@@ -131,14 +131,18 @@ def parse_apple_dev_id(cn):
 def is_ca(certificate):
     """Test if a x509 Certificate is a CA certificate"""
     # TODO: test self signed if no extensions found
-    extensions = certificate.extensions
     try:
-        return extensions.get_extension_for_oid(ExtensionOID.BASIC_CONSTRAINTS).value.ca
-    except x509.ExtensionNotFound:
+        extensions = certificate.extensions
         try:
-            return extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE).value.key_cert_sign
+            return extensions.get_extension_for_oid(ExtensionOID.BASIC_CONSTRAINTS).value.ca
         except x509.ExtensionNotFound:
-            pass
+            try:
+                return extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE).value.key_cert_sign
+            except x509.ExtensionNotFound:
+                pass
+    except ValueError:
+        # cryptography raises ValueError on a non-DER-canonical extension encoding
+        pass
     return False
 
 


### PR DESCRIPTION
## What

Three independent fixes for unhandled server errors (HTTP 500s) surfaced while reviewing application error logs. Each is its own commit.

### 1. Guard `is_ca()` against certificates with non-canonical extensions — `zentral/utils/certificates.py`
`is_ca()` accessed `certificate.extensions` outside any handler. `cryptography` raises a plain `ValueError` when an extension isn't DER-canonical (e.g. a `BasicConstraints` `ca` boolean encoded as an explicit default), which escaped and 500'd every machine-snapshot ingestion that parses such a cert (munki `post_job` and the other snapshot endpoints, via `prepare_ms_tree_certificates`). A machine reporting such a cert 500'd its check-in on every run, so its inventory stopped updating. A cert whose extensions can't be parsed is now treated as not-a-CA.

### 2. Dedup DDM status-report artifacts by version — `zentral/contrib/mdm/declarations/status_report.py`
A device can report the same artifact version under two server-tokens (the token carries retry / OS-version / reinstall-interval suffixes) during a re-push. Both collapse to one `artifact_version_pk`, so the target-artifact bulk upsert's `ON CONFLICT (target, artifact_version_id)` rejected the two rows with a `CardinalityViolation`, 500-ing the declarative-management status check-in (`/public/mdm/checkin/`). The status-report parser now keeps one entry per `artifact_version_pk` — the most present of the reported statuses (ranking exposed as `TargetArtifact.Status.presence_rank`) — and logs a warning when it collapses a duplicate.

### 3. Skip the machine-snapshot commit on a concurrent version race — `zentral/contrib/inventory/models.py`
Two near-simultaneous check-ins from the same machine + source can both pick the same next `MachineSnapshotCommit` version; one wins, the other hits the `(serial_number, source, version)` unique constraint. The manager already returned quietly when the winner had stored an identical snapshot, but raised `MTOError` (→ 500) when it had stored a different one (e.g. santa preflight). A differing snapshot just means a tree field changed inside the race window — the current snapshot is already up to date and the next check-in reconciles — so it now logs and skips instead of raising.

## Scope / not included
- Fix 3 addresses the commit race specifically. A separate, larger source of preflight 500s observed in production is nginx→gunicorn connection refusal under worker starvation — an availability/capacity matter, not an application bug.
- A monolith repository-sync get-then-create race (`_import_pkg_info` / `_import_catalogs`) is real but rare; it'll get its own PR (advisory-lock fix), since making it right spans several sites and a per-repo sync lock is the cleaner approach.

## Tests
Each fix ships focused tests (`tests/utils/test_certificates.py`, `tests/mdm/test_declarations_utils.py`, `tests/inventory/test_machine_snapshot.py`), exercising the new branches. Run with the project's docker-compose test setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
