### PR TITLE
Insert the MT objects of a tree in bulk, one statement per model

### DIFF
--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -845,6 +845,15 @@ class MachineSnapshotTestCase(TestCase):
         # the row is rolled back with the mismatch, it is not left under the wrong identity
         self.assertEqual(Source.objects.filter(name="fomo").count(), 0)
 
+    def test_commit_hash_mismatch_per_object_path(self):
+        # BusinessUnit overrides save(), so it is never bulk inserted
+        tree = {"name": "fomo", "reference": "fomo 1", "source": copy.deepcopy(self.source)}
+        with patch.object(BusinessUnit, "hash", return_value="yolo"):
+            with self.assertRaises(MTOError) as cm:
+                BusinessUnit.objects.commit(tree)
+        self.assertEqual(cm.exception.message, "Obj fomo Hash missmatch!!!")
+        self.assertEqual(BusinessUnit.objects.filter(name="fomo").count(), 0)
+
     # mt fields
 
     def test_get_mt_field_excluded(self):

--- a/tests/inventory/test_mt_models.py
+++ b/tests/inventory/test_mt_models.py
@@ -13,9 +13,10 @@ from zentral.contrib.inventory.models import (
     MachineSnapshot,
     OSXApp,
     OSXAppInstance,
+    OSXAppManager,
     Source,
 )
-from zentral.utils.mt_models import _NOT_CACHED, MTCommitCache, prepare_commit_tree
+from zentral.utils.mt_models import _NOT_CACHED, MTCommitCache, MTOError, prepare_commit_tree
 
 
 class MTCommitCacheTestCase(TestCase):
@@ -65,6 +66,11 @@ class MTCommitCacheTestCase(TestCase):
     def _existence_checks(ctx):
         # the shape of both the foreign key and the unique checks of full_clean()
         return [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("SELECT 1 AS")]
+
+    @staticmethod
+    def _inserts(ctx, model):
+        table = connection.ops.quote_name(model._meta.db_table)
+        return [q["sql"] for q in ctx.captured_queries if q["sql"].startswith(f"INSERT INTO {table}")]
 
     # cache
 
@@ -155,7 +161,7 @@ class MTCommitCacheTestCase(TestCase):
     def test_cache_set_upgrades_cached_absence(self):
         cache = MTCommitCache()
         source, _ = Source.objects.commit(self._source())
-        cache.prefetch({Source: {source.mt_hash, "yolo"}})
+        cache.prefetch({Source: {source.mt_hash: {}, "yolo": {}}})
         self.assertEqual(cache.get(Source, source.mt_hash), source)
         self.assertIsNone(cache.get(Source, "yolo"))
         # a capped cache still replaces a cached absence, or the object would be inserted twice
@@ -184,6 +190,51 @@ class MTCommitCacheTestCase(TestCase):
             OSXAppInstance.objects.commit({"bundle_path": "/Applications/App.app",
                                            "signed_by": self._certificate()})
 
+    # bulk inserts
+
+    def test_one_insert_per_model(self):
+        with CaptureQueriesContext(connection) as ctx:
+            snapshot, created = MachineSnapshot.objects.commit(self._snapshot(app_instance_count=5))
+        self.assertTrue(created)
+        self.assertEqual(snapshot.osx_app_instances.count(), 5)
+        for model in (Source, Certificate, OSXApp, OSXAppInstance, MachineSnapshot):
+            self.assertEqual(len(self._inserts(ctx, model)), 1, model)
+
+    def test_bulk_and_per_object_paths_agree(self):
+        # content addressed: if the two paths built one object differently, its hash would differ
+        # and the other path would insert a second row instead of resolving the first
+        with patch("zentral.utils.mt_models._bulk_commit"):
+            first, _ = MachineSnapshot.objects.commit(self._snapshot(app_instance_count=3))
+        self.assertEqual(OSXApp.objects.count(), 3)
+        bulk_tree = self._snapshot(app_instance_count=3)
+        bulk_tree["serial_number"] = "9876543210"
+        second, created = MachineSnapshot.objects.commit(bulk_tree)
+        self.assertTrue(created)
+        self.assertEqual(set(second.osx_app_instances.all()), set(first.osx_app_instances.all()))
+        self.assertEqual(OSXApp.objects.count(), 3)
+        # and the other way round: a tree the per object path shares with the bulk inserted rows
+        per_object_tree = self._snapshot(app_instance_count=4)
+        per_object_tree["serial_number"] = "1111111111"
+        with patch("zentral.utils.mt_models._bulk_commit"):
+            third, _ = MachineSnapshot.objects.commit(per_object_tree)
+        self.assertEqual(OSXApp.objects.count(), 4)
+        self.assertLessEqual(set(first.osx_app_instances.all()), set(third.osx_app_instances.all()))
+
+    def test_bulk_insert_conflict_falls_back(self):
+        with patch.object(OSXAppManager, "bulk_create", side_effect=IntegrityError):
+            snapshot, created = MachineSnapshot.objects.commit(self._snapshot(app_instance_count=3))
+        self.assertTrue(created)
+        # the rolled back batch and everything depending on it went through the per object path
+        self.assertEqual(OSXApp.objects.count(), 3)
+        self.assertEqual(snapshot.osx_app_instances.count(), 3)
+        self.assertEqual(snapshot.hash(), snapshot.mt_hash)
+
+    def test_commit_non_dict_m2m_item(self):
+        with self.assertRaises(MTOError) as cm:
+            MachineSnapshot.objects.commit(self._snapshot(app_instance_count=0,
+                                                          certificates=["yolo"]))
+        self.assertEqual(cm.exception.message, "Commit tree is not a dict")
+
     # collector
 
     def test_prepare_commit_tree_collector(self):
@@ -191,11 +242,12 @@ class MTCommitCacheTestCase(TestCase):
         collector = {}
         prepare_commit_tree(tree, MachineSnapshot, collector)
         app_instance = tree["osx_app_instances"][0]
-        self.assertEqual(collector[MachineSnapshot], {tree["mt_hash"]})
-        self.assertEqual(collector[Source], {tree["source"]["mt_hash"]})
-        self.assertEqual(collector[OSXAppInstance], {app_instance["mt_hash"]})
-        self.assertEqual(collector[OSXApp], {app_instance["app"]["mt_hash"]})
-        self.assertEqual(collector[Certificate], {app_instance["signed_by"]["mt_hash"]})
+        signed_by = app_instance["signed_by"]
+        self.assertEqual(collector[MachineSnapshot], {tree["mt_hash"]: tree})
+        self.assertEqual(collector[Source], {tree["source"]["mt_hash"]: tree["source"]})
+        self.assertEqual(collector[OSXAppInstance], {app_instance["mt_hash"]: app_instance})
+        self.assertEqual(collector[OSXApp], {app_instance["app"]["mt_hash"]: app_instance["app"]})
+        self.assertEqual(collector[Certificate], {signed_by["mt_hash"]: signed_by})
         # the JSONField subtree is hashed without a model
         self.assertNotIn(None, collector)
 

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -148,7 +148,7 @@ def prepare_commit_tree(tree, model=None, collector=None):
     # an excluded foreign key can point at a model without a mt_hash (BusinessUnit.meta_business_unit):
     # collecting it would break the prefetch
     if collector is not None and model is not None and issubclass(model, AbstractMTObject):
-        collector.setdefault(model, set()).add(tree['mt_hash'])
+        collector.setdefault(model, {})[tree['mt_hash']] = tree
 
 
 def cleanup_commit_tree(tree):
@@ -180,17 +180,121 @@ class MTCommitCache:
             self._objects[key] = obj
 
     def prefetch(self, collector):
-        for model, mt_hashes in collector.items():
+        for model, trees in collector.items():
             free_slots = MAX_COMMIT_CACHE_SIZE - len(self._objects)
             if free_slots <= 0:
                 return
-            mt_hashes = sorted(mt_hashes)[:free_slots]
+            mt_hashes = sorted(trees)[:free_slots]
             for idx in range(0, len(mt_hashes), COMMIT_CACHE_CHUNK_SIZE):
                 chunk = mt_hashes[idx:idx + COMMIT_CACHE_CHUNK_SIZE]
                 found = {o.mt_hash: o for o in model.objects.filter(mt_hash__in=chunk)}
                 for mt_hash in chunk:
                     # None caches the absence: the object can be built without a wasted query
                     self._objects[(model, mt_hash)] = found.get(mt_hash)
+
+
+def _build_mt_object(model, tree, commit_subtree):
+    # commit_subtree returns None when it cannot resolve the subtree yet, which leaves the whole
+    # object for a later round — or for the per object path, which raises the proper errors
+    obj = model()
+    m2m_fields = []
+    committed_fks = []
+    for k, v in tree.items():
+        if k == 'mt_hash':  # special excluded field
+            obj.mt_hash = v
+        elif isinstance(v, dict):
+            try:
+                f = obj.get_mt_field(k, many_to_one=True)
+            except MTOError:
+                # JSONField ???
+                f = obj.get_mt_field(k)
+                if isinstance(f, models.JSONField):
+                    t = copy.deepcopy(v)
+                    cleanup_commit_tree(t)
+                    setattr(obj, k, t)
+                else:
+                    raise MTOError(f'Cannot set field "{k}" to dict value')
+            else:
+                fk_obj = commit_subtree(f.related_model, v)
+                if fk_obj is None:
+                    return None
+                setattr(obj, k, fk_obj)
+                committed_fks.append(k)
+        elif isinstance(v, list):
+            f = obj.get_mt_field(k, many_to_many=True)
+            ol = []
+            for sv in v:
+                m2m_obj = commit_subtree(f.related_model, sv)
+                if m2m_obj is None:
+                    return None
+                ol.append(m2m_obj)
+            m2m_fields.append((k, ol))
+        else:
+            obj.get_mt_field(k)
+            setattr(obj, k, v)
+    return obj, m2m_fields, committed_fks
+
+
+def _bulk_insert(model, batch, cache):
+    try:
+        with transaction.atomic():
+            model.objects.bulk_create([obj for obj, _, _ in batch], batch_size=COMMIT_CACHE_CHUNK_SIZE)
+            m2m_rows = {}
+            for obj, m2m_fields, _ in batch:
+                for k, ol in m2m_fields:
+                    f = model._meta.get_field(k)
+                    m2m_rows.setdefault(f.remote_field.through, []).extend(
+                        f.remote_field.through(**{f.m2m_field_name(): obj, f.m2m_reverse_field_name(): m2m_obj})
+                        for m2m_obj in ol
+                    )
+            for through, rows in m2m_rows.items():
+                # the objects were all inserted above, so none of them can have m2m rows yet
+                through.objects.bulk_create(rows, batch_size=COMMIT_CACHE_CHUNK_SIZE)
+            for obj, _, committed_fks in batch:
+                obj.full_clean(exclude=committed_fks, validate_unique=False)
+                if not obj.hash(recursive=False) == obj.mt_hash:
+                    raise MTOError(f'Obj {obj} Hash missmatch!!!')
+    except IntegrityError:
+        # one of them was concurrently created, and a single insert cannot say which: roll the
+        # batch back and let the per object path recover them one by one
+        return False
+    for obj, _, _ in batch:
+        cache.set(model, obj.mt_hash, obj)
+    return True
+
+
+def _bulk_commit(cache, collector):
+    def resolve(model, subtree):
+        if not isinstance(subtree, dict):
+            return None
+        obj = cache.get(model, subtree['mt_hash'])
+        return obj if isinstance(obj, model) else None
+
+    pending = {}
+    for model, trees in collector.items():
+        # bulk_create does not call save(), where AbstractMachineGroup computes its key
+        if model.save is not models.Model.save:
+            continue
+        missing = {h: t for h, t in trees.items() if cache.get(model, h) is None}
+        if missing:
+            pending[model] = missing
+    # an object can only be inserted once its subtrees hold a pk, so the models are drained in
+    # dependency order, one round per level — a self referencing model takes one round per link
+    while pending:
+        progress = False
+        for model, trees in list(pending.items()):
+            batch = []
+            for mt_hash in list(trees):
+                built = _build_mt_object(model, trees[mt_hash], resolve)
+                if built is not None:
+                    batch.append(built)
+                    del trees[mt_hash]
+            if not trees:
+                del pending[model]
+            if batch and _bulk_insert(model, batch, cache):
+                progress = True
+        if not progress:
+            return
 
 
 class MTObjectManager(models.Manager):
@@ -215,38 +319,16 @@ class MTObjectManager(models.Manager):
                 # an unchanged tree stops at the get above, without walking a single subtree:
                 # only pay for the prefetch once the root hash has missed
                 _cache.prefetch(collector)
-            obj = self.model()
-            m2m_fields = []
-            committed_fks = []
-            for k, v in tree.items():
-                if k == 'mt_hash':  # special excluded field
-                    obj.mt_hash = v
-                elif isinstance(v, dict):
-                    try:
-                        f = obj.get_mt_field(k, many_to_one=True)
-                    except MTOError:
-                        # JSONField ???
-                        f = obj.get_mt_field(k)
-                        if isinstance(f, models.JSONField):
-                            t = copy.deepcopy(v)
-                            cleanup_commit_tree(t)
-                            setattr(obj, k, t)
-                        else:
-                            raise MTOError(f'Cannot set field "{k}" to dict value')
-                    else:
-                        fk_obj, _ = f.related_model.objects.commit(v, _cache=_cache)
-                        setattr(obj, k, fk_obj)
-                        committed_fks.append(k)
-                elif isinstance(v, list):
-                    f = obj.get_mt_field(k, many_to_many=True)
-                    ol = []
-                    for sv in v:
-                        m2m_obj, _ = f.related_model.objects.commit(sv, _cache=_cache)
-                        ol.append(m2m_obj)
-                    m2m_fields.append((k, ol))
-                else:
-                    obj.get_mt_field(k)
-                    setattr(obj, k, v)
+                if not extra_obj_save_kwargs:
+                    # the save kwargs only apply to the root, and bulk_create cannot forward them
+                    _bulk_commit(_cache, collector)
+                    cached = _cache.get(self.model, mt_hash)
+                    if isinstance(cached, self.model):
+                        return cached, True
+            obj, m2m_fields, committed_fks = _build_mt_object(
+                self.model, tree,
+                lambda model, subtree: model.objects.commit(subtree, _cache=_cache)[0]
+            )
             try:
                 with transaction.atomic():
                     obj.save(**extra_obj_save_kwargs)


### PR DESCRIPTION
Follow-up to #1553, now merged, so this targets `main` directly. Split out from that PR because it is a different kind of change: the commits there remove work that cannot fail, this one reorders work that can.

Committing an inventory tree walks it one object at a time: a savepoint, an insert and a release each, so a snapshot with 200 new app instances pays that 403 times. On `main` today that tree costs 1229 queries, of which only ~400 are the inserts themselves and ~800 are savepoint statements.

| scenario | `main` today | this branch |
|---|---:|---:|
| first commit, 200 new app instances | 1229 | **34** |
| re-commit with 1 new app instance | 29 | **28** |
| unchanged re-commit | 1 | **1** |

The query count now follows the number of *models* in the tree rather than the number of objects in it — the same tree at 1000 app instances also lands around 28.

## How it works

The collector added in #1553 already knows every subtree and its model before the first query, which is what makes batching possible at all. `commit()` drains the collected subtrees model by model, in dependency order: a model can only be inserted once all of its subtrees hold a pk, so each round handles one level of the tree, and a self-referencing model — the certificate chains — takes one round per link. A round is one `bulk_create` per model plus one per m2m through table.

The field walk is extracted into `_build_mt_object()` and shared with the per-object path, so there is one place that decides how a tree maps onto a model instance. The per-object path stays on as the fallback for everything the batching declines:

- `AbstractMachineGroup` and its subclasses compute their `key` in `save()`, which `bulk_create` skips, and a root with save kwargs cannot be batched either — both are one object per tree, not two hundred.
- A `bulk_create` that hits a unique violation cannot say *which* of its objects was concurrently created, so the batch is rolled back and handed over one object at a time. This is deliberately not `ignore_conflicts`: a violation on anything other than `mt_hash` still surfaces instead of being silently skipped.
- Whatever is still pending when a round makes no progress — which is how the models above, and anything depending on them, get committed.

## Why I think it is safe

The tree is content-addressed, which makes the two write paths differentially testable: **if the bulk path built any single object differently from the per-object path, that object's hash would differ, and the other path would insert a second row instead of resolving the first.** `test_bulk_and_per_object_paths_agree` runs a tree both ways in both orders and asserts the row counts do not move.

On top of that, `commit()` still verifies every created object's `hash()` against its `mt_hash` before the transaction closes, on both paths — and since #1553's last commit, a mismatch rolls the row back rather than leaving it behind.

Checked before writing any of this:

- **No signal receivers on any MT model.** The only `post_save` in the tree is on `puppet.Instance`, which is not an MT object. `bulk_create` sending no signals therefore changes nothing.
- **No custom `through` models**, so the m2m rows can be built from `m2m_field_name()` / `m2m_reverse_field_name()`.
- **`AbstractMachineGroup` is the only MT model overriding `save()`** — everything at `inventory/models.py:888`, `:1460`, `:1533` and `santa/models.py:706` is a plain `models.Model`.
- **`auto_now_add` on `mt_created_at` still works**: `bulk_create` calls `pre_save`, which is where `DateTimeField` sets it.
- **Statement size is bounded**: `batch_size=COMMIT_CACHE_CHUNK_SIZE`, and Django additionally caps it by the backend's parameter limit.

## What to look at hardest

- `_bulk_commit()`'s termination argument: a round that reports progress must have emptied at least one entry from `pending`, so `pending` shrinks monotonically and the loop cannot spin.
- The `except IntegrityError` handover in `_bulk_insert()`: the rolled-back objects keep the pks `bulk_create` assigned them, but they are never cached and never reused — the per-object path rebuilds them from the tree.
- Whether the m2m through rows can ever pre-exist for a freshly inserted parent. I argue no: the parents' `bulk_create` succeeded, so none of them was already in the table, so none of them can have through rows.

## Verification

- Full suite: **7426 tests, OK**.
- `zentral/utils/mt_models.py`: **100%**, 0 of 371 statements missed, measured over the full suite.
- `ruff` clean.

## What is left

About half of the remaining 34 queries are the `hash()` verification re-reading each m2m of the machine snapshot from the DB. That is a fixed cost per snapshot rather than per object, so it seemed a reasonable place to stop — computing it from the in-memory data instead would trade a real safety property for a handful of queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
