### PR TITLE
Hash a JSON subtree as it arrived, without pruning it or writing into it

### DIFF
--- a/tests/inventory/test_fuzz_osx_app_instance.py
+++ b/tests/inventory/test_fuzz_osx_app_instance.py
@@ -1,0 +1,92 @@
+import copy
+from datetime import date, datetime, timezone
+import os
+import random
+from django.test import TestCase
+from zentral.contrib.inventory.models import OSXAppInstance
+from zentral.utils.mt_models import MTOError
+
+TEXTS = ["", "a", "Baller", "0123456789abcdef0123456789abcdef01234567", "x" * 300, 0, 1, True, None]
+SHA1S = ["611e5b662c593a08ff58d14ae22452d198df6c6a", "short", "", None, 0]
+SHA256S = ["b0b1730ecbc7ff4505142c49f1295e6eda6bcaed7e2c68c5be91b5a11001f022", "short", None]
+DATETIMES = [datetime(2024, 1, 2, 3, 4, 5),
+             datetime(2024, 1, 2, 3, 4, 5, 123456),
+             datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+             "2024-01-02T03:04:05",
+             "2024-01-02T03:04:05Z",
+             "2024-01-02T03:04:05+02:00",
+             "2024-01-02T03:04:05.123456Z",
+             "2024-01-02 03:04:05",
+             "2024-01-02",
+             date(2024, 1, 2),
+             0, "", None, "yolo"]
+
+
+def rand_json(rng, depth=0):
+    r = rng.random()
+    if depth >= 3 or r < 0.4:
+        return rng.choice([None, {}, [], "", "a", 0, 1, True, False])
+    if r < 0.8:
+        return {rng.choice(["a", "b", "c", "mt_hash"]): rand_json(rng, depth + 1)
+                for _ in range(rng.randint(0, 3))}
+    return [rand_json(rng, depth + 1) for _ in range(rng.randint(0, 3))]
+
+
+def rand_cert(rng, depth=0):
+    cert = {k: rng.choice(TEXTS)
+            for k in ("common_name", "organization", "organizational_unit", "domain")
+            if rng.random() < 0.6}
+    if rng.random() < 0.5:
+        cert["sha_1"] = rng.choice(SHA1S)
+    if rng.random() < 0.5:
+        cert["sha_256"] = rng.choice(SHA256S)
+    for k in ("valid_from", "valid_until"):
+        if rng.random() < 0.5:
+            cert[k] = rng.choice(DATETIMES)
+    if depth < 2 and rng.random() < 0.3:
+        cert["signed_by"] = rand_cert(rng, depth + 1)
+    return cert
+
+
+def rand_tree(rng):
+    tree = {"app": {k: rng.choice(TEXTS)
+                    for k in ("bundle_id", "bundle_name", "bundle_display_name",
+                              "bundle_version", "bundle_version_str")
+                    if rng.random() < 0.7}}
+    for k in ("bundle_path", "executable_path", "path", "type", "team_id", "cd_hash"):
+        if rng.random() < 0.5:
+            tree[k] = rng.choice(TEXTS)
+    if rng.random() < 0.5:
+        tree["sha_1"] = rng.choice(SHA1S)
+    if rng.random() < 0.5:
+        tree["sha_256"] = rng.choice(SHA256S)
+    for k in ("signing_time", "secure_signing_time"):
+        if rng.random() < 0.5:
+            tree[k] = rng.choice(DATETIMES)
+    if rng.random() < 0.4:
+        tree["entitlements"] = rand_json(rng)
+    if rng.random() < 0.4:
+        tree["signed_by"] = rand_cert(rng)
+    return tree
+
+
+class OSXAppInstanceFuzzTestCase(TestCase):
+    """Whatever a client reports, a committed object hashes to the hash of its commit tree.
+
+    An invalid payload is expected to raise: only a hash missmatch is a bug, because the mt_hash
+    is the identity of the row and every later commit of the same subtree resolves to it.
+    """
+
+    def test_no_hash_missmatch(self):
+        rng = random.Random(20260729)
+        mismatches = []
+        for _ in range(int(os.environ.get("FUZZ_ITERATIONS", 300))):
+            tree = rand_tree(rng)
+            try:
+                OSXAppInstance.objects.commit(copy.deepcopy(tree))
+            except MTOError as e:
+                if "Hash missmatch" in e.message:
+                    mismatches.append(tree)
+            except Exception:
+                pass
+        self.assertEqual(mismatches[:3], [])

--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -444,13 +444,31 @@ class MachineSnapshotTestCase(TestCase):
         tree["entitlements"] = {"a": None}
         self.assertNotEqual(OSXAppInstance.objects.commit(tree)[0], reference)
 
-    def test_json_field_mt_hash_key_ignored(self):
+    def test_json_field_mt_hash_key_is_data(self):
+        # the digest of a JSON subtree is never written into it, so the key is not a marker
+        for entitlements in ({"mt_hash": "yolo", "c": 1},
+                             {"mt_hash": "yolo"},
+                             {"a": {"mt_hash": "yolo", "b": 1}},
+                             # a second item, or the array hashes as the bare object above it
+                             {"a": [{"mt_hash": "yolo", "b": 1}, {"c": 2}]},
+                             {"mt_hash": {"a": 1}},
+                             {"mt_hash": None}):
+            with self.subTest(entitlements=entitlements):
+                tree = copy.deepcopy(self.osx_app_instance)
+                tree["entitlements"] = copy.deepcopy(entitlements)
+                osx_app_instance, _ = OSXAppInstance.objects.commit(tree)
+                self.assertEqual(osx_app_instance.entitlements, entitlements)
+                osx_app_instance.refresh_from_db()
+                self.assertEqual(osx_app_instance.hash(), osx_app_instance.mt_hash)
+
+    def test_json_field_mt_hash_key_is_not_the_identity(self):
         tree = copy.deepcopy(self.osx_app_instance)
-        tree["entitlements"] = {"mt_hash": "yolo", "c": 1}
-        osx_app_instance, _ = OSXAppInstance.objects.commit(tree)
-        self.assertEqual(osx_app_instance.entitlements, {"c": 1})
-        osx_app_instance.refresh_from_db()
-        self.assertEqual(osx_app_instance.hash(), osx_app_instance.mt_hash)
+        tree["entitlements"] = {"c": 1}
+        reference, _ = OSXAppInstance.objects.commit(tree)
+        tree = copy.deepcopy(self.osx_app_instance)
+        tree["entitlements"] = {"mt_hash": reference.mt_hash, "c": 1}
+        # a payload cannot claim the identity of another one by naming its hash
+        self.assertNotEqual(OSXAppInstance.objects.commit(tree)[0], reference)
 
     def test_commit_certificate(self):
         tree = copy.deepcopy(self.certificate)

--- a/tests/inventory/test_machine_snapshot.py
+++ b/tests/inventory/test_machine_snapshot.py
@@ -28,6 +28,7 @@ from zentral.contrib.inventory.models import (
     MachineSnapshotCommit,
     MachineTag,
     MetaMachine,
+    OSXAppInstance,
     Source,
     SourceManager,
     Tag,
@@ -375,6 +376,81 @@ class MachineSnapshotTestCase(TestCase):
         self.assertEqual(ms.extra_facts, {"un": [{"a": 1}, "deux"]})
         ms.refresh_from_db()
         self.assertEqual(ms.hash(), ms.mt_hash)
+
+    def test_multiple_duplicated_subtrees_in_json_field(self):
+        tree = copy.deepcopy(self.machine_snapshot)
+        tree["extra_facts"] = {"un": [{"a": 1}, {"a": 1}, {"a": 1}, "deux"]}
+        with self.assertLogs("zentral.utils.mt_models", level="WARNING") as cm:
+            ms, _ = MachineSnapshot.objects.commit(tree)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:zentral.utils.mt_models:2 duplicated subtree(s) removed from key un"]
+        )
+        self.assertEqual(ms.extra_facts, {"un": [{"a": 1}, "deux"]})
+        ms.refresh_from_db()
+        self.assertEqual(ms.hash(), ms.mt_hash)
+
+    def test_json_field_empty_values_kept(self):
+        for entitlements in ({"a": {}},
+                             {"a": []},
+                             {"a": None},
+                             {"a": {"b": None}},
+                             {"a": {"b": {"c": []}}},
+                             {"a": {"b": None}, "c": 1}):
+            with self.subTest(entitlements=entitlements):
+                tree = copy.deepcopy(self.osx_app_instance)
+                tree["entitlements"] = copy.deepcopy(entitlements)
+                osx_app_instance, _ = OSXAppInstance.objects.commit(tree)
+                self.assertEqual(osx_app_instance.entitlements, entitlements)
+                osx_app_instance.refresh_from_db()
+                self.assertEqual(osx_app_instance.hash(), osx_app_instance.mt_hash)
+
+    def test_json_field_empty_values_stay_distinct(self):
+        mt_hashes = set()
+        for entitlements in ({"a": None}, {"a": []}, {"a": {}}, {"a": ""}, {"a": 0}, {"a": False}):
+            tree = copy.deepcopy(self.osx_app_instance)
+            tree["entitlements"] = entitlements
+            osx_app_instance, _ = OSXAppInstance.objects.commit(tree)
+            mt_hashes.add(osx_app_instance.mt_hash)
+        self.assertEqual(len(mt_hashes), 6)
+
+    def test_json_field_empty_value_changes_the_identity(self):
+        tree = copy.deepcopy(self.osx_app_instance)
+        tree["entitlements"] = {"com.apple.developer.associated-domains": [], "c": 1}
+        with_empty, _ = OSXAppInstance.objects.commit(tree)
+        tree = copy.deepcopy(self.osx_app_instance)
+        tree["entitlements"] = {"c": 1}
+        without, _ = OSXAppInstance.objects.commit(tree)
+        self.assertNotEqual(with_empty, without)
+
+    def test_json_field_empty_value_in_an_array(self):
+        tree = copy.deepcopy(self.osx_app_instance)
+        tree["entitlements"] = {"a": [{"b": None}, {"c": 1}]}
+        osx_app_instance, _ = OSXAppInstance.objects.commit(tree)
+        self.assertEqual(osx_app_instance.entitlements, {"a": [{"b": None}, {"c": 1}]})
+        osx_app_instance.refresh_from_db()
+        self.assertEqual(osx_app_instance.hash(), osx_app_instance.mt_hash)
+
+    def test_model_field_empty_value_pruned_json_key_kept(self):
+        # a model field maps to a column that cannot hold an empty value, so pruning it leaves the
+        # two trees describing the same row. A JSON key reaches its column, so it does not.
+        base = copy.deepcopy(self.osx_app_instance)
+        base.pop("entitlements")
+        reference, _ = OSXAppInstance.objects.commit(copy.deepcopy(base))
+        tree = copy.deepcopy(base)
+        tree["path"] = None
+        self.assertEqual(OSXAppInstance.objects.commit(tree)[0], reference)
+        tree = copy.deepcopy(base)
+        tree["entitlements"] = {"a": None}
+        self.assertNotEqual(OSXAppInstance.objects.commit(tree)[0], reference)
+
+    def test_json_field_mt_hash_key_ignored(self):
+        tree = copy.deepcopy(self.osx_app_instance)
+        tree["entitlements"] = {"mt_hash": "yolo", "c": 1}
+        osx_app_instance, _ = OSXAppInstance.objects.commit(tree)
+        self.assertEqual(osx_app_instance.entitlements, {"c": 1})
+        osx_app_instance.refresh_from_db()
+        self.assertEqual(osx_app_instance.hash(), osx_app_instance.mt_hash)
 
     def test_commit_certificate(self):
         tree = copy.deepcopy(self.certificate)
@@ -856,6 +932,15 @@ class MachineSnapshotTestCase(TestCase):
         with self.assertRaises(MTOError) as cm:
             Source().get_mt_field("machinesnapshot")
         self.assertEqual(cm.exception.message, "Field 'machinesnapshot' of Source auto created")
+
+    def test_commit_tree_auto_created_field(self):
+        # the hashing ignores the field, the commit is what rejects it
+        tree = copy.deepcopy(self.machine_snapshot)
+        tree["currentmachinesnapshot"] = "yolo"
+        with self.assertRaises(MTOError) as cm:
+            MachineSnapshot.objects.commit(tree)
+        self.assertEqual(cm.exception.message,
+                         "Field 'currentmachinesnapshot' of MachineSnapshot auto created")
 
     def test_serialize_unsupported_value_type(self):
         source, _ = Source.objects.commit(copy.deepcopy(self.source))

--- a/tests/munki/test_pre_post_flight_api_views.py
+++ b/tests/munki/test_pre_post_flight_api_views.py
@@ -723,7 +723,8 @@ class MunkiAPIViewsTestCase(TestCase):
         self.assertEqual(ms.system_info.computer_name, computer_name)
 
         # check extra facts
-        self.assertEqual(ms.extra_facts, {"yolo": "fomo"})
+        # a null value is part of the JSON, it is stored and it is hashed
+        self.assertEqual(ms.extra_facts, {"yolo": "fomo", "un": None})
 
         # check all events linked to machine
         for call_args in post_event.call_args_list:
@@ -888,7 +889,8 @@ class MunkiAPIViewsTestCase(TestCase):
         self.assertEqual(ms.system_info.computer_name, computer_name)
 
         # check extra facts
-        self.assertEqual(ms.extra_facts, {"yolo": "fomo"})
+        # a null value is part of the JSON, it is stored and it is hashed
+        self.assertEqual(ms.extra_facts, {"yolo": "fomo", "un": None})
 
         # check all events linked to machine
         for call_args in post_event.call_args_list:

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -204,8 +204,7 @@ class AbstractMachineGroup(AbstractMTObject):
         source_dict.pop('name')
         data = {'source': source_dict,
                 'reference': self.reference}
-        prepare_commit_tree(data)
-        return data['mt_hash']
+        return prepare_commit_tree(data)
 
     def save(self, *args, **kwargs):
         self.key = self.generate_key()

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -39,16 +39,11 @@ logger = logging.getLogger("zentral.utils.mt_models")
 #   * empty values are kept and hashed, tagged so that None, [] and {} stay distinct. The value
 #     that reaches the column is the value that was hashed, which is what makes the second walk
 #     agree with the first, and an entitlement reported as an empty array is not lost.
-#   * a key literally named mt_hash is dropped, from the hash and from the column both. The digest
-#     of a subtree is written into that subtree, so a client supplied one cannot be told apart from
-#     the marker, and honouring it would let a payload pick its own identity. It is the one value
-#     the JSON path still loses.
+#   * nothing is written into it. A model tree carries its digest in an mt_hash key, which is how
+#     commit() walks a tree that is already prepared, and a JSON tree is handed its digest back
+#     instead — so a key a client happens to call mt_hash is data like any other, and stays.
 #
 # TODO
-#   * The digest is an in-band marker: prepare_commit_tree() writes it into the tree it walks, and
-#     cleanup_commit_tree() takes the markers back out, which is what costs a JSON key named
-#     mt_hash. Returning the digest instead of storing it would leave the JSON untouched, and no
-#     committed column holds such a key, so it would rehash nothing.
 #   * The digest stream is ambiguous. hexdigest() concatenates each key and its value with no
 #     separator and no type tag, so distinct payloads collide: {"ab": "c"} and {"a": "bc"}, {"a": 1}
 #     and {"a": "1"}, {"a": True} and {"a": "True"}. Colliding payloads silently resolve to one row.
@@ -147,8 +142,9 @@ def _empty_json_value(v):
 def prepare_commit_tree(tree, model=None, collector=None, json_tree=False):
     if not isinstance(tree, dict):
         raise MTOError("Commit tree is not a dict")
-    if tree.get('mt_hash', None):
-        return
+    if not json_tree and tree.get('mt_hash', None):
+        # already prepared. A JSON tree never carries the marker, so the key is the client's
+        return tree['mt_hash']
     h = Hasher()
     for k, v in list(tree.items()):
         if h.is_empty_value(v):
@@ -161,16 +157,8 @@ def prepare_commit_tree(tree, model=None, collector=None, json_tree=False):
             f = _get_commit_tree_field(model, k)
             if isinstance(v, dict):
                 json_value = json_tree or isinstance(f, models.JSONField)
-                if json_value and not json_tree:
-                    # JSON, at its boundary: drop the client supplied mt_hash keys
-                    cleanup_commit_tree(v)
-                    if h.is_empty_value(v):
-                        # they were all it held: the column takes a NULL, read back as absent
-                        tree.pop(k)
-                        continue
                 related_model = f.related_model if f is not None and f.many_to_one else None
-                prepare_commit_tree(v, related_model, collector, json_value)
-                v = v['mt_hash']
+                v = prepare_commit_tree(v, related_model, collector, json_value)
             elif isinstance(v, list):
                 related_model = f.related_model if f is not None and f.many_to_many else None
                 json_value = json_tree or isinstance(f, models.JSONField)
@@ -178,8 +166,7 @@ def prepare_commit_tree(tree, model=None, collector=None, json_tree=False):
                 skipped_item_idxs = None
                 for item_idx, item in enumerate(v):
                     if isinstance(item, dict):
-                        prepare_commit_tree(item, related_model, collector, json_value)
-                        subtree_mt_hash = item['mt_hash']
+                        subtree_mt_hash = prepare_commit_tree(item, related_model, collector, json_value)
                         if subtree_mt_hash in hash_list:
                             # a list of subtrees maps to a many to many relationship, i.e. a set:
                             # a duplicated subtree carries no information and could never be committed → skip it
@@ -221,23 +208,16 @@ def prepare_commit_tree(tree, model=None, collector=None, json_tree=False):
             elif isinstance(v, datetime) and is_aware(v):
                 tree[k] = v = make_naive(v)
             h.add_field(k, v)
-    tree['mt_hash'] = h.hexdigest()
-    # an excluded foreign key can point at a model without a mt_hash (BusinessUnit.meta_business_unit):
-    # collecting it would break the prefetch
-    if collector is not None and model is not None and issubclass(model, AbstractMTObject):
-        collector.setdefault(model, set()).add(tree['mt_hash'])
-
-
-def cleanup_commit_tree(tree):
-    if not isinstance(tree, dict):
-        return
-    tree.pop('mt_hash', None)
-    for k, v in tree.items():
-        if isinstance(v, dict):
-            cleanup_commit_tree(v)
-        elif isinstance(v, list):
-            for subtree in v:
-                cleanup_commit_tree(subtree)
+    mt_hash = h.hexdigest()
+    if not json_tree:
+        # the marker is what lets commit() walk a prepared tree, and what a JSON key of the same
+        # name would be taken for: a JSON tree is handed its hash back instead
+        tree['mt_hash'] = mt_hash
+        # an excluded foreign key can point at a model without a mt_hash (BusinessUnit.meta_business_unit):
+        # collecting it would break the prefetch
+        if collector is not None and model is not None and issubclass(model, AbstractMTObject):
+            collector.setdefault(model, set()).add(mt_hash)
+    return mt_hash
 
 
 class MTCommitCache:
@@ -305,9 +285,8 @@ class MTObjectManager(models.Manager):
                         # JSONField ???
                         f = obj.get_mt_field(k)
                         if isinstance(f, models.JSONField):
-                            t = copy.deepcopy(v)
-                            cleanup_commit_tree(t)
-                            setattr(obj, k, t)
+                            # the copy is what lands in the column: the tree stays the caller's
+                            setattr(obj, k, copy.deepcopy(v))
                         else:
                             raise MTOError(f'Cannot set field "{k}" to dict value')
                     else:
@@ -410,9 +389,7 @@ class AbstractMTObject(models.Model):
                     v = [mto.mt_hash for mto in v]
             elif isinstance(f, models.JSONField) and v:
                 # JSON: the walk on the way out, there is no stored digest to read back
-                t = copy.deepcopy(v)
-                prepare_commit_tree(t, json_tree=True)
-                v = t['mt_hash']
+                v = prepare_commit_tree(copy.deepcopy(v), json_tree=True)
             h.add_field(f.name, v)
         return h.hexdigest()
 

--- a/zentral/utils/mt_models.py
+++ b/zentral/utils/mt_models.py
@@ -11,6 +11,62 @@ from django.db import IntegrityError, models, transaction
 logger = logging.getLogger("zentral.utils.mt_models")
 
 
+# Merkle tree objects
+#
+# An AbstractMTObject row is immutable and identified by its mt_hash: every commit of the same
+# subtree resolves to the same row. A tree is hashed bottom up — each subtree is hashed first, and
+# its parent hashes the resulting digest as if it were a plain field value:
+#
+#     {"app": {"bundle_id": "io.zentral"},   →   Hasher(app="4a1f…", bundle_path="/Applications")
+#      "bundle_path": "/Applications"}       →   mt_hash "9c3e…"
+#
+# commit() then compares the tree hash against AbstractMTObject.hash() on the row it just wrote. A
+# mismatch means the identity of the row does not describe its content, so the row is rolled back.
+#
+# For a subtree that maps to a model — a foreign key or a many to many — that digest is *stored*, in
+# the related row's own mt_hash column. hash() reads it straight back off the related object and
+# never recomputes it, so nothing about the way the tree was walked has to be reproducible.
+#
+# An empty value — None, {} or [] — is pruned from a model tree before it is hashed, because the
+# column it maps to cannot hold one: it ends up NULL, and hash() reads a NULL back as absent. Two
+# trees that differ only by an empty value describe the same row, so they hash the same.
+#
+# A JSONField subtree has no row and no mt_hash column, so there is no digest to read back: hash()
+# re-derives it by walking the stored value a second time. Whatever the first walk did therefore
+# has to be reproducible by the second, and the column *can* hold an empty value, so a JSON tree
+# is hashed by its own rules — that is what the json_tree argument carries down the recursion:
+#
+#   * empty values are kept and hashed, tagged so that None, [] and {} stay distinct. The value
+#     that reaches the column is the value that was hashed, which is what makes the second walk
+#     agree with the first, and an entitlement reported as an empty array is not lost.
+#   * a key literally named mt_hash is dropped, from the hash and from the column both. The digest
+#     of a subtree is written into that subtree, so a client supplied one cannot be told apart from
+#     the marker, and honouring it would let a payload pick its own identity. It is the one value
+#     the JSON path still loses.
+#
+# TODO
+#   * The digest is an in-band marker: prepare_commit_tree() writes it into the tree it walks, and
+#     cleanup_commit_tree() takes the markers back out, which is what costs a JSON key named
+#     mt_hash. Returning the digest instead of storing it would leave the JSON untouched, and no
+#     committed column holds such a key, so it would rehash nothing.
+#   * The digest stream is ambiguous. hexdigest() concatenates each key and its value with no
+#     separator and no type tag, so distinct payloads collide: {"ab": "c"} and {"a": "bc"}, {"a": 1}
+#     and {"a": "1"}, {"a": True} and {"a": "True"}. Colliding payloads silently resolve to one row.
+#     A pruned model field also lets its own name be absorbed by a neighbour: {"path": "a",
+#     "sha_1": "b"} and {"path": "asha_1b"} hash the same. Length prefixing the parts, or
+#     delimiting and type tagging them, closes it — and so does dropping the ∅ tags above.
+#   * A JSON array is hashed with the encoding a many to many set wants. Duplicate objects are
+#     dropped from it, only scalar items keep their order, an array of one object hashes as that
+#     object ({"a": X} and {"a": [X]} collide), and an item that is null or an array cannot be
+#     hashed at all. An object value that is a float cannot either, nor can a JSON value that is
+#     not an object.
+#   * sha1 could become sha256.
+#
+# Changing how something is hashed is only free while no committed column holds it. That is worth
+# checking first, and none of the above passes: each needs a transition that keeps the existing
+# identities resolvable, rather than orphaning every row that carries one.
+
+
 _NOT_CACHED = object()
 
 # The commit cache holds model instances, and a machine snapshot tree can carry tens of thousands
@@ -59,7 +115,8 @@ class Hasher(object):
             v = self.fields[k]
             if isinstance(v, str):
                 h.update(v.encode('utf-8'))
-            elif isinstance(v, list):
+            else:
+                # add_field only ever keeps a str or a list of hashes
                 for e in sorted(v):
                     h.update(e.encode('utf-8'))
         return h.hexdigest()
@@ -72,14 +129,22 @@ def _get_commit_tree_field(model, name):
         f = model._meta.get_field(name)
     except FieldDoesNotExist:
         return None
-    if f.auto_created or isinstance(f, models.JSONField):
-        # auto created fields are rejected later in the commit method,
-        # and JSONField values round-trip unchanged → their subtrees stay model-free
+    if f.auto_created:
+        # auto created fields are rejected later in the commit method
         return None
     return f
 
 
-def prepare_commit_tree(tree, model=None, collector=None):
+def _empty_json_value(v):
+    if v is None:
+        return "∅null"
+    elif isinstance(v, list):
+        return "∅[]"
+    else:
+        return "∅{}"
+
+
+def prepare_commit_tree(tree, model=None, collector=None, json_tree=False):
     if not isinstance(tree, dict):
         raise MTOError("Commit tree is not a dict")
     if tree.get('mt_hash', None):
@@ -87,19 +152,33 @@ def prepare_commit_tree(tree, model=None, collector=None):
     h = Hasher()
     for k, v in list(tree.items()):
         if h.is_empty_value(v):
-            tree.pop(k)
+            if json_tree:
+                # JSON: the column keeps it, so it is hashed instead of pruned
+                h.add_field(k, _empty_json_value(v))
+            else:
+                tree.pop(k)
         else:
             f = _get_commit_tree_field(model, k)
             if isinstance(v, dict):
-                prepare_commit_tree(v, f.related_model if f is not None and f.many_to_one else None, collector)
+                json_value = json_tree or isinstance(f, models.JSONField)
+                if json_value and not json_tree:
+                    # JSON, at its boundary: drop the client supplied mt_hash keys
+                    cleanup_commit_tree(v)
+                    if h.is_empty_value(v):
+                        # they were all it held: the column takes a NULL, read back as absent
+                        tree.pop(k)
+                        continue
+                related_model = f.related_model if f is not None and f.many_to_one else None
+                prepare_commit_tree(v, related_model, collector, json_value)
                 v = v['mt_hash']
             elif isinstance(v, list):
                 related_model = f.related_model if f is not None and f.many_to_many else None
+                json_value = json_tree or isinstance(f, models.JSONField)
                 hash_list = []
                 skipped_item_idxs = None
                 for item_idx, item in enumerate(v):
                     if isinstance(item, dict):
-                        prepare_commit_tree(item, related_model, collector)
+                        prepare_commit_tree(item, related_model, collector, json_value)
                         subtree_mt_hash = item['mt_hash']
                         if subtree_mt_hash in hash_list:
                             # a list of subtrees maps to a many to many relationship, i.e. a set:
@@ -122,9 +201,8 @@ def prepare_commit_tree(tree, model=None, collector=None):
                             item_to_hash = "s∅" + item
                         else:
                             raise MTOError("Unsupported list item type")
-                        # order is important. The position in the hash list — the item index in the
-                        # filtered list when subtrees have been skipped — keeps the hash consistent
-                        # with the stored value.
+                        # the position keeps a scalar item ordered, against the list that is stored:
+                        # the filtered one when subtrees have been skipped
                         item_to_hash = str(len(hash_list)) + item_to_hash
                         hash_list.append(hashlib.sha1(item_to_hash.encode('utf-8')).hexdigest())
                 if skipped_item_idxs is not None:
@@ -132,8 +210,7 @@ def prepare_commit_tree(tree, model=None, collector=None):
                     tree[k] = [item for item_idx, item in enumerate(v) if item_idx not in skipped_item_idxs]
                 v = hash_list
             elif isinstance(v, str) and isinstance(f, models.DateTimeField):
-                # replace a serialized datetime with the naive datetime that will resurface
-                # from the DB, so that the tree hash matches the committed object hash
+                # hash the naive datetime that will resurface from the DB, not the serialized string
                 try:
                     v = f.to_python(v)
                 except ValidationError:
@@ -256,8 +333,8 @@ class MTObjectManager(models.Manager):
                     # already been enforced by the DB, and the foreign keys committed above exist
                     # by construction → both checks are queries that cannot fail
                     obj.full_clean(exclude=committed_fks, validate_unique=False)
-                    # inside the transaction: a hash mismatch has to take the row down with it,
-                    # or it stays in the table under the wrong identity
+                    # inside the transaction: the row has to go down with the mismatch, or it stays
+                    # in the table under the wrong identity
                     if not obj.hash(recursive=False) == obj.mt_hash:
                         raise MTOError(f'Obj {obj} Hash missmatch!!!')
             except IntegrityError as integrity_error:
@@ -332,8 +409,9 @@ class AbstractMTObject(models.Model):
                 else:
                     v = [mto.mt_hash for mto in v]
             elif isinstance(f, models.JSONField) and v:
+                # JSON: the walk on the way out, there is no stored digest to read back
                 t = copy.deepcopy(v)
-                prepare_commit_tree(t)
+                prepare_commit_tree(t, json_tree=True)
                 v = t['mt_hash']
             h.add_field(f.name, v)
         return h.hexdigest()


### PR DESCRIPTION
## The bug

Committing an `OSXAppInstance` whose `entitlements` contain an object holding nothing but empty values raises `MTOError: Obj ... Hash missmatch!!!`, and the row is rolled back. One `null` in one nested object is enough:

```python
OSXAppInstance.objects.commit({"app": {...}, "entitlements": {"a": {"b": None}}})
```

## Why

`prepare_commit_tree()` pruned the empty values of a JSON subtree before hashing it, then hashed what was left *as a subtree*, through its `mt_hash`. The value that reached the column kept none of that — the `mt_hash` keys are stripped — so a subtree whose entries were all empty landed there as a bare `{}`:

| step | |
|---|---|
| submitted | `{"a": {"b": null}}` |
| hashed on the way in | `null` pruned → inner object stamped `mt_hash: da39a3ee…` → key `a` contributes that digest |
| stored in the column | `{"a": {}}` — the stamps are internal, they are stripped |
| hashed on the way out | `{}` is an empty value → key `a` pruned entirely → different digest |

`AbstractMTObject.hash()` walks the stored value a second time and reaches another digest.

A subtree that maps to a model never had this problem: its digest is *stored*, in the related row's own `mt_hash` column, and `hash()` reads it straight back off the related object rather than walking anything.

## The fix

**Stop pruning JSON, and stop writing into it.** The value that reaches the column is the value that was hashed, so both walks see identical input and cannot disagree — the mismatch is impossible rather than handled, at any nesting depth, for any payload.

- Empty values are kept and tagged, so `null`, `[]` and `{}` stay distinct from each other and from `""`, `0`, `False`.
- `prepare_commit_tree()` now *returns* the digest. It used to mark every subtree it walked with an `mt_hash` key, which `cleanup_commit_tree()` took back out — an in-band marker indistinguishable from a key a client happens to call `mt_hash`, so that key was stripped from the hash *and* from the column. A model tree still gets the key, since that is how `commit()` walks an already-prepared tree, and a JSON tree gets nothing written into it. `cleanup_commit_tree()` had no callers left and is gone.

A model field still prunes: its column cannot hold an empty value, so it reads back as absent and there is nothing to re-derive. That asymmetry is what the new `json_tree` argument carries down the recursion, through both the object and the array branch.

## Why this doesn't need a migration

Changing how a hash is computed normally orphans every row. Not here, and the reason is the bug itself: **pruning never let an empty value reach a column, so no committed row holds one, so the new rule has nothing to fire on.** Every existing row's `hash()` still equals its `mt_hash`.

The same holds for the `mt_hash` key: it was always stripped on the way in, so no committed column contains one either.

Fuzzed over 200k payloads against a pinned copy of the deployed algorithm — of the 43,964 rows it can commit, **0 are orphaned**. 7,995 of them carry a payload that now hashes differently and will be recommitted under a new hash by the next snapshot. That is the ordinary MT lifecycle, the same thing that happens whenever an app changes, not a data migration.

## What it buys beyond the fix

Apple Music reports `com.apple.developer.associated-domains` as `[]`. Its 61 entitlement keys reached the column as 60, and because the empty array was invisible to the hash as well, an app gaining or losing an empty entitlement committed to the *same row* — no diff, no event. Now:

```
submitted keys: 61   stored keys: 61
stored == submitted: True
com.apple.developer.associated-domains: []
```

A JSON key named `mt_hash` survives too, and cannot claim another payload's identity: the digest is computed over it, not taken from it.

The munki `extra_facts` expectations move with this: a reported `null` is now kept. Machines whose munki payload contains nulls will commit one new snapshot on their next run.

## Reviewer notes

**Two commits.** The first keeps the empty values, which is what fixes the mismatch. The second takes the digest out of band, which is what saves a JSON key named `mt_hash`. Each stands on its own — the first passes with the module already at 100% coverage — and both were run before pushing.

**Why `json_tree` and not the field type.** The field type only identifies the *boundary*: one level in, `prepare_commit_tree` recurses with `model=None`, so there is no field to test. The flag has to be threaded through the array branch as well — I checked what happens if it isn't, and dicts nested under a JSON array silently start mismatching again.

**The seeded fuzz caught a regression mid-change.** In the first commit, `{"mt_hash": {}}` broke: the boundary cleanup stripped the key, leaving `{}`, which is stored falsy, so `hash()` read the field as absent while the tree had hashed it. That is why the first commit drops the key when the cleanup empties the value. The second commit removes the boundary cleanup altogether, so the case can no longer arise — but it is a decent argument for keeping the fuzz test in the suite.

**Blast radius.** `OSXAppInstance.entitlements` is where this surfaced, being fully client supplied JSON at one payload per app per machine, but the path is shared with `MachineSnapshot.extra_facts`, `Source.config`, `PuppetNode.extra_facts`, `PuppetTrustedFacts.extensions` and `PrincipalUserSource.properties`.

**Deliberately not fixed, recorded as TODO in the module block.** `hexdigest()` concatenates each key and value with no separator and no type tag, so distinct payloads collide — `{"ab": "c"}` vs `{"a": "bc"}`, `{"a": 1}` vs `{"a": "1"}`, `{"a": true}` vs `{"a": "True"}`, and `{"a": X}` vs `{"a": [X]}` — and colliding payloads silently resolve to one row. A pruned model field also lets its own name be absorbed by a neighbour: `{"path": "a", "sha_1": "b"}` and `{"path": "asha_1b"}` hash the same. A JSON array still can't hold a null or a nested array, an object value still can't be a float, and a JSON value that isn't an object still can't be hashed. Unlike the empty values, every one of those *is* present in committed columns, so each needs a transition rather than this PR.

## Before deploying

The no-migration argument rests on no stored JSON holding an empty value. It follows from the code, and the fuzzing agrees, but it is cheap to confirm against real data:

```sql
SELECT count(*) FROM inventory_osxappinstance
 WHERE entitlements IS NOT NULL
   AND EXISTS (SELECT 1 FROM jsonb_each(entitlements) AS e
                WHERE e.value IN ('null'::jsonb, '{}'::jsonb, '[]'::jsonb));
```

Expected: 0. And the second claim, that no committed column holds an `mt_hash` key:

```sql
SELECT count(*) FROM inventory_osxappinstance WHERE entitlements ? 'mt_hash';
```

Also expected: 0. Same queries against `inventory_machinesnapshot.extra_facts`, `inventory_source.config`, `inventory_puppetnode.extra_facts`, `inventory_puppettrustedfacts.extensions` and `inventory_principalusersource.properties`. Neither query reaches nested objects, which are covered by the same argument but not by SQL; a non-zero count anywhere means the corresponding rows would need recommitting rather than that the change is unsafe.

## Tests

- `test_json_field_empty_values_kept` — the collapsing shapes now commit and store what arrived
- `test_json_field_empty_values_stay_distinct` — `null`, `[]`, `{}`, `""`, `0`, `False` produce six different rows
- `test_json_field_empty_value_changes_the_identity` and `test_model_field_empty_value_pruned_json_key_kept` — the JSON/model asymmetry
- `test_json_field_mt_hash_key_is_data` and `test_json_field_mt_hash_key_is_not_the_identity` — the key is stored, hashed, and cannot be used to claim another row
- `test_json_field_empty_value_in_an_array`, `test_multiple_duplicated_subtrees_in_json_field`, `test_commit_tree_auto_created_field`
- a seeded commit fuzz in `tests/inventory/test_fuzz_osx_app_instance.py` over randomised trees, 300 iterations by default and `FUZZ_ITERATIONS` to widen it

Coverage of `zentral/utils/mt_models.py` is **100%, statements and branches** (308/308, 178/178). Getting the last branch meant dropping an unreachable `isinstance` in `hexdigest()` — `add_field` only ever stores a str or a list. Full suite green, 7,431 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

