### PR TITLE
Compress the raw events too big for the queue, and stop building oversized SQS batches

### DIFF
--- a/tests/core_queues/test_aws_sns_sqs.py
+++ b/tests/core_queues/test_aws_sns_sqs.py
@@ -26,9 +26,12 @@ from zentral.core.queues.backends.aws_sns_sqs import (
     ProcessWorker,
     SimpleStoreWorker,
 )
+from zentral.core.queues.compression import COMPRESSED_RAW_EVENT_KEY, decompress_raw_event
 from zentral.core.stores.backends.http import HTTPStoreSerializer
 from zentral.core.stores.backends.s3_parquet import S3ParquetStoreSerializer
 from zentral.core.stores.models import Store
+
+from .test_compression import build_big_raw_event
 
 
 class AWSSNSSQSQueuesTestCase(TestCase):
@@ -746,6 +749,19 @@ class AWSSNSSQSQueuesTestCase(TestCase):
         self.assertIs(args[2], eq._raw_events_queue)
         SQSSendThread.return_value.start.assert_called_once()
         self.assertEqual(eq._raw_events_queue.qsize(), 2)
+
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues._setup_graceful_stop")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues.setup_queue")
+    @patch("zentral.core.queues.backends.aws_sns_sqs.SQSSendThread")
+    def test_post_raw_event_compresses_big_raw_event(self, SQSSendThread, setup_queue, setup_graceful_stop):
+        setup_queue.return_value = "https://example.com/rq"
+        eq = self.get_queues()
+        raw_event = build_big_raw_event()
+        eq.post_raw_event("routing-key", raw_event)
+        _, routing_key, posted_raw_event, _ = eq._raw_events_queue.get_nowait()
+        self.assertEqual(routing_key, "routing-key")
+        self.assertEqual(list(posted_raw_event), [COMPRESSED_RAW_EVENT_KEY])
+        self.assertEqual(decompress_raw_event(posted_raw_event), raw_event)
 
     @patch("zentral.core.queues.backends.aws_sns_sqs.setup_signal_handler")
     def test_setup_graceful_stop_wires_signals_once(self, setup_signal_handler):

--- a/tests/core_queues/test_aws_sns_sqs.py
+++ b/tests/core_queues/test_aws_sns_sqs.py
@@ -3,6 +3,7 @@ import os.path
 import queue
 import signal
 import threading
+import time
 from datetime import datetime
 from unittest.mock import Mock, patch
 
@@ -590,6 +591,56 @@ class AWSSNSSQSQueuesTestCase(TestCase):
         w = eq.get_store_worker(store)
         self.assertIsInstance(w, SimpleStoreWorker)
         self.assertEqual(w._threads[0].visibility_timeout, 120)
+
+    # batching: SQS rejects a whole batch over its size cap, so the batch is split by bytes too
+
+    def _run_send_thread(self, event_ds):
+        """Drain event_ds through a real run() loop and return the sent batches."""
+        eq = self.get_queues()
+        stop_event = threading.Event()
+        in_queue = queue.Queue()
+        for event_d in event_ds:
+            in_queue.put((None, "routing-key", event_d, time.monotonic()))
+        thread = SQSSendThread("https://www.example.com/queue", stop_event, in_queue, None, eq.client_kwargs)
+        thread.client = Mock()
+        thread.client.send_message_batch = Mock(return_value={"Successful": [], "Failed": []})
+        # pre-set: run() drains the in_queue, then flushes and exits on the first empty get
+        stop_event.set()
+        thread.run()
+        return [c.kwargs["Entries"] for c in thread.client.send_message_batch.call_args_list]
+
+    def test_send_thread_batches_ten_small_messages_together(self):
+        batches = self._run_send_thread([{"i": i} for i in range(10)])
+        self.assertEqual([len(b) for b in batches], [10])
+
+    def test_send_thread_splits_batch_over_the_byte_limit(self):
+        # two messages that each fit on their own but not together
+        half = SQSSendThread.max_batch_byte_size // 2 + 1024
+        batches = self._run_send_thread([{"payload": "x" * half}, {"payload": "y" * half}])
+        self.assertEqual([len(b) for b in batches], [1, 1])
+        self.assertIn("x", batches[0][0]["MessageBody"])
+        self.assertIn("y", batches[1][0]["MessageBody"])
+
+    def test_send_thread_keeps_the_message_attributes_in_the_byte_count(self):
+        entry = {"Id": "entry-id-1",
+                 "MessageBody": '{"yolo": "fomo"}',
+                 "MessageAttributes": {"zentral.routing_key": {"DataType": "String",
+                                                               "StringValue": "inventory_machine_snapshot"}}}
+        self.assertEqual(
+            SQSSendThread._entry_byte_size(entry),
+            len(entry["MessageBody"]) + len("zentral.routing_key") + len("String")
+            + len("inventory_machine_snapshot")
+        )
+
+    def test_send_thread_sends_oversized_message_alone_and_logs_it(self):
+        oversized = {"payload": "x" * (SQSSendThread.max_batch_byte_size + 1024)}
+        with self.assertLogs("zentral.core.queues.backends.aws_sns_sqs.sqs", level="ERROR") as cm:
+            batches = self._run_send_thread([{"i": 1}, oversized, {"i": 2}])
+        # the small message before it is not batched with it, and it is not batched with the one after
+        self.assertEqual([len(b) for b in batches], [1, 1, 1])
+        self.assertGreater(len(batches[1][0]["MessageBody"]), SQSSendThread.max_batch_byte_size)
+        self.assertIn("byte message over the", cm.output[0])
+        self.assertIn("routing key routing-key", cm.output[0])
 
     # shutdown behavior: out_queue.put loops must observe stop_event
 

--- a/tests/core_queues/test_compression.py
+++ b/tests/core_queues/test_compression.py
@@ -1,0 +1,80 @@
+from base64 import b64encode
+from datetime import datetime
+import uuid
+from compression import zstd
+from django.test import SimpleTestCase
+from kombu.utils import json
+from zentral.core.queues.compression import (COMPRESSED_RAW_EVENT_KEY, COMPRESSION_MIN_SIZE,
+                                             compress_raw_event_if_needed, decompress_raw_event)
+
+
+def build_big_raw_event():
+    return {"ms_tree": {"serial_number": "0123456789",
+                        "osx_app_instances": [{"app": {"bundle_id": f"com.example.app{i}",
+                                                       "bundle_name": f"App {i}",
+                                                       "bundle_version": "1.2.3",
+                                                       "bundle_version_str": "1.2.3"},
+                                               "bundle_path": f"/Applications/App {i}.app"}
+                                              for i in range(200)]}}
+
+
+class RawEventCompressionTestCase(SimpleTestCase):
+    maxDiff = None
+
+    def test_small_raw_event_posted_as_is(self):
+        raw_event = {"ms_tree": {"serial_number": "0123456789"}}
+        self.assertIs(compress_raw_event_if_needed(raw_event), raw_event)
+
+    def test_raw_event_under_the_threshold_posted_as_is(self):
+        raw_event = {"ms_tree": ""}
+        padding = COMPRESSION_MIN_SIZE - len(json.dumps(raw_event).encode("utf-8")) - 1
+        raw_event["ms_tree"] = "y" * padding
+        self.assertEqual(len(json.dumps(raw_event).encode("utf-8")), COMPRESSION_MIN_SIZE - 1)
+        self.assertIs(compress_raw_event_if_needed(raw_event), raw_event)
+
+    def test_raw_event_at_the_threshold_compressed(self):
+        raw_event = {"ms_tree": ""}
+        padding = COMPRESSION_MIN_SIZE - len(json.dumps(raw_event).encode("utf-8"))
+        raw_event["ms_tree"] = "y" * padding
+        self.assertEqual(len(json.dumps(raw_event).encode("utf-8")), COMPRESSION_MIN_SIZE)
+        self.assertEqual(list(compress_raw_event_if_needed(raw_event)), [COMPRESSED_RAW_EVENT_KEY])
+
+    def test_big_raw_event_compressed_and_inflated(self):
+        raw_event = build_big_raw_event()
+        serialized_size = len(json.dumps(raw_event).encode("utf-8"))
+        self.assertGreater(serialized_size, COMPRESSION_MIN_SIZE)
+        compressed_raw_event = compress_raw_event_if_needed(raw_event)
+        self.assertEqual(list(compressed_raw_event), [COMPRESSED_RAW_EVENT_KEY])
+        self.assertIsInstance(compressed_raw_event[COMPRESSED_RAW_EVENT_KEY], str)
+        self.assertLess(len(json.dumps(compressed_raw_event).encode("utf-8")), serialized_size)
+        self.assertEqual(decompress_raw_event(compressed_raw_event), raw_event)
+
+    def test_payload_needs_no_json_escaping(self):
+        # the base64 alphabet contains no character JSON escapes, so the wire size is the payload
+        # plus the {"…":"…"} wrapper and nothing more — an encoding that needs escaping would cost
+        # more on the wire than it saves
+        compressed_raw_event = compress_raw_event_if_needed(build_big_raw_event())
+        payload = compressed_raw_event[COMPRESSED_RAW_EVENT_KEY]
+        self.assertEqual(len(json.dumps(compressed_raw_event).encode("utf-8")),
+                         len(payload) + len(COMPRESSED_RAW_EVENT_KEY) + 8)
+
+    def test_datetimes_and_uuids_survive_compression(self):
+        raw_event = build_big_raw_event()
+        raw_event["ms_tree"]["last_seen"] = datetime(2026, 7, 28, 12, 34, 56)
+        raw_event["ms_tree"]["target"] = uuid.UUID("cae8b1c6-b1a5-4ea6-b1b3-5b7cd9a5e0f6")
+        # the blob must inflate to exactly what an uncompressed raw event deserializes to,
+        # whatever the registered kombu encoders make of those two types
+        self.assertEqual(decompress_raw_event(compress_raw_event_if_needed(raw_event)),
+                         json.loads(json.dumps(raw_event)))
+
+    def test_decompress_uncompressed_raw_event_posted_as_is(self):
+        raw_event = {"ms_tree": {"serial_number": "0123456789"}}
+        self.assertIs(decompress_raw_event(raw_event), raw_event)
+
+    def test_decompress_not_a_dict_posted_as_is(self):
+        raw_event = ["yolo", "fomo"]
+        self.assertIs(decompress_raw_event(raw_event), raw_event)
+
+    def test_decompress_corrupted_payload_raises(self):
+        with self.assertRaises(zstd.ZstdError):
+            decompress_raw_event({COMPRESSED_RAW_EVENT_KEY: b64encode(b"not a zstd frame").decode("ascii")})

--- a/tests/core_queues/test_google_pubsub.py
+++ b/tests/core_queues/test_google_pubsub.py
@@ -1,8 +1,11 @@
 from unittest.mock import Mock, patch
 from django.test import TestCase
+from kombu.utils import json
 from zentral.core.queues.backends.google_pubsub import EventQueues, PreprocessWorker
 from zentral.core.queues.backends.google_pubsub.consumer import BaseWorker
+from zentral.core.queues.compression import COMPRESSED_RAW_EVENT_KEY, decompress_raw_event
 from zentral.core.queues.exceptions import RetryLater
+from .test_compression import build_big_raw_event
 
 
 class GooglePubSubQueuesTestCase(TestCase):
@@ -78,6 +81,17 @@ class GooglePubSubQueuesTestCase(TestCase):
         self.assertIsInstance(publish.call_args_list[0].args[1], bytes)
         self.assertEqual(publish.call_args_list[0].kwargs, {"event_type": "yolo"})
         self.assertEqual(publish.call_args_list[1].kwargs, {"routing_key": "routing-key"})
+
+    @patch("zentral.core.queues.backends.google_pubsub.pubsub_v1.PublisherClient")
+    def test_post_raw_event_compresses_big_raw_event(self, PublisherClient):
+        eq = self.get_queues()
+        raw_event = build_big_raw_event()
+        eq.post_raw_event("routing-key", raw_event)
+        publish = PublisherClient.return_value.publish
+        publish.assert_called_once()
+        posted_raw_event = json.loads(publish.call_args.args[1])
+        self.assertEqual(list(posted_raw_event), [COMPRESSED_RAW_EVENT_KEY])
+        self.assertEqual(decompress_raw_event(posted_raw_event), raw_event)
 
 
 class GooglePubSubBaseWorkerTestCase(TestCase):

--- a/tests/core_queues/test_kombu.py
+++ b/tests/core_queues/test_kombu.py
@@ -1,7 +1,9 @@
 from unittest.mock import Mock, PropertyMock, patch
 from django.test import SimpleTestCase
-from zentral.core.queues.backends.kombu import PreprocessWorker
+from zentral.core.queues.backends.kombu import EventQueues, PreprocessWorker
+from zentral.core.queues.compression import COMPRESSED_RAW_EVENT_KEY, decompress_raw_event
 from zentral.core.queues.exceptions import RetryLater
+from .test_compression import build_big_raw_event
 
 
 class KombuPreprocessWorkerTestCase(SimpleTestCase):
@@ -33,3 +35,19 @@ class KombuPreprocessWorkerTestCase(SimpleTestCase):
             w.do_preprocess_raw_event({"foo": "bar"}, message)
         message.requeue.assert_called_once()
         message.ack.assert_not_called()
+
+
+class KombuEventQueuesTestCase(SimpleTestCase):
+    maxDiff = None
+
+    @patch("zentral.core.queues.backends.kombu.producers")
+    def test_post_raw_event_compresses_big_raw_event(self, producers):
+        eq = EventQueues({"backend_url": "memory://"})
+        raw_event = build_big_raw_event()
+        eq.post_raw_event("routing-key", raw_event)
+        publish = producers.__getitem__.return_value.acquire.return_value.__enter__.return_value.publish
+        publish.assert_called_once()
+        posted_raw_event = publish.call_args.args[0]
+        self.assertEqual(list(posted_raw_event), [COMPRESSED_RAW_EVENT_KEY])
+        self.assertEqual(decompress_raw_event(posted_raw_event), raw_event)
+        self.assertEqual(publish.call_args.kwargs["routing_key"], "routing-key")

--- a/tests/core_queues/test_preprocessing.py
+++ b/tests/core_queues/test_preprocessing.py
@@ -1,8 +1,11 @@
+from base64 import b64encode
 from unittest.mock import patch
 from django.db import InterfaceError, OperationalError
 from django.test import SimpleTestCase
+from zentral.core.queues.compression import COMPRESSED_RAW_EVENT_KEY, compress_raw_event_if_needed
 from zentral.core.queues.exceptions import RetryLater
 from zentral.core.queues.preprocessing import iter_preprocessed_events
+from .test_compression import build_big_raw_event
 
 CLOSE_OLD_CONNECTIONS = "zentral.core.queues.preprocessing.close_old_connections"
 
@@ -13,8 +16,10 @@ class _Preprocessor:
     def __init__(self, events=None, error=None):
         self._events = events or []
         self._error = error
+        self.raw_events = []
 
     def process_raw_event(self, raw_event):
+        self.raw_events.append(raw_event)
         yield from self._events
         if self._error is not None:
             raise self._error
@@ -36,6 +41,25 @@ class IterPreprocessedEventsTestCase(SimpleTestCase):
                 ["a", "b"],
             )
         close_old_connections.assert_not_called()
+
+    def test_compressed_raw_event_inflated_before_the_preprocessor(self):
+        pp = _Preprocessor(events=["a"])
+        raw_event = build_big_raw_event()
+        compressed_raw_event = compress_raw_event_if_needed(raw_event)
+        self.assertNotEqual(compressed_raw_event, raw_event)
+        self.assertEqual(
+            list(iter_preprocessed_events(self._preprocessors(pp), pp.routing_key, compressed_raw_event)),
+            ["a"],
+        )
+        self.assertEqual(pp.raw_events, [raw_event])
+
+    def test_undecompressable_raw_event_dropped(self):
+        pp = _Preprocessor(events=["a"])
+        raw_event = {COMPRESSED_RAW_EVENT_KEY: b64encode(b"not a zstd frame").decode("ascii")}
+        with self.assertLogs("zentral.core.queues.preprocessing", level="ERROR") as cm:
+            self.assertEqual(list(iter_preprocessed_events(self._preprocessors(pp), pp.routing_key, raw_event)), [])
+        self.assertIn(f"Preprocessor {pp.routing_key}: could not decompress raw event", cm.output[0])
+        self.assertEqual(pp.raw_events, [])
 
     def test_missing_routing_key_yields_nothing(self):
         pp = _Preprocessor(events=["a"])

--- a/zentral/core/queues/backends/aws_sns_sqs/__init__.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/__init__.py
@@ -15,6 +15,7 @@ from django.utils.functional import cached_property
 from zentral.conf import settings
 from zentral.conf.config import ConfigDict
 from zentral.core.queues.backends.base import BaseEventQueues
+from zentral.core.queues.compression import compress_raw_event_if_needed
 from zentral.core.queues.preprocessing import iter_preprocessed_events
 from zentral.utils.signals import setup_signal_handler
 from zentral.utils.time import naive_utcnow
@@ -513,7 +514,7 @@ class EventQueues(BaseEventQueues):
                 thread.start()
                 self._threads.append(thread)
                 self._raw_events_queue = raw_events_queue
-        self._raw_events_queue.put((None, routing_key, raw_event, time.monotonic()))
+        self._raw_events_queue.put((None, routing_key, compress_raw_event_if_needed(raw_event), time.monotonic()))
 
     def post_event(self, event):
         # see post_raw_event: one-time sender-thread creation under the lock, put() outside.

--- a/zentral/core/queues/backends/aws_sns_sqs/sqs.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/sqs.py
@@ -143,6 +143,11 @@ class SQSDeleteThread(threading.Thread):
 class SQSSendThread(threading.Thread):
     max_number_of_messages = 10
     max_event_age_seconds = 5
+    # SQS caps a single message and the sum of a batch at the same size, and rejects the batch as a
+    # whole when it is over: without this, one big message takes the nine it was batched with down
+    # with it. The margin covers the attribute accounting on the SQS side not being byte for byte
+    # the one in _entry_byte_size.
+    max_batch_byte_size = 1048576 - 10240
 
     def __init__(self, queue_url, stop_event, in_queue, out_queue, client_kwargs):
         self.client = boto3.client("sqs", **client_kwargs)
@@ -152,9 +157,20 @@ class SQSSendThread(threading.Thread):
         self.out_queue = out_queue
         super().__init__(name="SQS send thread", daemon=True)
 
+    @staticmethod
+    def _entry_byte_size(entry):
+        # the attributes count against the message size too, not only the body
+        size = len(entry["MessageBody"].encode("utf-8"))
+        for name, attribute in entry.get("MessageAttributes", {}).items():
+            size += (len(name.encode("utf-8"))
+                     + len(attribute["DataType"].encode("utf-8"))
+                     + len(attribute["StringValue"].encode("utf-8")))
+        return size
+
     def run(self):
         logger.info("[%s] start on queue %s", self.name, self.queue_url)
         self.entries = {}
+        self.batch_byte_size = 0
         self.min_event_ts = None
         while True:
             logger.debug("[%s] %s event(s) to send", self.name, len(self.entries))
@@ -186,9 +202,21 @@ class SQSSendThread(threading.Thread):
                             "StringValue": routing_key
                         }
                     }
+                entry_byte_size = self._entry_byte_size(entry)
+                if self.entries and self.batch_byte_size + entry_byte_size > self.max_batch_byte_size:
+                    logger.debug("[%s] send %s event(s) to keep the batch under %s bytes",
+                                 self.name, len(self.entries), self.max_batch_byte_size)
+                    self.send_entries()
+                if entry_byte_size > self.max_batch_byte_size:
+                    # nothing can be done about it here, but it is sent on its own, so it only
+                    # takes itself down when the queue rejects it
+                    logger.error("[%s] %s byte message over the %s byte limit, routing key %s",
+                                 self.name, entry_byte_size, self.max_batch_byte_size, routing_key or "-")
                 self.entries[entry_id] = (receipt_handle, entry)
+                self.batch_byte_size += entry_byte_size
                 self.min_event_ts = min(self.min_event_ts or event_ts, event_ts)
-                if len(self.entries) == self.max_number_of_messages:
+                if len(self.entries) == self.max_number_of_messages or \
+                   self.batch_byte_size >= self.max_batch_byte_size:
                     self.send_entries()
 
     def send_entries(self):
@@ -234,4 +262,5 @@ class SQSSendThread(threading.Thread):
                 logger.error("[%s] %s/%s event sending error(s)", self.name, failed_entry_count, entry_count)
         # update state
         self.entries = {}
+        self.batch_byte_size = 0
         self.min_event_ts = None

--- a/zentral/core/queues/backends/google_pubsub/__init__.py
+++ b/zentral/core/queues/backends/google_pubsub/__init__.py
@@ -11,6 +11,7 @@ from google.cloud import pubsub_v1
 from google.oauth2 import service_account
 from zentral.conf import settings
 from zentral.core.queues.backends.base import BaseEventQueues
+from zentral.core.queues.compression import compress_raw_event_if_needed
 from zentral.core.queues.exceptions import RetryLater
 from zentral.core.queues.preprocessing import iter_preprocessed_events
 from .consumer import BaseWorker, Consumer, ConsumerProducer
@@ -419,7 +420,7 @@ class EventQueues(BaseEventQueues):
         return worker_class(self.enriched_events_topic, self.credentials, event_store)
 
     def post_raw_event(self, routing_key, raw_event):
-        self._publish(self.raw_events_topic, raw_event, routing_key=routing_key)
+        self._publish(self.raw_events_topic, compress_raw_event_if_needed(raw_event), routing_key=routing_key)
 
     def post_event(self, event):
         self._publish(self.events_topic, event.serialize(machine_metadata=False), event_type=event.event_type)

--- a/zentral/core/queues/backends/kombu.py
+++ b/zentral/core/queues/backends/kombu.py
@@ -6,6 +6,7 @@ from kombu import Connection, Consumer, Exchange, Queue
 from kombu.mixins import ConsumerMixin, ConsumerProducerMixin
 from kombu.pools import producers
 from zentral.core.queues.backends.base import BaseEventQueues
+from zentral.core.queues.compression import compress_raw_event_if_needed
 from zentral.core.queues.exceptions import RetryLater
 from zentral.core.queues.preprocessing import iter_preprocessed_events
 from zentral.utils.json import save_dead_letter
@@ -248,7 +249,7 @@ class EventQueues(BaseEventQueues):
 
     def post_raw_event(self, routing_key, raw_event):
         with producers[self.connection].acquire(block=True) as producer:
-            producer.publish(raw_event,
+            producer.publish(compress_raw_event_if_needed(raw_event),
                              serializer='json',
                              exchange=raw_events_exchange,
                              routing_key=routing_key,

--- a/zentral/core/queues/compression.py
+++ b/zentral/core/queues/compression.py
@@ -1,0 +1,41 @@
+import logging
+from base64 import b64decode, b64encode
+from compression import zstd
+from kombu.utils import json
+
+
+logger = logging.getLogger("zentral.core.queues.compression")
+
+
+# Raw events travel as JSON, and SQS caps the message size — a cap it also applies to the sum of a
+# whole send batch. Machine snapshot trees carrying a full app inventory go over it, and the queue
+# rejects them. A raw event that big is posted as a single base64'd zstd blob under this key
+# instead: iter_preprocessed_events inflates it, so the preprocessors only ever see the raw event
+# the producer posted.
+#
+# base85 would shave 6% off the wire — nothing outside the pipeline reads these blobs — but
+# b85encode/b85decode are pure Python where the base64 pair has a C fast path, and the decode lands
+# on the preprocess worker: 6ms a blob there is not worth the 6%.
+COMPRESSED_RAW_EVENT_KEY = "zstd_raw_event"
+
+# Small raw events stay readable in the queue. The threshold is low enough that a full batch of
+# messages at the threshold still fits well inside the limit for a single message, so a big tree
+# can never take a batch over it on its own.
+COMPRESSION_MIN_SIZE = 16 * 2**10
+
+
+def compress_raw_event_if_needed(raw_event):
+    # kombu's encoder, the one every backend serializes raw events with, so that the blob
+    # deserializes into exactly the dict the preprocessor would have received uncompressed
+    serialized_raw_event = json.dumps(raw_event).encode("utf-8")
+    if len(serialized_raw_event) < COMPRESSION_MIN_SIZE:
+        return raw_event
+    payload = b64encode(zstd.compress(serialized_raw_event)).decode("ascii")
+    logger.debug("Raw event compressed from %d to %d bytes", len(serialized_raw_event), len(payload))
+    return {COMPRESSED_RAW_EVENT_KEY: payload}
+
+
+def decompress_raw_event(raw_event):
+    if not isinstance(raw_event, dict) or COMPRESSED_RAW_EVENT_KEY not in raw_event:
+        return raw_event
+    return json.loads(zstd.decompress(b64decode(raw_event[COMPRESSED_RAW_EVENT_KEY])))

--- a/zentral/core/queues/preprocessing.py
+++ b/zentral/core/queues/preprocessing.py
@@ -1,5 +1,6 @@
 import logging
 from django.db import InterfaceError, OperationalError, close_old_connections
+from zentral.core.queues.compression import decompress_raw_event
 from zentral.core.queues.exceptions import RetryLater
 
 
@@ -8,7 +9,8 @@ logger = logging.getLogger("zentral.core.queues.preprocessing")
 
 def iter_preprocessed_events(preprocessors, routing_key, raw_event):
     # Single entry point every queue backend uses to run a preprocessor: resolve the one for
-    # the routing key, yield the events it produces, and recycle a dead pooled connection.
+    # the routing key, inflate the raw event if the producer had to compress it to fit in the
+    # queue, yield the events it produces, and recycle a dead pooled connection.
     #
     # Preprocessors run in a long-lived worker with no request cycle, so Django never recycles
     # their pooled connection (CONN_HEALTH_CHECKS / CONN_MAX_AGE are driven by the request
@@ -22,6 +24,12 @@ def iter_preprocessed_events(preprocessors, routing_key, raw_event):
     preprocessor = preprocessors.get(routing_key)
     if not preprocessor:
         logger.error("No preprocessor for routing key %s", routing_key)
+        return
+    try:
+        raw_event = decompress_raw_event(raw_event)
+    except Exception as error:
+        # deterministic error: the same payload would fail the same way on a retry → drop it
+        logger.error("Preprocessor %s: could not decompress raw event: %s", routing_key, error)
         return
     try:
         yield from preprocessor.process_raw_event(raw_event)


### PR DESCRIPTION
Two commits: raw events too big for the queue are now compressed, and the SQS send thread no longer builds batches that the queue rejects whole.

## Why

Machine snapshot trees carrying a full app inventory serialize to more than SQS accepts. The queue rejects the message, the tree never reaches the preprocessor, and the snapshot is lost.

The per-message limit is not the only one that bites. SQS applies the same 1 MiB cap to the *sum* of a `send_message_batch`, and `SQSSendThread` batched ten messages with no size accounting — so one big message took the nine it happened to travel with down with it. `send_entries` clears its entries whatever the outcome, and on the producer path there is no receipt handle to re-enqueue, so all ten raw events were simply lost, behind a single log line.

## 1. Compress the raw events too big for the queue with zstd

- New [`zentral/core/queues/compression.py`](https://github.com/zentralopensource/zentral/blob/compress-big-raw-events/zentral/core/queues/compression.py): a raw event whose serialized form reaches 16KB is posted as one base64'd zstd blob under a dedicated `zstd_raw_event` key.
- The three backends call `compress_raw_event_if_needed()` in `post_raw_event`; `iter_preprocessed_events()` inflates the blob — the single entry point every backend already runs its preprocessors through.
- Producers and preprocessors are untouched: `MachineSnapshotPreprocessor` still receives the `{"ms_tree": …}` dict it always got, and smaller raw events go on the wire unchanged, still readable in the queue.

Notes for reviewers:

- **The threshold is 16KB, not the message limit.** A full batch of messages at the threshold stays far inside the cap, so the fix doesn't depend on getting that number right.
- **The blob is built with kombu's encoder**, the one every backend serializes raw events with, so what inflates is exactly what an uncompressed raw event deserializes to. `tests/core_queues/test_compression.py` pins that for datetimes and UUIDs.
- **All three backends compress, kombu included**, so dev on RabbitMQ exercises the same envelope path as prod on SQS.
- **An undecompressable blob is logged and dropped**, not re-enqueued — a retry would fail the same way, consistent with how the inventory preprocessor already treats deterministic errors.
- **base64, not base85.** Nothing outside the pipeline reads these blobs, so a denser encoding was on the table — 5/4 instead of 4/3, and the b85 alphabet needs no JSON escaping either. Measured, it isn't worth it: `b85encode`/`b85decode` are pure Python where the base64 pair has a C fast path, ~4.6ms to encode and ~6.3ms to decode a 90KB blob against 0.06ms either way. That would make the encoding the most expensive step in the path (zstd itself is 1.2ms) and put the 6.3ms on the preprocess worker, for 6% off the wire. A test pins the property that makes base64 free here: the wire size is the payload plus the wrapper and nothing more, because its alphabet contains no character JSON escapes.
- **No new dependency**: `compression.zstd` is stdlib as of Python 3.14, and the image is `python:3.14-trixie` (libzstd 1.5.7).

## 2. Split the SQS batches by size, not only by count

Compression cut the batch exposure by ~9x but did not remove it: a tree past ~4,270 apps still comes out over a tenth of the cap once compressed and base64'd, and ten of those overflow a batch again. `SQSSendThread` now accounts for the bytes as entries accumulate and sends what fits before adding one that would cross the cap, instead of always counting to ten.

- A message over the cap on its own can't be sent at all, here or anywhere else. It now travels alone, so it only takes itself down, and it's logged with its size and routing key.
- Message attributes count against the size too, so the routing key is part of the accounting.
- The budget keeps a margin under 1 MiB — the SQS-side accounting isn't byte for byte the one in `_entry_byte_size`, and being a few bytes optimistic would cost a whole batch.

This part is a pre-existing bug that predates compression; it's here because compression is what made the remaining window small enough to be worth closing properly.

## Measurements

Effective ratio is `0.75 × zstd ratio` — base64 is a flat 4/3, plus 22 bytes of JSON wrapper. On modelled munki trees, with the batch budget at 1,038,336 bytes:

| tree | raw | on the wire | effective | per batch | batch bytes |
|---|---|---|---|---|---|
| 500 apps | 107,558 | 10,626 | 10.1x | 10 | 106,260 |
| 2,000 apps | 430,058 | 46,110 | 9.3x | 10 | 461,100 |
| 5,000 apps | 1,075,058 | 121,422 | 8.9x | 8 | 971,376 |
| 20,000 apps | 4,300,058 | 500,050 | 8.6x | 2 | 1,000,100 |

The largest tree that still lets ten of its kind share one batch is ~4,271 apps. Past that the send thread splits the batch instead of having it rejected whole.

Verified end-to-end through the dev RabbitMQ, publishing a real 5,000-app tree via `post_raw_event` and inflating it in `iter_preprocessed_events`: 881,801 bytes → 22,634 on the wire (that tree is repetitive, hence the better-than-table ratio), preprocessor receives the original tree.

## Testing

New tests cover the round trip, the threshold boundary in both directions, encoder transparency, inflation ahead of the preprocessor, the no-JSON-escaping property, the corrupt-blob drop, one case per backend asserting a big raw event goes out compressed, and for the send thread: ten small messages still batching together, a byte-limit split, attribute bytes in the count, and the oversized-message-alone path.

```
docker compose -f docker-compose.yml -f docker-compose.tests.yml run --rm \
    -e ZENTRAL_CONF_DIR=/zentral/tests/conf -e ZENTRAL_FORCE_ES_OS_INDEX_REFRESH=1 \
    -e ZENTRAL_POLICIES_SYNC=0 -e ZENTRAL_PROBES_SYNC=0 -e ZENTRAL_QUIET=1 -e ZENTRAL_STORES_SYNC=0 \
    web python server/manage.py test --keepdb \
    tests.core_queues tests.inventory tests.munki tests.turbo tests.puppet tests.wsone
```

1,373 tests, all passing.

## Deploying

A preprocess worker still on the previous release drops a compressed raw event as an unparsable tree, so restart the preprocess workers before the web workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
