### PR TITLE
Cache and prefetch the MT objects when committing an inventory tree

### DIFF
--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -29,10 +29,11 @@ from zentral.contrib.inventory.models import (
     MachineTag,
     MetaMachine,
     Source,
+    SourceManager,
     Tag,
 )
 from zentral.contrib.inventory.utils.db import inventory_events_from_machine_snapshot_commit
-from zentral.utils.mt_models import MTOError, prepare_commit_tree
+from zentral.utils.mt_models import Hasher, MTOError, prepare_commit_tree
 from zentral.utils.time import naive_utcnow
 
 
@@ -780,3 +781,95 @@ class MachineSnapshotTestCase(TestCase):
                          ["ERROR:zentral.contrib.inventory.models:Commit tree last seen is not a str or a datetime"])
         self.assertTrue(t0 <= msc.last_seen <= naive_utcnow())
         self.assertEqual(msc.last_seen, last_seen)
+
+    # hasher
+
+    def test_hasher_invalid_field_name(self):
+        with self.assertRaises(ValueError) as cm:
+            Hasher().add_field(None, "yolo")
+        self.assertEqual(cm.exception.args[0], "Invalid field name None")
+
+    def test_hasher_field_already_added(self):
+        hasher = Hasher()
+        hasher.add_field("un", "yolo")
+        with self.assertRaises(ValueError) as cm:
+            hasher.add_field("un", "fomo")
+        self.assertEqual(cm.exception.args[0], "Field un already added")
+
+    def test_hasher_invalid_field_value(self):
+        with self.assertRaises(ValueError) as cm:
+            Hasher().add_field("un", 1.2)
+        self.assertEqual(cm.exception.args[0], "Invalid field value 1.2 for field un")
+
+    def test_hasher_aware_datetime(self):
+        hasher = Hasher()
+        hasher.add_field("un", parser.parse("2026-07-24T10:11:12+02:00"))
+        naive_hasher = Hasher()
+        naive_hasher.add_field("un", datetime(2026, 7, 24, 8, 11, 12))
+        self.assertEqual(hasher.hexdigest(), naive_hasher.hexdigest())
+
+    # commit tree
+
+    def test_prepare_commit_tree_not_a_dict(self):
+        with self.assertRaises(MTOError) as cm:
+            prepare_commit_tree(["yolo"])
+        self.assertEqual(cm.exception.message, "Commit tree is not a dict")
+
+    def test_commit_dict_value_for_text_field(self):
+        with self.assertRaises(MTOError) as cm:
+            Source.objects.commit({"module": {"un": 1}, "name": "yolo"})
+        self.assertEqual(cm.exception.message, 'Cannot set field "module" to dict value')
+
+    def test_commit_concurrently_created_object(self):
+        source, _ = Source.objects.commit(copy.deepcopy(self.source))
+        tree = dict(self.source, name="fomo")
+        with patch.object(SourceManager, "get", side_effect=[Source.DoesNotExist, source]), \
+             patch.object(Source, "save", side_effect=IntegrityError):
+            obj, created = Source.objects.commit(tree)
+        self.assertFalse(created)
+        self.assertEqual(obj, source)
+
+    def test_commit_integrity_error_not_a_key_error(self):
+        tree = dict(self.source, name="fomo")
+        with patch.object(SourceManager, "get", side_effect=Source.DoesNotExist), \
+             patch.object(Source, "save", side_effect=IntegrityError):
+            with self.assertRaises(IntegrityError):
+                Source.objects.commit(tree)
+
+    def test_commit_hash_mismatch(self):
+        tree = dict(self.source, name="fomo")
+        with patch.object(Source, "hash", return_value="yolo"):
+            with self.assertRaises(MTOError) as cm:
+                Source.objects.commit(tree)
+        self.assertEqual(cm.exception.message, "Obj fomo Hash missmatch!!!")
+
+    # mt fields
+
+    def test_get_mt_field_excluded(self):
+        with self.assertRaises(MTOError) as cm:
+            Source().get_mt_field("mt_hash")
+        self.assertEqual(cm.exception.message, "Field 'mt_hash' of Source is excluded")
+
+    def test_get_mt_field_auto_created(self):
+        with self.assertRaises(MTOError) as cm:
+            Source().get_mt_field("machinesnapshot")
+        self.assertEqual(cm.exception.message, "Field 'machinesnapshot' of Source auto created")
+
+    def test_serialize_unsupported_value_type(self):
+        source, _ = Source.objects.commit(copy.deepcopy(self.source))
+        source.config = [1, 2]
+        with self.assertRaises(ValueError) as cm:
+            source.serialize()
+        self.assertEqual(cm.exception.args[0], "Can't serialize Source.config value of type <class 'list'>")
+
+    def test_diff_different_model(self):
+        source, _ = Source.objects.commit(copy.deepcopy(self.source))
+        certificate, _ = Certificate.objects.commit(copy.deepcopy(self.certificate))
+        with self.assertRaises(MTOError) as cm:
+            source.diff(certificate)
+        self.assertEqual(cm.exception.message, "Can only compare to an object of the same model")
+
+    def test_diff_removed_mt_object(self):
+        ms, _ = MachineSnapshot.objects.commit(copy.deepcopy(self.machine_snapshot2))
+        ms2, _ = MachineSnapshot.objects.commit(copy.deepcopy(self.machine_snapshot))
+        self.assertEqual(ms2.diff(ms)["os_version"], {"removed": ms.os_version.serialize()})

--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -842,6 +842,8 @@ class MachineSnapshotTestCase(TestCase):
             with self.assertRaises(MTOError) as cm:
                 Source.objects.commit(tree)
         self.assertEqual(cm.exception.message, "Obj fomo Hash missmatch!!!")
+        # the row is rolled back with the mismatch, it is not left under the wrong identity
+        self.assertEqual(Source.objects.filter(name="fomo").count(), 0)
 
     # mt fields
 

--- a/tests/inventory/test_mt_models.py
+++ b/tests/inventory/test_mt_models.py
@@ -1,0 +1,182 @@
+import copy
+from unittest.mock import patch
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from zentral.contrib.inventory.models import (
+    BusinessUnit,
+    Certificate,
+    MachineGroup,
+    MachineSnapshot,
+    OSXApp,
+    OSXAppInstance,
+    Source,
+)
+from zentral.utils.mt_models import _NOT_CACHED, MTCommitCache, prepare_commit_tree
+
+
+class MTCommitCacheTestCase(TestCase):
+    maxDiff = None
+
+    # utils
+
+    @staticmethod
+    def _source():
+        return {"module": "io.zentral.tests", "name": "zentral"}
+
+    @staticmethod
+    def _certificate(common_name="Apple Root CA"):
+        return {"common_name": common_name,
+                "organization": "Apple Inc.",
+                "organizational_unit": "Apple Certification Authority",
+                "sha_1": "611e5b662c593a08ff58d14ae22452d198df6c60"}
+
+    @staticmethod
+    def _app_instance(idx, certificate):
+        return {"app": {"bundle_id": f"io.zentral.app{idx}",
+                        "bundle_name": f"App{idx}",
+                        "bundle_version_str": f"1.{idx}"},
+                "bundle_path": f"/Applications/App{idx}.app",
+                # a real payload carries a distinct dict for every occurrence
+                "signed_by": copy.deepcopy(certificate)}
+
+    def _snapshot(self, app_instance_count=1, **kwargs):
+        certificate = self._certificate()
+        tree = {"source": self._source(),
+                "serial_number": "0123456789",
+                "osx_app_instances": [self._app_instance(idx, certificate)
+                                      for idx in range(app_instance_count)]}
+        tree.update(kwargs)
+        return tree
+
+    @staticmethod
+    def _mt_hash_lookups(ctx, model):
+        # only the lookups by mt_hash: the m2m fetches of hash() and full_clean() select the
+        # same tables, and the quoted names keep inventory_osxapp from matching
+        # inventory_osxappinstance
+        table = connection.ops.quote_name(model._meta.db_table)
+        column = connection.ops.quote_name("mt_hash")
+        return [q["sql"] for q in ctx.captured_queries if f"WHERE {table}.{column} " in q["sql"]]
+
+    # cache
+
+    def test_repeated_subtrees_committed_once(self):
+        tree = self._snapshot(app_instance_count=5)
+        with CaptureQueriesContext(connection) as ctx:
+            snapshot, created = MachineSnapshot.objects.commit(tree)
+        self.assertTrue(created)
+        self.assertEqual(Certificate.objects.count(), 1)
+        self.assertEqual(snapshot.osx_app_instances.count(), 5)
+        self.assertEqual(
+            set(snapshot.osx_app_instances.values_list("signed_by", flat=True)),
+            {Certificate.objects.first().pk}
+        )
+        # the prefetch is the only mt_hash lookup: the 5 occurrences of the certificate are cached
+        self.assertEqual(len(self._mt_hash_lookups(ctx, Certificate)), 1)
+        self.assertEqual(len(self._mt_hash_lookups(ctx, OSXApp)), 1)
+
+    def test_unchanged_tree_single_query(self):
+        tree = self._snapshot(app_instance_count=5)
+        snapshot, created = MachineSnapshot.objects.commit(copy.deepcopy(tree))
+        self.assertTrue(created)
+        with CaptureQueriesContext(connection) as ctx:
+            snapshot2, created2 = MachineSnapshot.objects.commit(tree)
+        self.assertFalse(created2)
+        self.assertEqual(snapshot, snapshot2)
+        # the root hash hits: no subtree is walked, and nothing is prefetched
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+    def test_existing_subtrees_prefetched(self):
+        MachineSnapshot.objects.commit(self._snapshot(app_instance_count=2))
+        with CaptureQueriesContext(connection) as ctx:
+            snapshot, created = MachineSnapshot.objects.commit(self._snapshot(app_instance_count=3))
+        self.assertTrue(created)
+        self.assertEqual(Certificate.objects.count(), 1)
+        self.assertEqual(OSXApp.objects.count(), 3)
+        self.assertEqual(OSXAppInstance.objects.count(), 3)
+        self.assertEqual(snapshot.osx_app_instances.count(), 3)
+        for model in (Certificate, OSXApp, OSXAppInstance, Source):
+            selects = self._mt_hash_lookups(ctx, model)
+            self.assertEqual(len(selects), 1, model)
+            self.assertIn("IN (", selects[0])
+
+    def test_same_mt_hash_across_models(self):
+        group_tree = {"source": self._source(), "reference": "yolo", "name": "yolo"}
+        tree = self._snapshot(business_unit=copy.deepcopy(group_tree),
+                              groups=[copy.deepcopy(group_tree)])
+        prepared = copy.deepcopy(tree)
+        prepare_commit_tree(prepared, MachineSnapshot)
+        self.assertEqual(prepared["business_unit"]["mt_hash"], prepared["groups"][0]["mt_hash"])
+        snapshot, created = MachineSnapshot.objects.commit(tree)
+        self.assertTrue(created)
+        self.assertIsInstance(snapshot.business_unit, BusinessUnit)
+        self.assertEqual([type(group) for group in snapshot.groups.all()], [MachineGroup])
+
+    def test_prefetch_chunked(self):
+        tree = self._snapshot(app_instance_count=0,
+                              certificates=[self._certificate(f"CA{idx}") for idx in range(3)])
+        with patch("zentral.utils.mt_models.COMMIT_CACHE_CHUNK_SIZE", 1):
+            with CaptureQueriesContext(connection) as ctx:
+                snapshot, created = MachineSnapshot.objects.commit(tree)
+        self.assertTrue(created)
+        self.assertEqual(snapshot.certificates.count(), 3)
+        self.assertEqual(len(self._mt_hash_lookups(ctx, Certificate)), 3)
+
+    def test_cache_cap_falls_back_to_lookups(self):
+        tree = self._snapshot(app_instance_count=5)
+        with patch("zentral.utils.mt_models.MAX_COMMIT_CACHE_SIZE", 0):
+            with CaptureQueriesContext(connection) as ctx:
+                snapshot, created = MachineSnapshot.objects.commit(tree)
+        self.assertTrue(created)
+        self.assertEqual(Certificate.objects.count(), 1)
+        self.assertEqual(snapshot.osx_app_instances.count(), 5)
+        # nothing is cached: one lookup per occurrence of the certificate, no prefetch
+        selects = self._mt_hash_lookups(ctx, Certificate)
+        self.assertEqual(len(selects), 5)
+        self.assertNotIn("IN (", selects[0])
+
+    def test_cache_set_capped(self):
+        cache = MTCommitCache()
+        source, _ = Source.objects.commit(self._source())
+        with patch("zentral.utils.mt_models.MAX_COMMIT_CACHE_SIZE", 1):
+            cache.set(Source, source.mt_hash, source)
+            cache.set(Certificate, "yolo", None)
+        self.assertEqual(cache.get(Source, source.mt_hash), source)
+        self.assertIs(cache.get(Certificate, "yolo"), _NOT_CACHED)
+
+    def test_cache_set_upgrades_cached_absence(self):
+        cache = MTCommitCache()
+        source, _ = Source.objects.commit(self._source())
+        cache.prefetch({Source: {source.mt_hash, "yolo"}})
+        self.assertEqual(cache.get(Source, source.mt_hash), source)
+        self.assertIsNone(cache.get(Source, "yolo"))
+        # a capped cache still replaces a cached absence, or the object would be inserted twice
+        with patch("zentral.utils.mt_models.MAX_COMMIT_CACHE_SIZE", 0):
+            cache.set(Source, "yolo", source)
+        self.assertEqual(cache.get(Source, "yolo"), source)
+
+    # collector
+
+    def test_prepare_commit_tree_collector(self):
+        tree = self._snapshot(extra_facts={"un": {"deux": 3}})
+        collector = {}
+        prepare_commit_tree(tree, MachineSnapshot, collector)
+        app_instance = tree["osx_app_instances"][0]
+        self.assertEqual(collector[MachineSnapshot], {tree["mt_hash"]})
+        self.assertEqual(collector[Source], {tree["source"]["mt_hash"]})
+        self.assertEqual(collector[OSXAppInstance], {app_instance["mt_hash"]})
+        self.assertEqual(collector[OSXApp], {app_instance["app"]["mt_hash"]})
+        self.assertEqual(collector[Certificate], {app_instance["signed_by"]["mt_hash"]})
+        # the JSONField subtree is hashed without a model
+        self.assertNotIn(None, collector)
+
+    def test_prepare_commit_tree_collector_skips_non_mt_model(self):
+        tree = {"source": self._source(),
+                "reference": "yolo",
+                "name": "yolo",
+                "meta_business_unit": {"name": "yolo"}}
+        collector = {}
+        prepare_commit_tree(tree, BusinessUnit, collector)
+        self.assertEqual(set(collector), {BusinessUnit, Source})

--- a/tests/inventory/test_mt_models.py
+++ b/tests/inventory/test_mt_models.py
@@ -1,7 +1,8 @@
 import copy
 from unittest.mock import patch
 
-from django.db import connection
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 
@@ -59,6 +60,11 @@ class MTCommitCacheTestCase(TestCase):
         table = connection.ops.quote_name(model._meta.db_table)
         column = connection.ops.quote_name("mt_hash")
         return [q["sql"] for q in ctx.captured_queries if f"WHERE {table}.{column} " in q["sql"]]
+
+    @staticmethod
+    def _existence_checks(ctx):
+        # the shape of both the foreign key and the unique checks of full_clean()
+        return [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("SELECT 1 AS")]
 
     # cache
 
@@ -156,6 +162,27 @@ class MTCommitCacheTestCase(TestCase):
         with patch("zentral.utils.mt_models.MAX_COMMIT_CACHE_SIZE", 0):
             cache.set(Source, "yolo", source)
         self.assertEqual(cache.get(Source, "yolo"), source)
+
+    # full_clean
+
+    def test_commit_skips_the_full_clean_existence_checks(self):
+        with CaptureQueriesContext(connection) as ctx:
+            snapshot, created = MachineSnapshot.objects.commit(self._snapshot(app_instance_count=5))
+        self.assertTrue(created)
+        self.assertEqual(snapshot.osx_app_instances.count(), 5)
+        self.assertEqual(self._existence_checks(ctx), [])
+
+    def test_commit_still_validates_fields(self):
+        with self.assertRaises(ValidationError) as cm:
+            MachineSnapshot.objects.commit(self._snapshot(platform="yolo"))
+        self.assertEqual(list(cm.exception.message_dict), ["platform"])
+
+    def test_commit_missing_required_foreign_key(self):
+        # save() runs before full_clean(): the not null constraint is what rejects a missing
+        # foreign key, which is why skipping its existence check loses nothing
+        with self.assertRaises(IntegrityError):
+            OSXAppInstance.objects.commit({"bundle_path": "/Applications/App.app",
+                                           "signed_by": self._certificate()})
 
     # collector
 

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -256,6 +256,10 @@ class MTObjectManager(models.Manager):
                     # already been enforced by the DB, and the foreign keys committed above exist
                     # by construction → both checks are queries that cannot fail
                     obj.full_clean(exclude=committed_fks, validate_unique=False)
+                    # inside the transaction: a hash mismatch has to take the row down with it,
+                    # or it stays in the table under the wrong identity
+                    if not obj.hash(recursive=False) == obj.mt_hash:
+                        raise MTOError(f'Obj {obj} Hash missmatch!!!')
             except IntegrityError as integrity_error:
                 # the object has been concurrently created ?
                 try:
@@ -264,8 +268,6 @@ class MTObjectManager(models.Manager):
                     # that was not a key error:
                     raise integrity_error
             else:
-                if not obj.hash(recursive=False) == obj.mt_hash:
-                    raise MTOError(f'Obj {obj} Hash missmatch!!!')
                 created = True
         _cache.set(self.model, mt_hash, obj)
         return obj, created

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -49,9 +49,7 @@ class Hasher(object):
         for k in sorted(self.fields.keys()):
             h.update(k.encode('utf-8'))
             v = self.fields[k]
-            if isinstance(v, bytes):
-                h.update(v)
-            elif isinstance(v, str):
+            if isinstance(v, str):
                 h.update(v.encode('utf-8'))
             elif isinstance(v, list):
                 for e in sorted(v):

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -11,6 +11,14 @@ from django.db import IntegrityError, models, transaction
 logger = logging.getLogger("zentral.utils.mt_models")
 
 
+_NOT_CACHED = object()
+
+# The commit cache holds model instances, and a machine snapshot tree can carry tens of thousands
+# of subtrees → cap it. Past the cap, the extra subtrees simply take the uncached path.
+MAX_COMMIT_CACHE_SIZE = 10000
+COMMIT_CACHE_CHUNK_SIZE = 1000
+
+
 class MTOError(Exception):
     def __init__(self, message):
         super().__init__(message)
@@ -71,7 +79,7 @@ def _get_commit_tree_field(model, name):
     return f
 
 
-def prepare_commit_tree(tree, model=None):
+def prepare_commit_tree(tree, model=None, collector=None):
     if not isinstance(tree, dict):
         raise MTOError("Commit tree is not a dict")
     if tree.get('mt_hash', None):
@@ -83,7 +91,7 @@ def prepare_commit_tree(tree, model=None):
         else:
             f = _get_commit_tree_field(model, k)
             if isinstance(v, dict):
-                prepare_commit_tree(v, f.related_model if f is not None and f.many_to_one else None)
+                prepare_commit_tree(v, f.related_model if f is not None and f.many_to_one else None, collector)
                 v = v['mt_hash']
             elif isinstance(v, list):
                 related_model = f.related_model if f is not None and f.many_to_many else None
@@ -91,7 +99,7 @@ def prepare_commit_tree(tree, model=None):
                 skipped_item_idxs = None
                 for item_idx, item in enumerate(v):
                     if isinstance(item, dict):
-                        prepare_commit_tree(item, related_model)
+                        prepare_commit_tree(item, related_model, collector)
                         subtree_mt_hash = item['mt_hash']
                         if subtree_mt_hash in hash_list:
                             # a list of subtrees maps to a many to many relationship, i.e. a set:
@@ -137,6 +145,10 @@ def prepare_commit_tree(tree, model=None):
                 tree[k] = v = make_naive(v)
             h.add_field(k, v)
     tree['mt_hash'] = h.hexdigest()
+    # an excluded foreign key can point at a model without a mt_hash (BusinessUnit.meta_business_unit):
+    # collecting it would break the prefetch
+    if collector is not None and model is not None and issubclass(model, AbstractMTObject):
+        collector.setdefault(model, set()).add(tree['mt_hash'])
 
 
 def cleanup_commit_tree(tree):
@@ -151,13 +163,58 @@ def cleanup_commit_tree(tree):
                 cleanup_commit_tree(subtree)
 
 
+class MTCommitCache:
+    def __init__(self):
+        self._objects = {}
+
+    def get(self, model, mt_hash):
+        # the mt_hash is only unique per table: BusinessUnit and MachineGroup have the same hashable
+        # fields, and a machine snapshot tree carries both → the model is part of the key
+        return self._objects.get((model, mt_hash), _NOT_CACHED)
+
+    def set(self, model, mt_hash, obj):
+        key = (model, mt_hash)
+        # only new keys are capped: a cached absence must always be upgraded to the committed
+        # object, or the next occurrence of the subtree would try to insert it again
+        if key in self._objects or len(self._objects) < MAX_COMMIT_CACHE_SIZE:
+            self._objects[key] = obj
+
+    def prefetch(self, collector):
+        for model, mt_hashes in collector.items():
+            free_slots = MAX_COMMIT_CACHE_SIZE - len(self._objects)
+            if free_slots <= 0:
+                return
+            mt_hashes = sorted(mt_hashes)[:free_slots]
+            for idx in range(0, len(mt_hashes), COMMIT_CACHE_CHUNK_SIZE):
+                chunk = mt_hashes[idx:idx + COMMIT_CACHE_CHUNK_SIZE]
+                found = {o.mt_hash: o for o in model.objects.filter(mt_hash__in=chunk)}
+                for mt_hash in chunk:
+                    # None caches the absence: the object can be built without a wasted query
+                    self._objects[(model, mt_hash)] = found.get(mt_hash)
+
+
 class MTObjectManager(models.Manager):
-    def commit(self, tree, **extra_obj_save_kwargs):
-        prepare_commit_tree(tree, self.model)
+    def commit(self, tree, _cache=None, **extra_obj_save_kwargs):
+        collector = {} if _cache is None else None
+        prepare_commit_tree(tree, self.model, collector)
+        mt_hash = tree['mt_hash']
+        if _cache is None:
+            _cache = MTCommitCache()
+        cached = _cache.get(self.model, mt_hash)
+        if cached is not _NOT_CACHED and cached is not None:
+            return cached, False
         created = False
-        try:
-            obj = self.get(mt_hash=tree['mt_hash'])
-        except self.model.DoesNotExist:
+        obj = None
+        if cached is _NOT_CACHED:
+            try:
+                obj = self.get(mt_hash=mt_hash)
+            except self.model.DoesNotExist:
+                pass
+        if obj is None:
+            if collector is not None:
+                # an unchanged tree stops at the get above, without walking a single subtree:
+                # only pay for the prefetch once the root hash has missed
+                _cache.prefetch(collector)
             obj = self.model()
             m2m_fields = []
             for k, v in tree.items():
@@ -176,13 +233,13 @@ class MTObjectManager(models.Manager):
                         else:
                             raise MTOError(f'Cannot set field "{k}" to dict value')
                     else:
-                        fk_obj, _ = f.related_model.objects.commit(v)
+                        fk_obj, _ = f.related_model.objects.commit(v, _cache=_cache)
                         setattr(obj, k, fk_obj)
                 elif isinstance(v, list):
                     f = obj.get_mt_field(k, many_to_many=True)
                     ol = []
                     for sv in v:
-                        m2m_obj, _ = f.related_model.objects.commit(sv)
+                        m2m_obj, _ = f.related_model.objects.commit(sv, _cache=_cache)
                         ol.append(m2m_obj)
                     m2m_fields.append((k, ol))
                 else:
@@ -197,7 +254,7 @@ class MTObjectManager(models.Manager):
             except IntegrityError as integrity_error:
                 # the object has been concurrently created ?
                 try:
-                    obj = self.get(mt_hash=tree['mt_hash'])
+                    obj = self.get(mt_hash=mt_hash)
                 except self.model.DoesNotExist:
                     # that was not a key error:
                     raise integrity_error
@@ -205,6 +262,7 @@ class MTObjectManager(models.Manager):
                 if not obj.hash(recursive=False) == obj.mt_hash:
                     raise MTOError(f'Obj {obj} Hash missmatch!!!')
                 created = True
+        _cache.set(self.model, mt_hash, obj)
         return obj, created
 
 

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -217,6 +217,7 @@ class MTObjectManager(models.Manager):
                 _cache.prefetch(collector)
             obj = self.model()
             m2m_fields = []
+            committed_fks = []
             for k, v in tree.items():
                 if k == 'mt_hash':  # special excluded field
                     obj.mt_hash = v
@@ -235,6 +236,7 @@ class MTObjectManager(models.Manager):
                     else:
                         fk_obj, _ = f.related_model.objects.commit(v, _cache=_cache)
                         setattr(obj, k, fk_obj)
+                        committed_fks.append(k)
                 elif isinstance(v, list):
                     f = obj.get_mt_field(k, many_to_many=True)
                     ol = []
@@ -250,7 +252,10 @@ class MTObjectManager(models.Manager):
                     obj.save(**extra_obj_save_kwargs)
                     for k, l in m2m_fields:
                         getattr(obj, k).set(l)
-                    obj.full_clean()
+                    # full_clean runs after a successful insert, so every unique constraint has
+                    # already been enforced by the DB, and the foreign keys committed above exist
+                    # by construction → both checks are queries that cannot fail
+                    obj.full_clean(exclude=committed_fks, validate_unique=False)
             except IntegrityError as integrity_error:
                 # the object has been concurrently created ?
                 try:


### PR DESCRIPTION
Committing an inventory tree walks every subtree and looks each one up by `mt_hash`, **once per occurrence**. An unchanged tree is already cheap — the root hash hits and nothing below it is walked — but any change means a new root hash and a full walk, and a machine snapshot inlines the same signing certificate chain in every one of its app instances.

Measured with a synthetic snapshot tree, counting queries per `commit()`:

| scenario | `main` | + cache/prefetch | + full_clean skips |
|---|---:|---:|---:|
| first commit, 200 new app instances | 2629 | 2033 | **1229** |
| re-commit with 1 new app instance | 234 | 35 | **29** |
| unchanged re-commit | 1 | 1 | **1** |

Four commits, each independently green and at 100% on the module. Batching the inserts is the follow-up in #1554, stacked on this branch — it is a much bigger change and wants its own review.

## 1. Cover the untested MT object paths and drop a dead branch

`zentral/utils/mt_models.py` sat at 94%, so this brings it to 100% before anything changes underneath: the `Hasher` value errors, the tree-shape errors, the concurrent-creation recovery in both directions, the post-save hash mismatch, the `get_mt_field` guards, and two `serialize()`/`diff()` branches.

It also drops the `bytes` branch of `Hasher.hexdigest()`, which was unreachable rather than untested — `add_field` only ever stores a `str` (ints and datetimes are converted) or a list of hex digests, and raises on anything else. **No digest changes**, which matters since `mt_hash` is persisted.

## 2. Cache and prefetch the MT objects when committing a tree

`MTObjectManager.commit()` threads an `MTCommitCache` through the recursion, seeded by one chunked `mt_hash__in` lookup per model. `prepare_commit_tree()` already resolves the related model of every subtree, so it can collect them while it computes their hashes — no second walk, no change to the tree format.

- **The prefetch only runs once the root hash has missed.** Doing it eagerly would have turned the unchanged-tree path from 1 query into ~10 plus thousands of fetched rows. That path is still exactly one query, and a test pins it.
- **The cache is keyed by `(model, mt_hash)`, not by the hash alone.** `mt_hash` is only unique per table, and it does collide across tables here: `BusinessUnit` and `MachineGroup` share their hashable field set (`key` excluded on both, `meta_business_unit` on `BusinessUnit`), and a machine snapshot tree carries both — `business_unit` and `groups`. A hash-only cache hands a `BusinessUnit` to the `groups` m2m. Regression test included.

## 3. Skip the full_clean queries that cannot fail

`full_clean()` runs *after* `obj.save()`, which makes both of its query-generating checks dead weight — 2 queries per created object:

- `validate_unique` re-checks `mt_hash` — a unique column, excluding the row's own pk, right after our insert succeeded. Since the insert comes first, the DB has already enforced every unique constraint on the object, so the check can never find anything.
- The foreign keys committed from the tree were fetched or created a few frames up, so `ForeignKey.validate`'s existence query asks about rows we are holding.

Only the foreign keys set from the tree are excluded, which is exactly the set where the existence query is the only remaining check: a non-empty value passes the null and blank checks, and these fields declare no choices or validators. Choices, `max_length` and blank validation still run on the agent-supplied values, with a test asserting that a bad `platform` is still rejected. A required foreign key missing from the tree is still rejected by the not-null constraint, exactly as before — `save()` precedes `full_clean()`, so that case never reached the validation to begin with, and a test pins the ordering.

## 4. Roll back the row when the committed object hash does not match

The post-save verification sat in the `else:` of the try, which runs after `transaction.atomic()` has already committed. A mismatch raised `MTOError` but left the row behind, in a table where the `mt_hash` **is** the identity — every later commit of that subtree would resolve to it. Moving the check inside the block takes the row down with the exception.

## Memory

The cache holds model instances, so it is bounded three ways: capped at `MAX_COMMIT_CACHE_SIZE` (10000) with a graceful fall back to the uncached path past it, lookups chunked at 1000 so there is no giant `IN` list, and its lifetime is one top-level `commit()` call. The collector is only 40-char strings — strictly smaller than the tree already resident in memory. Nothing is cached across requests, which would go stale against `cleanup_inventory`.

The cap applies to *new* keys only: a prefetched absence must always be upgradable to the committed object, otherwise every later occurrence retries the insert and burns a savepoint rollback.

## Notes for the reviewer

- Behaviour-preserving. The new `_cache` kwarg is private and keyword-only in practice; no caller passes a positional second argument, and `BusinessUnit.objects.commit(tree, meta_business_unit=...)` still reaches `**extra_obj_save_kwargs`.
- The `issubclass(model, AbstractMTObject)` guard in the collector is deliberate: an excluded FK can point at a model without an `mt_hash` (`BusinessUnit.meta_business_unit`), and collecting it would turn a clear `MTOError` into a `FieldError` from the prefetch.
- Independent of any change to the ingestion payload format — a deduplicated wire format would benefit from this, but does not need it.
- Commits 1 and 4 are behaviour fixes and could be split off; 2 and 3 build on each other.

## Verification

- Full suite: **7389 tests, OK**.
- `zentral/utils/mt_models.py`: **100%**, 0 of 311 statements missed, measured over the full suite.
- `ruff` clean.

## What is left

Of the 1229 queries left in the first-commit case, only ~400 are the inserts themselves. The rest is ~800 `SAVEPOINT`/`RELEASE` statements — one `transaction.atomic()` per committed object. Collapsing those needs `bulk_create`, which the collector added here makes possible: that is #1554, which takes the same tree to 34 queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
