### PR TITLE
Fix uncommittable machine snapshot trees: subtree dedup, poison raw-event drop, dead serialize

### DIFF
--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -32,7 +32,7 @@ from zentral.contrib.inventory.models import (
     Tag,
 )
 from zentral.contrib.inventory.utils.db import inventory_events_from_machine_snapshot_commit
-from zentral.utils.mt_models import MTOError
+from zentral.utils.mt_models import MTOError, prepare_commit_tree
 from zentral.utils.time import naive_utcnow
 
 
@@ -327,9 +327,46 @@ class MachineSnapshotTestCase(TestCase):
     def test_duplicated_subtrees(self):
         tree = copy.deepcopy(self.machine_snapshot3)
         tree["osx_app_instances"].append(copy.deepcopy(self.osx_app_instance2))
-        with self.assertRaises(MTOError,
-                               msg="Duplicated subtree in key osx_app_instances"):
-            MachineSnapshot.objects.commit(tree)
+        with self.assertLogs("zentral.utils.mt_models", level="WARNING") as cm:
+            ms, created = MachineSnapshot.objects.commit(tree)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:zentral.utils.mt_models:1 duplicated subtree(s) removed from key osx_app_instances"]
+        )
+        self.assertTrue(created)
+        self.assertEqual(ms.osx_app_instances.count(), 2)
+        ms.refresh_from_db()
+        self.assertEqual(ms.hash(), ms.mt_hash)
+        # same snapshot as the one committed from the tree without the duplicate
+        ms2, created2 = MachineSnapshot.objects.commit(copy.deepcopy(self.machine_snapshot3))
+        self.assertFalse(created2)
+        self.assertEqual(ms, ms2)
+
+    def test_prepare_commit_tree_datetime_list_items(self):
+        dt = parser.parse('2035/02/09 22:40:36 +0100')
+        tree = {"un": [dt]}
+        prepare_commit_tree(tree)
+        tree_naive = {"un": [make_naive(dt)]}
+        prepare_commit_tree(tree_naive)
+        self.assertEqual(tree["mt_hash"], tree_naive["mt_hash"])
+
+    def test_prepare_commit_tree_unsupported_list_item_type(self):
+        with self.assertRaises(MTOError) as cm:
+            prepare_commit_tree({"un": [object()]})
+        self.assertEqual(cm.exception.message, "Unsupported list item type")
+
+    def test_duplicated_subtrees_in_json_field(self):
+        tree = copy.deepcopy(self.machine_snapshot)
+        tree["extra_facts"] = {"un": [{"a": 1}, {"a": 1}, "deux"]}
+        with self.assertLogs("zentral.utils.mt_models", level="WARNING") as cm:
+            ms, _ = MachineSnapshot.objects.commit(tree)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:zentral.utils.mt_models:1 duplicated subtree(s) removed from key un"]
+        )
+        self.assertEqual(ms.extra_facts, {"un": [{"a": 1}, "deux"]})
+        ms.refresh_from_db()
+        self.assertEqual(ms.hash(), ms.mt_hash)
 
     def test_commit_certificate(self):
         tree = copy.deepcopy(self.certificate)

--- a/tests/inventory/test_preprocessors.py
+++ b/tests/inventory/test_preprocessors.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
+from django.db import OperationalError
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.events import post_machine_snapshot_raw_event, AddMachine, InventoryHeartbeat
 from zentral.contrib.inventory.models import MachineSnapshot
 from zentral.contrib.inventory.preprocessors import get_preprocessors, MachineSnapshotPreprocessor
+from zentral.core.queues.exceptions import RetryLater
 
 
 class InventoryPreprocessorsTestCase(TestCase):
@@ -34,3 +36,53 @@ class InventoryPreprocessorsTestCase(TestCase):
         self.assertIsInstance(events[1], InventoryHeartbeat)
         ms = MachineSnapshot.objects.current().get(serial_number=serial_number)
         self.assertEqual(ms.system_info.computer_name, computer_name)
+
+    def test_process_raw_machine_snapshot_deterministic_error_dropped(self):
+        pp = MachineSnapshotPreprocessor()
+        serial_number = get_random_string(12)
+        with self.assertLogs("zentral.contrib.inventory.preprocessors", level="ERROR") as cm:
+            events = list(pp.process_raw_event(
+                {"ms_tree": {"serial_number": serial_number,
+                             "reference": serial_number,
+                             "source": {"module": "zentral.contrib.munki",
+                                        "name": "Munki"},
+                             "yolo": "fomo"}}
+            ))
+        self.assertEqual(events, [])
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn(f"Source Munki, serial number {serial_number}: machine snapshot tree dropped", cm.output[0])
+        self.assertIn("yolo", cm.output[0])
+        self.assertNotIn("Traceback", cm.output[0])
+        self.assertFalse(MachineSnapshot.objects.filter(serial_number=serial_number).exists())
+
+    def test_process_raw_machine_snapshot_missing_tree_dropped(self):
+        pp = MachineSnapshotPreprocessor()
+        with self.assertLogs("zentral.contrib.inventory.preprocessors", level="ERROR") as cm:
+            events = list(pp.process_raw_event({}))
+        self.assertEqual(events, [])
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("Source UNKNOWN, serial number UNKNOWN: machine snapshot tree dropped", cm.output[0])
+
+    @patch("zentral.contrib.inventory.preprocessors.commit_machine_snapshot_and_yield_events")
+    def test_process_raw_machine_snapshot_retry_later_passthrough(self, cmsaye):
+        cmsaye.side_effect = RetryLater
+        pp = MachineSnapshotPreprocessor()
+        with self.assertNoLogs("zentral.contrib.inventory.preprocessors", level="ERROR"):
+            with self.assertRaises(RetryLater):
+                list(pp.process_raw_event({"ms_tree": {"serial_number": get_random_string(12)}}))
+
+    @patch("zentral.contrib.inventory.preprocessors.commit_machine_snapshot_and_yield_events")
+    def test_process_raw_machine_snapshot_recoverable_db_error(self, cmsaye):
+        cmsaye.side_effect = OperationalError("server closed the connection unexpectedly")
+        pp = MachineSnapshotPreprocessor()
+        serial_number = get_random_string(12)
+        with self.assertLogs("zentral.contrib.inventory.preprocessors", level="ERROR") as cm:
+            with self.assertRaises(RetryLater):
+                list(pp.process_raw_event(
+                    {"ms_tree": {"serial_number": serial_number,
+                                 "source": {"module": "zentral.contrib.munki",
+                                            "name": "Munki"}}}
+                ))
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn(f"Source Munki, serial number {serial_number}: recoverable DB error", cm.output[0])
+        self.assertIn("server closed the connection unexpectedly", cm.output[0])

--- a/zentral/contrib/inventory/preprocessors.py
+++ b/zentral/contrib/inventory/preprocessors.py
@@ -1,4 +1,6 @@
 import logging
+from django.db import InterfaceError, OperationalError
+from zentral.core.queues.exceptions import RetryLater
 from .utils import commit_machine_snapshot_and_yield_events
 
 
@@ -8,8 +10,30 @@ logger = logging.getLogger("zentral.contrib.inventory.preprocessors")
 class MachineSnapshotPreprocessor:
     routing_key = "inventory_machine_snapshot"
 
+    @staticmethod
+    def _get_source_name_and_serial_number(ms_tree):
+        source_name = serial_number = None
+        if isinstance(ms_tree, dict):
+            serial_number = ms_tree.get("serial_number")
+            source = ms_tree.get("source")
+            if isinstance(source, dict):
+                source_name = source.get("name")
+        return source_name or "UNKNOWN", serial_number or "UNKNOWN"
+
     def process_raw_event(self, raw_event):
-        yield from commit_machine_snapshot_and_yield_events(raw_event["ms_tree"])
+        ms_tree = raw_event.get("ms_tree")
+        try:
+            yield from commit_machine_snapshot_and_yield_events(ms_tree)
+        except RetryLater:
+            raise
+        except (InterfaceError, OperationalError) as error:
+            logger.error("Source %s, serial number %s: recoverable DB error: %s",
+                         *self._get_source_name_and_serial_number(ms_tree), error)
+            raise RetryLater
+        except Exception as error:
+            # deterministic error: reprocessing the tree would fail the same way → drop it
+            logger.error("Source %s, serial number %s: machine snapshot tree dropped: %s",
+                         *self._get_source_name_and_serial_number(ms_tree), error)
 
 
 def get_preprocessors():

--- a/zentral/contrib/inventory/utils/db.py
+++ b/zentral/contrib/inventory/utils/db.py
@@ -17,8 +17,6 @@ def inventory_events_from_machine_snapshot_commit(machine_snapshot_commit):
     source = machine_snapshot_commit.source.serialize()
     diff = machine_snapshot_commit.update_diff()
     if diff is None:
-        machine_payload = machine_snapshot_commit.machine_snapshot.serialize()
-        machine_payload
         yield ('add_machine',
                None,
                machine_snapshot_commit.machine_snapshot.serialize(

--- a/zentral/contrib/inventory/utils/db.py
+++ b/zentral/contrib/inventory/utils/db.py
@@ -95,14 +95,10 @@ def commit_machine_snapshot_and_trigger_events(tree):
 
 
 def commit_machine_snapshot_and_yield_events(tree):
-    try:
-        msc, _, last_seen = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(tree)
-    except Exception:
-        logger.exception("Could not commit machine snapshot")
-        raise
-    else:
-        # inventory events
-        if msc:
-            yield from iter_inventory_events(msc.serial_number, inventory_events_from_machine_snapshot_commit(msc))
-        # compliance checks
-        yield from jmespath_checks_cache.process_tree(tree, last_seen)
+    # errors are handled by the callers, in the preprocessors for example
+    msc, _, last_seen = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(tree)
+    # inventory events
+    if msc:
+        yield from iter_inventory_events(msc.serial_number, inventory_events_from_machine_snapshot_commit(msc))
+    # compliance checks
+    yield from jmespath_checks_cache.process_tree(tree, last_seen)

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -1,10 +1,14 @@
 import copy
 from datetime import datetime
 import hashlib
+import logging
 from django.core.exceptions import FieldDoesNotExist
 from django.utils.functional import cached_property
 from django.utils.timezone import is_aware, make_naive
 from django.db import IntegrityError, models, transaction
+
+
+logger = logging.getLogger("zentral.utils.mt_models")
 
 
 class MTOError(Exception):
@@ -69,12 +73,17 @@ def prepare_commit_tree(tree):
                 v = v['mt_hash']
             elif isinstance(v, list):
                 hash_list = []
+                skipped_item_idxs = None
                 for item_idx, item in enumerate(v):
                     if isinstance(item, dict):
                         prepare_commit_tree(item)
                         subtree_mt_hash = item['mt_hash']
                         if subtree_mt_hash in hash_list:
-                            raise MTOError("Duplicated subtree in key {}".format(k))
+                            # a list of subtrees maps to a many to many relationship, i.e. a set:
+                            # a duplicated subtree carries no information and could never be committed → skip it
+                            if skipped_item_idxs is None:
+                                skipped_item_idxs = []
+                            skipped_item_idxs.append(item_idx)
                         else:
                             hash_list.append(subtree_mt_hash)
                     else:
@@ -90,8 +99,14 @@ def prepare_commit_tree(tree):
                             item_to_hash = "s∅" + item
                         else:
                             raise MTOError("Unsupported list item type")
-                        item_to_hash = str(item_idx) + item_to_hash  # order is important
+                        # order is important. The position in the hash list — the item index in the
+                        # filtered list when subtrees have been skipped — keeps the hash consistent
+                        # with the stored value.
+                        item_to_hash = str(len(hash_list)) + item_to_hash
                         hash_list.append(hashlib.sha1(item_to_hash.encode('utf-8')).hexdigest())
+                if skipped_item_idxs is not None:
+                    logger.warning("%d duplicated subtree(s) removed from key %s", len(skipped_item_idxs), k)
+                    tree[k] = [item for item_idx, item in enumerate(v) if item_idx not in skipped_item_idxs]
                 v = hash_list
             elif isinstance(v, datetime) and is_aware(v):
                 tree[k] = v = make_naive(v)

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -13,6 +13,7 @@ logger = logging.getLogger("zentral.utils.mt_models")
 
 class MTOError(Exception):
     def __init__(self, message):
+        super().__init__(message)
         self.message = message
 
 


### PR DESCRIPTION
Machines occasionally report the same `osx_app_instance` twice. The resulting `MTOError` made the whole snapshot uncommittable, and on the async path (munki, osquery) the raw event was redelivered forever, crashing the preprocess worker on each attempt. Three commits:

### 1. Dedup identical subtrees in `prepare_commit_tree` instead of failing

The subtree lists map to many to many relationships, i.e. sets: a duplicated subtree carries no information and could never round-trip its hash. Duplicated subtrees are now skipped with a warning, and the list is replaced by the original filtered through the skipped indexes. Only subtrees are deduplicated, never the scalar items. The happy path costs nothing: the skipped indexes are only collected, and the list only rebuilt, when a duplicate is found. Scalar items — the only index-sensitive ones — hash their index via the position in the hash list, i.e. their index in the filtered list, keeping the tree hash consistent with the stored value.

### 2. Drop machine snapshot trees on deterministic preprocessing errors

In the machine snapshot preprocessor, only recoverable DB errors (`InterfaceError`, `OperationalError`) are retried, now via `RetryLater` instead of a worker crash. Anything else logs a single error line — source name, serial number, error message, no traceback — and drops the tree; machine snapshots are periodic full reports, so a dropped tree costs one check-in. `MTOError` now calls `super().__init__` so that `str(error)` is not empty, and `commit_machine_snapshot_and_yield_events` leaves error handling to its callers.

### 3. Remove dead full `serialize()` before the `add_machine` event

The discarded `serialize()` walked every m2m relation (certificates, osx_app_instances, …) for each new machine snapshot, only for the result to be thrown away; the event payload is built by the following `serialize(exclude=...)` call.

All changed lines are covered by tests (`tests.inventory`: 515 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)