### PR TITLE
Look up Apps and Books asset metadata in the location storefront

### DIFF
--- a/tests/mdm/management_commands/test_others.py
+++ b/tests/mdm/management_commands/test_others.py
@@ -1,16 +1,16 @@
 import datetime
 import uuid
 from io import StringIO
-from unittest.mock import call, patch
+from unittest.mock import call, patch, Mock
 
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 
 from zentral.contrib.mdm.dep_client import DEPClientError
-from zentral.contrib.mdm.models import ACMEIssuer, Location, SCEPIssuer
+from zentral.contrib.mdm.models import ACMEIssuer, Location, LocationAsset, SCEPIssuer
 
-from ..utils import force_dep_virtual_server
+from ..utils import force_asset, force_dep_virtual_server
 
 
 class MDMManagementCommandsTest(TestCase):
@@ -77,6 +77,120 @@ class MDMManagementCommandsTest(TestCase):
             f"Sync apps & books for location {location.pk} fomo\n"
         )
         sync_assets.assert_called_once_with(location)
+
+    # refresh_apps_books_asset_metadata
+
+    def _force_location_asset_without_metadata(self, location):
+        asset = force_asset()
+        LocationAsset.objects.create(asset=asset, location=location)
+        return asset
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.AppsBooksClient")
+    def test_refresh_apps_books_asset_metadata(self, AppsBooksClient, refresh_asset_metadata):
+        location = self._force_location(name="yolo")
+        asset = self._force_location_asset_without_metadata(location)
+        client = Mock()
+        AppsBooksClient.from_location.return_value = client
+        refresh_asset_metadata.return_value = True
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            f"Location {location.pk} yolo, DE storefront\n"
+            f"Asset {asset.adam_id} {asset.pricing_param} refreshed\n"
+        )
+        refresh_asset_metadata.assert_called_once_with(client, asset)
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.AppsBooksClient")
+    def test_refresh_apps_books_asset_metadata_not_refreshed(self, AppsBooksClient, refresh_asset_metadata):
+        location = self._force_location(name="yolo")
+        asset = self._force_location_asset_without_metadata(location)
+        refresh_asset_metadata.return_value = False
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            f"Location {location.pk} yolo, DE storefront\n"
+            f"Asset {asset.adam_id} {asset.pricing_param} not refreshed\n"
+        )
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.AppsBooksClient")
+    def test_refresh_apps_books_asset_metadata_skips_assets_with_metadata(
+        self, AppsBooksClient, refresh_asset_metadata
+    ):
+        location = self._force_location(name="yolo")
+        asset = self._force_location_asset_without_metadata(location)
+        asset.name = get_random_string(12)
+        asset.save()
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', stdout=out)
+        self.assertEqual(out.getvalue(), f"Location {location.pk} yolo, DE storefront\n")
+        refresh_asset_metadata.assert_not_called()
+        AppsBooksClient.from_location.assert_not_called()
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.AppsBooksClient")
+    def test_refresh_apps_books_asset_metadata_all(self, AppsBooksClient, refresh_asset_metadata):
+        location = self._force_location(name="yolo")
+        asset = self._force_location_asset_without_metadata(location)
+        asset.name = get_random_string(12)
+        asset.save()
+        refresh_asset_metadata.return_value = True
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', '--all', stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            f"Location {location.pk} yolo, DE storefront\n"
+            f"Asset {asset.adam_id} {asset.pricing_param} refreshed\n"
+        )
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.AppsBooksClient")
+    def test_refresh_apps_books_asset_metadata_dry_run(self, AppsBooksClient, refresh_asset_metadata):
+        location = self._force_location(name="yolo")
+        asset = self._force_location_asset_without_metadata(location)
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', '--dry-run', stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            f"Location {location.pk} yolo, DE storefront\n"
+            f"Asset {asset.adam_id} {asset.pricing_param} to refresh\n"
+        )
+        AppsBooksClient.from_location.assert_not_called()
+        refresh_asset_metadata.assert_not_called()
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.AppsBooksClient")
+    def test_refresh_apps_books_asset_metadata_one_location(self, AppsBooksClient, refresh_asset_metadata):
+        location = self._force_location(name="yolo")
+        self._force_location_asset_without_metadata(location)
+        other_location = self._force_location(name="fomo")
+        other_asset = self._force_location_asset_without_metadata(other_location)
+        refresh_asset_metadata.return_value = True
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', '--location', str(other_location.pk), stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            f"Location {other_location.pk} fomo, DE storefront\n"
+            f"Asset {other_asset.adam_id} {other_asset.pricing_param} refreshed\n"
+        )
+
+    @patch("zentral.contrib.mdm.management.commands.refresh_apps_books_asset_metadata.refresh_asset_metadata")
+    def test_refresh_apps_books_asset_metadata_list_locations(self, refresh_asset_metadata):
+        location1 = self._force_location(name="yolo")
+        location2 = self._force_location(name="fomo")
+        out = StringIO()
+        call_command('refresh_apps_books_asset_metadata', '--list-locations', stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            "Existing locations:\n"
+            f"{location2.pk} fomo\n"
+            f"{location1.pk} yolo\n"
+        )
+        refresh_asset_metadata.assert_not_called()
 
     # sync_dep_devices
 

--- a/tests/mdm/test_apps_books_assets_assignments_sync.py
+++ b/tests/mdm/test_apps_books_assets_assignments_sync.py
@@ -10,6 +10,8 @@ from zentral.contrib.mdm.apps_books import (_sync_asset_d,
                                             associate_location_asset,
                                             bulk_assign_location_asset,
                                             disassociate_location_asset,
+                                            iter_location_assets_to_refresh,
+                                            refresh_asset_metadata,
                                             sync_asset, sync_assets,
                                             update_location_asset_counts)
 from zentral.contrib.mdm.events import (AssetCreatedEvent, AssetUpdatedEvent,
@@ -506,6 +508,84 @@ class MDMAppsBooksAssetsAssignmentsSyncTestCase(TestCase):
         client.iter_asset_device_assignments.return_value = [serial_number]
         sync_assets(location)
         self.assertEqual(len(post_event.call_args_list), 3)
+
+    # iter_location_assets_to_refresh
+
+    def test_iter_location_assets_to_refresh_only_without_metadata(self):
+        location = force_location()
+        asset_with_metadata = force_asset()
+        asset_with_metadata.name = get_random_string(12)
+        asset_with_metadata.save()
+        force_location_asset(asset=asset_with_metadata, location=location)
+        asset_without_metadata = force_location_asset(location=location).asset
+        asset_with_empty_name = force_asset()
+        asset_with_empty_name.name = ""
+        asset_with_empty_name.save()
+        force_location_asset(asset=asset_with_empty_name, location=location)
+        self.assertEqual(
+            set(iter_location_assets_to_refresh(location)),
+            {asset_without_metadata, asset_with_empty_name}
+        )
+
+    def test_iter_location_assets_to_refresh_all(self):
+        location = force_location()
+        asset = force_asset()
+        asset.name = get_random_string(12)
+        asset.save()
+        force_location_asset(asset=asset, location=location)
+        other_asset = force_location_asset(location=location).asset
+        self.assertEqual(
+            set(iter_location_assets_to_refresh(location, only_without_metadata=False)),
+            {asset, other_asset}
+        )
+
+    def test_iter_location_assets_to_refresh_other_location(self):
+        location = force_location()
+        force_location_asset()
+        self.assertEqual(list(iter_location_assets_to_refresh(location)), [])
+
+    # refresh_asset_metadata
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_refresh_asset_metadata(self, post_event):
+        asset = force_asset()
+        asset_name = get_random_string(12)
+        bundle_id = "pro.zentral.tests"
+        client = Mock()
+        client.get_asset_metadata.return_value = {"name": asset_name, "bundleId": bundle_id}
+        self.assertTrue(refresh_asset_metadata(client, asset))
+        client.get_asset_metadata.assert_called_once_with(asset.adam_id)
+        asset.refresh_from_db()
+        self.assertEqual(asset.name, asset_name)
+        self.assertEqual(asset.bundle_id, bundle_id)
+        self.assertEqual(asset.metadata, {"name": asset_name, "bundleId": bundle_id})
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AssetUpdatedEvent)
+        self.assertEqual(event.payload["name"], asset_name)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_refresh_asset_metadata_not_in_storefront(self, post_event):
+        asset = force_asset()
+        client = Mock()
+        client.get_asset_metadata.return_value = None
+        self.assertFalse(refresh_asset_metadata(client, asset))
+        asset.refresh_from_db()
+        self.assertIsNone(asset.name)
+        post_event.assert_not_called()
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_refresh_asset_metadata_noop(self, post_event):
+        asset = force_asset()
+        metadata = {"name": get_random_string(12), "bundleId": "pro.zentral.tests"}
+        asset.metadata = metadata
+        asset.name = metadata["name"]
+        asset.bundle_id = metadata["bundleId"]
+        asset.save()
+        client = Mock()
+        client.get_asset_metadata.return_value = metadata
+        self.assertFalse(refresh_asset_metadata(client, asset))
+        post_event.assert_not_called()
 
     # _update_location_asset_counts
 

--- a/tests/mdm/test_apps_books_client.py
+++ b/tests/mdm/test_apps_books_client.py
@@ -44,6 +44,7 @@ class MDMAppsBooksClientTestCase(TestCase):
             str(location.mdm_info_id) if location else None,
             location.name if location else None,
             "enterprisestore",
+            location.country_code if location else None,
             location
         ), location
 
@@ -189,6 +190,31 @@ class MDMAppsBooksClientTestCase(TestCase):
         requests.get.return_value = resp
         client, location = self._get_client({"urls": {"contentMetadataLookup": "https://www.example.com"}}, True)
         self.assertEqual(client.get_asset_metadata("yolo"), {"ok": True})
+
+    @patch("zentral.contrib.mdm.apps_books.requests")
+    def test_get_asset_metadata_location_storefront(self, requests):
+        resp = Mock()
+        resp.json.return_value = {"results": {"yolo": {"ok": True}}}
+        requests.get.return_value = resp
+        client, _ = self._get_client({"urls": {"contentMetadataLookup": "https://www.example.com"}}, True)
+        self.assertEqual(client.get_asset_metadata("yolo"), {"ok": True})
+        _, kwargs = requests.get.call_args_list[0]
+        self.assertEqual(kwargs["params"]["cc"], "de")
+
+    def test_get_asset_metadata_default_storefront(self):
+        client, _ = self._get_client({}, False)
+        self.assertEqual(client.country_code, "us")
+
+    @patch("zentral.contrib.mdm.apps_books.requests")
+    def test_get_asset_metadata_not_in_storefront(self, requests):
+        resp = Mock()
+        resp.json.return_value = {"results": {}}
+        requests.get.return_value = resp
+        client, _ = self._get_client({"urls": {"contentMetadataLookup": "https://www.example.com"}}, True)
+        with self.assertLogs("zentral.contrib.mdm.apps_books", level="ERROR") as cm:
+            self.assertIsNone(client.get_asset_metadata("yolo"))
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("no asset yolo metadata in the de storefront", cm.output[0])
 
     # iter_asset_device_assignments
 

--- a/zentral/contrib/mdm/apps_books.py
+++ b/zentral/contrib/mdm/apps_books.py
@@ -59,6 +59,7 @@ class AppsBooksClient:
         mdm_info_id=None,
         location_name=None,
         platform=None,
+        country_code=None,
         location=None
     ):
         self.server_token = server_token
@@ -72,6 +73,7 @@ class AppsBooksClient:
         self.mdm_info_id = mdm_info_id
         self.location_name = location_name
         self.platform = platform or "enterprisestore"
+        self.country_code = (country_code or "us").lower()
         self._service_config = None
         self.location = location
 
@@ -81,6 +83,7 @@ class AppsBooksClient:
                    str(location.mdm_info_id),
                    location.name,
                    location.platform,
+                   location.country_code,
                    location)
 
     def make_request(self, path, retry_if_invalid_token=True, verify_mdm_info=False, **kwargs):
@@ -192,10 +195,10 @@ class AppsBooksClient:
             resp = requests.get(
                 url,
                 params={"version": 2,
-                        "p": "mdm-lockup",  # TODO: Really?
+                        "p": "mdm-lockup",  # Apple confirmed "mdm-lookup" in the protocol reference is a typo
                         "caller": "MDM",
                         "platform": self.platform,
-                        "cc": "us",
+                        "cc": self.country_code,
                         "l": "en",
                         "id": adam_id},
                 cookies={"itvt": self.server_token}
@@ -204,7 +207,12 @@ class AppsBooksClient:
         except Exception:
             logger.exception("Location %s: could not get asset %s metadata.", self.location_name, adam_id)
         else:
-            return resp.json().get("results", {}).get(adam_id)
+            metadata = resp.json().get("results", {}).get(adam_id)
+            if not metadata:
+                logger.error("Location %s: no asset %s metadata in the %s storefront.",
+                             self.location_name, adam_id, self.country_code)
+                return
+            return metadata
 
     # assignments
 

--- a/zentral/contrib/mdm/apps_books.py
+++ b/zentral/contrib/mdm/apps_books.py
@@ -8,6 +8,7 @@ import requests
 from base.utils import deployment_info
 from django.core.cache import cache
 from django.db import connection, transaction
+from django.db.models import Q
 from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 
@@ -540,6 +541,34 @@ def sync_assets(location):
     for asset_d in client.iter_assets():
         for event in _sync_asset_d(location, client, asset_d):
             event.post()
+
+
+def iter_location_assets_to_refresh(location, only_without_metadata=True):
+    qs = Asset.objects.filter(locationasset__location=location)
+    if only_without_metadata:
+        qs = qs.filter(Q(name__isnull=True) | Q(name=""))
+    yield from qs.order_by("adam_id", "pricing_param")
+
+
+def refresh_asset_metadata(client, asset):
+    metadata = client.get_asset_metadata(asset.adam_id)
+    if not metadata:
+        return False
+    with transaction.atomic():
+        asset = Asset.objects.select_for_update().get(pk=asset.pk)
+        updated = False
+        for attr, new_val in (("metadata", metadata),
+                              ("name", metadata.get("name")),
+                              ("bundle_id", metadata.get("bundleId"))):
+            if getattr(asset, attr) != new_val:
+                setattr(asset, attr, new_val)
+                updated = True
+        if not updated:
+            return False
+        asset.save()
+        event = AssetUpdatedEvent(EventMetadata(), asset.serialize_for_event(keys_only=False))
+    event.post()
+    return True
 
 
 def _update_location_asset_counts(location_asset, updates, notification_id):

--- a/zentral/contrib/mdm/management/commands/refresh_apps_books_asset_metadata.py
+++ b/zentral/contrib/mdm/management/commands/refresh_apps_books_asset_metadata.py
@@ -1,0 +1,53 @@
+from django.core.management.base import BaseCommand
+from zentral.contrib.mdm.apps_books import (AppsBooksClient,
+                                            iter_location_assets_to_refresh,
+                                            refresh_asset_metadata)
+from zentral.contrib.mdm.models import Location
+from zentral.core.queues import queues
+
+
+class Command(BaseCommand):
+    help = 'Refresh apps & books asset metadata'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--list-locations', action='store_true', dest='list_locations', default=False,
+                            help='list existing apps & books locations')
+        parser.add_argument('--location', dest='location_ids', type=int, nargs='+',
+                            help='only refresh the assets of these locations')
+        parser.add_argument('--all', action='store_true', dest='all_assets', default=False,
+                            help='refresh all assets, not only the ones without metadata')
+        parser.add_argument('--dry-run', action='store_true', dest='dry_run', default=False,
+                            help='list the assets to refresh without contacting Apple')
+
+    def write(self, msg):
+        if self.verbosity:
+            self.stdout.write(msg)
+
+    def handle(self, *args, **kwargs):
+        self.verbosity = kwargs.get("verbosity", 1)
+        location_qs = Location.objects.all().order_by("name")
+        if kwargs.get('list_locations'):
+            self.write("Existing locations:")
+            for location in location_qs:
+                self.write(f"{location.pk} {location}")
+            return
+        location_ids = kwargs.get("location_ids")
+        if location_ids:
+            location_qs = location_qs.filter(pk__in=location_ids)
+        only_without_metadata = not kwargs.get("all_assets")
+        dry_run = kwargs.get("dry_run")
+        for location in location_qs:
+            self.write(f"Location {location.pk} {location}, {location.country_code} storefront")
+            client = None
+            for asset in iter_location_assets_to_refresh(location, only_without_metadata):
+                if dry_run:
+                    self.write(f"Asset {asset.adam_id} {asset.pricing_param} to refresh")
+                    continue
+                if client is None:
+                    client = AppsBooksClient.from_location(location)
+                if refresh_asset_metadata(client, asset):
+                    self.write(f"Asset {asset.adam_id} {asset.pricing_param} refreshed")
+                else:
+                    self.write(f"Asset {asset.adam_id} {asset.pricing_param} not refreshed")
+        if not dry_run:
+            queues.stop()


### PR DESCRIPTION
## What

The Apps and Books content metadata lookup was pinned to the US storefront:

```python
"cc": "us",
```

Apple scopes that catalog by country, so an asset that is not sold in the US resolves to an empty result. The asset is then created with its adam ID but no name, bundle ID or icon.

`Location` already stores a `country_code`, collected from `countryISO2ACode` when the location is set up, but it never reached the client. It does now, and the lookup uses it.

## Why it went unnoticed

The empty result is a 200 with no entry for the adam ID, so neither the exception handler nor the missing-URL branch fired and nothing reached the logs. `get_asset_metadata` now logs it.

That silence is also why this is hard to spot in the wild: most apps are in the US catalog too, so they resolve by accident. Only country-exclusive assets fail, and they fail quietly.

## Backfill

Affected assets do not recover on their own. The sync only sets `name`/`bundle_id`/`metadata` when the lookup resolves, so a missing result leaves the stored values untouched rather than overwriting them — every later sync repeats the same failed lookup.

`sync_apps_books` would fix them now that the storefront is right, but it refetches every asset and all of its device assignments. The new `refresh_apps_books_asset_metadata` command reads only the assets without metadata, and saves and emits an event only when the lookup actually changes something:

```
python server/manage.py refresh_apps_books_asset_metadata --location <id> --dry-run
```

Flags: `--list-locations`, `--location` (accepts several ids), `--all` to also refresh assets that already have metadata, `--dry-run` to list candidates without contacting Apple. `--dry-run` builds no client and never touches the queue; the client is constructed lazily, so a location with nothing to refresh makes no API call.

## Notes for reviewers

- `country_code` is inserted before `location` in the `AppsBooksClient` signature rather than appended — there are only two construction sites, both updated. It is lowercased because Apple returns `countryISO2ACode` uppercase, and defaults to `us` when the client is built without a location, which is the case during location setup in `forms.py`.
- The candidate filter matches `name` null **or** empty, since `_sync_asset_d` leaves `name` unset when the payload carries no `name` key.
- `refresh_asset_metadata` re-reads under `select_for_update` and posts `AssetUpdatedEvent` after the transaction commits.
- `l` is still hard-coded to `"en"`. It does not affect whether an asset resolves, so it is left out of this change, but a non-English tenant gets English names. Easy follow-up now that the country code is plumbed through.
- No docs change: of the sibling commands, only `mdmcerts` is documented.

## Tests

`tests.mdm` — 2471 passing, 13 new. Coverage for the storefront parameter, the default, and the silent empty result; for both new helpers; and for the command across default, `--all`, `--dry-run`, `--location` and `--list-locations`. ruff and flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)