### PR TITLE
DB connection resilience behind the RDS Proxy (start: CONN_HEALTH_CHECKS)

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -194,7 +194,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'ATOMIC_REQUESTS': True,
-        'CONN_MAX_AGE': 3600
+        'CONN_MAX_AGE': 3600,
+        # idle persistent connections may be closed by the DB server or a connection pooler; verify before reuse
+        'CONN_HEALTH_CHECKS': True
     }
 }
 # Populate DATABASES with the following variables from the zentral conf:

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -196,7 +196,9 @@ DATABASES = {
         'ATOMIC_REQUESTS': True,
         'CONN_MAX_AGE': 3600,
         # idle persistent connections may be closed by the DB server or a connection pooler; verify before reuse
-        'CONN_HEALTH_CHECKS': True
+        'CONN_HEALTH_CHECKS': True,
+        # cap connection setup so a stalled connect fails fast rather than hanging the request
+        'OPTIONS': {'connect_timeout': 10}
     }
 }
 # Populate DATABASES with the following variables from the zentral conf:


### PR DESCRIPTION
Improve resilience of the database connection.

**Context:** intermittent DB-connection errors are causing occasional 5xx. With persistent connections (`CONN_MAX_AGE=3600`), an idle connection can be closed by the database server or a connection pooler/proxy in front of it; the next request then either reuses a dead connection, or a stalled connect hangs the request until the worker timeout (→ worker kill → 502).

**Commits:**
1. **`CONN_HEALTH_CHECKS = True`** — verify a persistent connection is alive before reuse (Django 4.1+) and transparently reopen it if dead. Removes the **stale-reuse** failure mode.
2. **`connect_timeout = 10`** (DB `OPTIONS`) — cap connection setup so a stalled connect fails fast and cleanly instead of hanging until the worker timeout and getting the worker killed. Turns those hangs from **502s (worker kill) into fast, clean errors** with no worker churn. 10s sits well above a normal sub-second connect, so a transient hiccup or a cold pooler/DB scale-up can still complete.

Both apply to `default` and `ro` (`ro` copies `default`'s config). Safe, no behavior change on a healthy connection.

**Intentionally NOT included — an app-level connect retry.** Django omits connection retry by design: it delegates connection management to the infrastructure layer (it ships no built-in pool either), and an app-side retry risks masking the underlying cause. The remaining new-connect failures should be pursued at the connection-pooler / DB layer first; a bounded, logged, connect-only retry would only be added later if those drops prove irreducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
