### PR TITLE
Recycle the DB connection for all preprocessors on a recoverable DB error

### DIFF
--- a/tests/core_queues/test_aws_sns_sqs.py
+++ b/tests/core_queues/test_aws_sns_sqs.py
@@ -424,6 +424,22 @@ class AWSSNSSQSQueuesTestCase(TestCase):
         self.assertEqual(w._threads[0].visibility_timeout, 120)
 
     @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues.get_queue")
+    def test_preprocess_worker_generate_events(self, get_queue):
+        get_queue.return_value = (True, "raw-events", "https://www.example.com/fomo")
+        w = self.get_queues().get_preprocess_worker()
+        w.metrics_exporter = None
+        event = Mock(event_type="yolo")
+        event.serialize.return_value = {"_zentral": {"type": "yolo"}}
+        preprocessor = Mock(routing_key="test_routing_key")
+        preprocessor.process_raw_event.return_value = iter([event])
+        w.preprocessors = {"test_routing_key": preprocessor}
+        self.assertEqual(
+            list(w.generate_events("test_routing_key", {"foo": "bar"})),
+            [(None, {"_zentral": {"type": "yolo"}})],
+        )
+        preprocessor.process_raw_event.assert_called_once_with({"foo": "bar"})
+
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues.get_queue")
     def test_get_enrich_worker(self, get_queue):
         get_queue.return_value = (True, "events", "https://www.example.com/fomo")
         eq = self.get_queues()

--- a/tests/core_queues/test_google_pubsub.py
+++ b/tests/core_queues/test_google_pubsub.py
@@ -1,7 +1,8 @@
 from unittest.mock import Mock, patch
 from django.test import TestCase
-from zentral.core.queues.backends.google_pubsub import EventQueues
+from zentral.core.queues.backends.google_pubsub import EventQueues, PreprocessWorker
 from zentral.core.queues.backends.google_pubsub.consumer import BaseWorker
+from zentral.core.queues.exceptions import RetryLater
 
 
 class GooglePubSubQueuesTestCase(TestCase):
@@ -24,6 +25,35 @@ class GooglePubSubQueuesTestCase(TestCase):
         self.assertEqual(eq.enriched_events_topic, "projects/p/topics/enriched-events")
         self.assertIsNone(eq.credentials)
         self.assertIsNone(eq.publisher_client)
+
+    def test_preprocess_worker_callback_publishes_events(self):
+        w = self.get_queues().get_preprocess_worker()
+        self.assertIsInstance(w, PreprocessWorker)
+        w.metrics_exporter = None
+        w.publish_event = Mock()
+        event = Mock(event_type="yolo")
+        preprocessor = Mock(routing_key="test_routing_key")
+        preprocessor.process_raw_event.return_value = iter([event])
+        w.preprocessors = {"test_routing_key": preprocessor}
+        message = Mock(data=b'{"foo": "bar"}')
+        message.attributes = {"routing_key": "test_routing_key"}
+        w.callback(message)
+        preprocessor.process_raw_event.assert_called_once_with({"foo": "bar"})
+        w.publish_event.assert_called_once_with(event, machine_metadata=False)
+        message.ack.assert_called_once()
+
+    def test_preprocess_worker_callback_nacks_on_retry_later(self):
+        w = self.get_queues().get_preprocess_worker()
+        w.metrics_exporter = None
+        w.publish_event = Mock()
+        preprocessor = Mock(routing_key="test_routing_key")
+        preprocessor.process_raw_event.side_effect = RetryLater
+        w.preprocessors = {"test_routing_key": preprocessor}
+        message = Mock(data=b'{"foo": "bar"}')
+        message.attributes = {"routing_key": "test_routing_key"}
+        w.callback(message)
+        message.nack.assert_called_once()
+        message.ack.assert_not_called()
 
     @patch("zentral.core.queues.backends.google_pubsub.pubsub_v1.PublisherClient")
     def test_publish_creates_publisher_client_once(self, PublisherClient):

--- a/tests/core_queues/test_kombu.py
+++ b/tests/core_queues/test_kombu.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock, PropertyMock, patch
+from django.test import SimpleTestCase
+from zentral.core.queues.backends.kombu import PreprocessWorker
+from zentral.core.queues.exceptions import RetryLater
+
+
+class KombuPreprocessWorkerTestCase(SimpleTestCase):
+    def test_do_preprocess_raw_event_publishes_events(self):
+        w = PreprocessWorker(Mock())
+        w.metrics_exporter = None
+        event = Mock(event_type="yolo")
+        event.serialize.return_value = {"_zentral": {"type": "yolo"}}
+        preprocessor = Mock(routing_key="test_routing_key")
+        preprocessor.process_raw_event.return_value = iter([event])
+        w.preprocessors = {"test_routing_key": preprocessor}
+        message = Mock()
+        message.delivery_info = {"routing_key": "test_routing_key"}
+        with patch.object(PreprocessWorker, "producer", new_callable=PropertyMock) as producer:
+            w.do_preprocess_raw_event({"foo": "bar"}, message)
+        preprocessor.process_raw_event.assert_called_once_with({"foo": "bar"})
+        producer.return_value.publish.assert_called_once()
+        message.ack.assert_called_once()
+
+    def test_do_preprocess_raw_event_requeues_on_retry_later(self):
+        w = PreprocessWorker(Mock())
+        w.metrics_exporter = None
+        preprocessor = Mock(routing_key="test_routing_key")
+        preprocessor.process_raw_event.side_effect = RetryLater
+        w.preprocessors = {"test_routing_key": preprocessor}
+        message = Mock()
+        message.delivery_info = {"routing_key": "test_routing_key"}
+        with patch.object(PreprocessWorker, "producer", new_callable=PropertyMock):
+            w.do_preprocess_raw_event({"foo": "bar"}, message)
+        message.requeue.assert_called_once()
+        message.ack.assert_not_called()

--- a/tests/core_queues/test_preprocessing.py
+++ b/tests/core_queues/test_preprocessing.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+from django.db import InterfaceError, OperationalError
+from django.test import SimpleTestCase
+from zentral.core.queues.exceptions import RetryLater
+from zentral.core.queues.preprocessing import iter_preprocessed_events
+
+CLOSE_OLD_CONNECTIONS = "zentral.core.queues.preprocessing.close_old_connections"
+
+
+class _Preprocessor:
+    routing_key = "test_routing_key"
+
+    def __init__(self, events=None, error=None):
+        self._events = events or []
+        self._error = error
+
+    def process_raw_event(self, raw_event):
+        yield from self._events
+        if self._error is not None:
+            raise self._error
+
+
+class IterPreprocessedEventsTestCase(SimpleTestCase):
+    """iter_preprocessed_events is the single entry point every queue backend uses to run a
+    preprocessor: it resolves the routing key and recycles a dropped pooled connection."""
+
+    @staticmethod
+    def _preprocessors(preprocessor):
+        return {preprocessor.routing_key: preprocessor}
+
+    def test_events_pass_through_without_touching_connections(self):
+        pp = _Preprocessor(events=["a", "b"])
+        with patch(CLOSE_OLD_CONNECTIONS) as close_old_connections:
+            self.assertEqual(
+                list(iter_preprocessed_events(self._preprocessors(pp), pp.routing_key, {})),
+                ["a", "b"],
+            )
+        close_old_connections.assert_not_called()
+
+    def test_missing_routing_key_yields_nothing(self):
+        pp = _Preprocessor(events=["a"])
+        with self.assertLogs("zentral.core.queues.preprocessing", level="ERROR") as cm:
+            self.assertEqual(list(iter_preprocessed_events(self._preprocessors(pp), None, {})), [])
+        self.assertIn("Message without routing key", cm.output[0])
+
+    def test_unknown_routing_key_yields_nothing(self):
+        with self.assertLogs("zentral.core.queues.preprocessing", level="ERROR") as cm:
+            self.assertEqual(list(iter_preprocessed_events({}, "unknown_routing_key", {})), [])
+        self.assertIn("No preprocessor for routing key unknown_routing_key", cm.output[0])
+
+    def test_operational_error_recycles_connection_and_reenqueues(self):
+        pp = _Preprocessor(error=OperationalError("server closed the connection unexpectedly"))
+        with patch(CLOSE_OLD_CONNECTIONS) as close_old_connections:
+            with self.assertRaises(RetryLater):
+                list(iter_preprocessed_events(self._preprocessors(pp), pp.routing_key, {}))
+        close_old_connections.assert_called_once()
+
+    def test_interface_error_recycles_connection_and_reenqueues(self):
+        pp = _Preprocessor(error=InterfaceError("connection already closed"))
+        with patch(CLOSE_OLD_CONNECTIONS) as close_old_connections:
+            with self.assertRaises(RetryLater):
+                list(iter_preprocessed_events(self._preprocessors(pp), pp.routing_key, {}))
+        close_old_connections.assert_called_once()
+
+    def test_retry_later_passes_through_without_recycling(self):
+        pp = _Preprocessor(error=RetryLater())
+        with patch(CLOSE_OLD_CONNECTIONS) as close_old_connections:
+            with self.assertRaises(RetryLater):
+                list(iter_preprocessed_events(self._preprocessors(pp), pp.routing_key, {}))
+        close_old_connections.assert_not_called()

--- a/tests/inventory/test_preprocessors.py
+++ b/tests/inventory/test_preprocessors.py
@@ -72,17 +72,15 @@ class InventoryPreprocessorsTestCase(TestCase):
                 list(pp.process_raw_event({"ms_tree": {"serial_number": get_random_string(12)}}))
 
     @patch("zentral.contrib.inventory.preprocessors.commit_machine_snapshot_and_yield_events")
-    def test_process_raw_machine_snapshot_recoverable_db_error(self, cmsaye):
+    def test_process_raw_machine_snapshot_db_error_propagates(self, cmsaye):
         cmsaye.side_effect = OperationalError("server closed the connection unexpectedly")
         pp = MachineSnapshotPreprocessor()
-        serial_number = get_random_string(12)
-        with self.assertLogs("zentral.contrib.inventory.preprocessors", level="ERROR") as cm:
-            with self.assertRaises(RetryLater):
+        # transient DB errors are re-raised, not dropped, so the worker recycles the
+        # connection and re-enqueues (see zentral.core.queues.preprocessing)
+        with self.assertNoLogs("zentral.contrib.inventory.preprocessors", level="ERROR"):
+            with self.assertRaises(OperationalError):
                 list(pp.process_raw_event(
-                    {"ms_tree": {"serial_number": serial_number,
+                    {"ms_tree": {"serial_number": get_random_string(12),
                                  "source": {"module": "zentral.contrib.munki",
                                             "name": "Munki"}}}
                 ))
-        self.assertEqual(len(cm.output), 1)
-        self.assertIn(f"Source Munki, serial number {serial_number}: recoverable DB error", cm.output[0])
-        self.assertIn("server closed the connection unexpectedly", cm.output[0])

--- a/zentral/contrib/inventory/preprocessors.py
+++ b/zentral/contrib/inventory/preprocessors.py
@@ -24,12 +24,10 @@ class MachineSnapshotPreprocessor:
         ms_tree = raw_event.get("ms_tree")
         try:
             yield from commit_machine_snapshot_and_yield_events(ms_tree)
-        except RetryLater:
+        except (RetryLater, InterfaceError, OperationalError):
+            # RetryLater and transient DB errors are recycled and re-enqueued by the worker
+            # (iter_preprocessed_events); re-raise so the broad drop below never swallows them
             raise
-        except (InterfaceError, OperationalError) as error:
-            logger.error("Source %s, serial number %s: recoverable DB error: %s",
-                         *self._get_source_name_and_serial_number(ms_tree), error)
-            raise RetryLater
         except Exception as error:
             # deterministic error: reprocessing the tree would fail the same way → drop it
             logger.error("Source %s, serial number %s: machine snapshot tree dropped: %s",

--- a/zentral/core/queues/backends/aws_sns_sqs/__init__.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/__init__.py
@@ -15,6 +15,7 @@ from django.utils.functional import cached_property
 from zentral.conf import settings
 from zentral.conf.config import ConfigDict
 from zentral.core.queues.backends.base import BaseEventQueues
+from zentral.core.queues.preprocessing import iter_preprocessed_events
 from zentral.utils.signals import setup_signal_handler
 from zentral.utils.time import naive_utcnow
 
@@ -101,16 +102,9 @@ class PreprocessWorker(WorkerMixin, ConsumerProducer):
         super().run(*args, **kwargs)
 
     def generate_events(self, routing_key, event_d):
-        if not routing_key:
-            logger.error("Message w/o routing key")
-        else:
-            preprocessor = self.preprocessors.get(routing_key)
-            if not preprocessor:
-                logger.error("No preprocessor for routing key %s", routing_key)
-            else:
-                for event in preprocessor.process_raw_event(event_d):
-                    yield None, event.serialize(machine_metadata=False)
-                    self.inc_counter("produced_events", event.event_type)
+        for event in iter_preprocessed_events(self.preprocessors, routing_key, event_d):
+            yield None, event.serialize(machine_metadata=False)
+            self.inc_counter("produced_events", event.event_type)
         self.inc_counter("preprocessed_events", routing_key or "UNKNOWN")
 
 

--- a/zentral/core/queues/backends/google_pubsub/__init__.py
+++ b/zentral/core/queues/backends/google_pubsub/__init__.py
@@ -12,6 +12,7 @@ from google.oauth2 import service_account
 from zentral.conf import settings
 from zentral.core.queues.backends.base import BaseEventQueues
 from zentral.core.queues.exceptions import RetryLater
+from zentral.core.queues.preprocessing import iter_preprocessed_events
 from .consumer import BaseWorker, Consumer, ConsumerProducer
 
 
@@ -41,21 +42,14 @@ class PreprocessWorker(ConsumerProducer):
 
     def callback(self, message):
         routing_key = message.attributes.get("routing_key")
-        if not routing_key:
-            self.log_error("Message w/o routing key")
-        else:
-            preprocessor = self.preprocessors.get(routing_key)
-            if not preprocessor:
-                self.log_error("No preprocessor for routing key %s", routing_key)
-            else:
-                try:
-                    for event in preprocessor.process_raw_event(json.loads(message.data)):
-                        self.publish_event(event, machine_metadata=False)
-                        self.inc_counter("produced_events", event.event_type)
-                except RetryLater:
-                    self.log_error("Message with routing key %s could not be preprocessed. Re-enqueued", routing_key)
-                    message.nack()
-                    return
+        try:
+            for event in iter_preprocessed_events(self.preprocessors, routing_key, json.loads(message.data)):
+                self.publish_event(event, machine_metadata=False)
+                self.inc_counter("produced_events", event.event_type)
+        except RetryLater:
+            self.log_error("Message with routing key %s could not be preprocessed. Re-enqueued", routing_key)
+            message.nack()
+            return
         message.ack()
         self.inc_counter("preprocessed_events", routing_key or "UNKNOWN")
 

--- a/zentral/core/queues/backends/kombu.py
+++ b/zentral/core/queues/backends/kombu.py
@@ -7,6 +7,7 @@ from kombu.mixins import ConsumerMixin, ConsumerProducerMixin
 from kombu.pools import producers
 from zentral.core.queues.backends.base import BaseEventQueues
 from zentral.core.queues.exceptions import RetryLater
+from zentral.core.queues.preprocessing import iter_preprocessed_events
 from zentral.utils.json import save_dead_letter
 
 
@@ -95,24 +96,17 @@ class PreprocessWorker(ConsumerProducerMixin, BaseWorker):
 
     def do_preprocess_raw_event(self, body, message):
         routing_key = message.delivery_info.get("routing_key")
-        if not routing_key:
-            logger.error("Message w/o routing key")
-        else:
-            preprocessor = self.preprocessors.get(routing_key)
-            if not preprocessor:
-                logger.error("No preprocessor for routing key %s", routing_key)
-            else:
-                try:
-                    for event in preprocessor.process_raw_event(body):
-                        self.producer.publish(event.serialize(machine_metadata=False),
-                                              serializer='json',
-                                              exchange=events_exchange,
-                                              declare=[events_exchange])
-                        self.inc_counter("produced_events", event.event_type)
-                except RetryLater:
-                    logger.error("Message with routing key %s could not be processed. Re-enqueued", routing_key)
-                    message.requeue()
-                    return
+        try:
+            for event in iter_preprocessed_events(self.preprocessors, routing_key, body):
+                self.producer.publish(event.serialize(machine_metadata=False),
+                                      serializer='json',
+                                      exchange=events_exchange,
+                                      declare=[events_exchange])
+                self.inc_counter("produced_events", event.event_type)
+        except RetryLater:
+            logger.error("Message with routing key %s could not be processed. Re-enqueued", routing_key)
+            message.requeue()
+            return
         message.ack()
         self.inc_counter("preprocessed_events", routing_key or "UNKNOWN")
 

--- a/zentral/core/queues/preprocessing.py
+++ b/zentral/core/queues/preprocessing.py
@@ -1,0 +1,31 @@
+import logging
+from django.db import InterfaceError, OperationalError, close_old_connections
+from zentral.core.queues.exceptions import RetryLater
+
+
+logger = logging.getLogger("zentral.core.queues.preprocessing")
+
+
+def iter_preprocessed_events(preprocessors, routing_key, raw_event):
+    # Single entry point every queue backend uses to run a preprocessor: resolve the one for
+    # the routing key, yield the events it produces, and recycle a dead pooled connection.
+    #
+    # Preprocessors run in a long-lived worker with no request cycle, so Django never recycles
+    # their pooled connection (CONN_HEALTH_CHECKS / CONN_MAX_AGE are driven by the request
+    # signals). When a pooler/proxy drops an idle connection, the next commit raises
+    # InterfaceError/OperationalError: drop the dead connection so the retry and the following
+    # messages reconnect, then re-enqueue with RetryLater. A RetryLater raised by a preprocessor
+    # (e.g. an API rate limit) passes straight through.
+    if not routing_key:
+        logger.error("Message without routing key")
+        return
+    preprocessor = preprocessors.get(routing_key)
+    if not preprocessor:
+        logger.error("No preprocessor for routing key %s", routing_key)
+        return
+    try:
+        yield from preprocessor.process_raw_event(raw_event)
+    except (InterfaceError, OperationalError) as error:
+        logger.error("Preprocessor %s: recoverable DB error, re-enqueuing: %s", routing_key, error)
+        close_old_connections()
+        raise RetryLater


### PR DESCRIPTION
## Problem

The preprocess worker runs a long-lived consumer loop with no request/response cycle, so Django never recycles its pooled DB connection: `CONN_HEALTH_CHECKS` and `CONN_MAX_AGE` are driven by the `request_started` / `request_finished` signals, which workers don't emit.

Behind a connection pooler/proxy that closes idle connections (e.g. RDS Proxy), a dropped connection surfaces on the next commit as `OperationalError` / `InterfaceError`. Only the inventory preprocessor caught that and retried — and it reused the same dead connection, so every following `inventory_machine_snapshot` message failed with `connection already closed` until the process restarted; the worker re-enqueued continuously and dead-lettered a large share of check-ins. The other preprocessors (`mdm`, `jamf`, `puppet`, `wsone`) had no handling at all and just let the worker crash.

This is the worker-tier counterpart to #1536, which enabled `CONN_HEALTH_CHECKS` for the (request-cycle) web tier.

## Fix

Add `iter_preprocessed_events()` — a single entry point every queue backend uses to run a preprocessor. It resolves the preprocessor for the routing key, yields the events it produces, and on a recoverable DB error drops the dead connection with `close_old_connections()` and raises `RetryLater`, so the retry — and the following messages — reconnect instead of failing on the same broken connection. `RetryLater` (e.g. an API rate limit raised by a preprocessor) and any other error pass straight through.

The three backends (SQS, Pub/Sub, kombu) now share it instead of each duplicating the routing-key lookup and the retry handling — so every preprocessor (current and future) gets the connection resilience uniformly. The inventory preprocessor no longer handles the DB error itself; it just re-raises it, so its deterministic-drop `except Exception` can't swallow it.

## Testing

- `tests/core_queues/test_preprocessing.py` covers the wrapper: events pass through untouched; missing/unknown routing key yields nothing; `OperationalError` / `InterfaceError` → connection recycled + `RetryLater`; a plain `RetryLater` passes through without recycling.
- Per-backend tests drive each preprocess worker through the wrapper on both the happy path and the `RetryLater` re-enqueue path (`test_kombu.py`, plus additions to `test_aws_sns_sqs.py` and `test_google_pubsub.py`).
- Updated `tests/inventory/test_preprocessors.py`: a transient DB error now propagates (re-raised, not dropped).
- `tests.core_queues` + `tests.inventory.test_preprocessors` pass (60 tests); the changed lines are fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
