### PR TITLE
Audit the MDM command creation paths without serializing secrets

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -504,6 +504,45 @@ A Recovery Password Configuration can only be deleted if it is not linked to any
 3. Use the *Delete* button in the list view or on the configuration details page.
 4. Confirm the deletion when prompted.
 
+## Command audit trail
+
+Every command an operator creates is recorded as a `zentral_audit` event with the `created` action. This covers both entry points:
+
+- the *New command* forms in the web interface, under a device's detail page
+- the `erase/`, `lock/` and `send_custom_command/` HTTP API endpoints
+
+Each event carries the full request context — the authenticated user (including whether an API token was used, and which one), the source IP, the user agent, the HTTP method, the path and the resolved view name — alongside the serialized command. Events are tagged with the device serial number, so they also appear in the device's event timeline, and are linked to the command UUID.
+
+Deleting a queued command is audited the same way, with the `deleted` action.
+
+### Command parameters and secrets
+
+The command parameters are included in the audit event, but a parameter is only serialized verbatim if the command explicitly declares it as safe to log. Every other parameter is reported by name with a placeholder value, so the audit trail records that a parameter was supplied without disclosing it:
+
+- `<redacted>` — a secret, such as the PIN of a *Device lock* or *Erase device* command, or the new password of a *Set firmware password*, *Set recovery lock* or *Set auto admin password* command
+- `<omitted>` — a parameter that is not declared as safe to log
+
+Commands that carry no parameters have no parameters entry at all.
+
+*Custom* commands are a special case, because their property list payload is written by an operator and can hold anything. Only the shape of the payload is audited: its `RequestType` and the names of the other top level keys, never their values.
+
+```json
+{
+  "action": "created",
+  "object": {
+    "model": "mdm.devicecommand",
+    "pk": "42",
+    "new_value": {
+      "name": "DeviceLock",
+      "uuid": "8f2c1b9e-...",
+      "kwargs": {"Message": "Lost laptop", "PIN": "<redacted>"}
+    }
+  }
+}
+```
+
+Note that commands Zentral creates on its own — the inventory refreshes, artifact installations and other work scheduled while a device checks in — are not part of this audit trail. It records operator actions.
+
 ## HTTP API
 
 ### `/api/mdm/dep/devices/`

--- a/tests/mdm/test_api_commands_views.py
+++ b/tests/mdm/test_api_commands_views.py
@@ -256,6 +256,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              }}
         )
         metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
         self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(sorted(metadata["tags"]), ["mdm", "zentral"])
 

--- a/tests/mdm/test_api_enrolled_devices_views.py
+++ b/tests/mdm/test_api_enrolled_devices_views.py
@@ -1,3 +1,4 @@
+import json
 import plistlib
 from datetime import datetime
 from unittest.mock import patch
@@ -20,6 +21,7 @@ from zentral.contrib.mdm.events import (
     RecoveryPasswordViewedEvent,
 )
 from zentral.contrib.mdm.models import Platform
+from zentral.core.events.base import AuditEvent
 
 from .utils import force_dep_enrollment_session, force_enrolled_user
 
@@ -808,6 +810,77 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             {"RequestType": "DeviceLock",
              "PIN": "012345"}
         )
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_lock_enrolled_device_audit_event(self, post_event):
+        self.set_permissions("mdm.add_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("mdm_api:lock_enrolled_device", args=(self.enrolled_device.pk,)),
+                                 {"pin": "012345", "message": "lost mac"}, ip="1.2.3.4")
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(callbacks), 1)
+        db_command = self.enrolled_device.commands.first()
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "mdm.devicecommand")
+        self.assertEqual(event.payload["object"]["pk"], str(db_command.pk))
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["name"], "DeviceLock")
+        self.assertEqual(new_value["kwargs"], {"Message": "lost mac", "PIN": "<redacted>"})
+        # the PIN reaches the device but never the audit trail
+        self.assertNotIn("012345", json.dumps(event.payload))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(db_command.uuid)]})
+        self.assertEqual(sorted(metadata["tags"]), ["mdm", "zentral"])
+        request = metadata["request"]
+        self.assertEqual(request["method"], "POST")
+        self.assertEqual(request["ip"], "1.2.3.4")
+        self.assertEqual(request["view"], "mdm_api:lock_enrolled_device")
+        self.assertEqual(
+            request["path"],
+            reverse("mdm_api:lock_enrolled_device", args=(self.enrolled_device.pk,))
+        )
+        self.assertEqual(request["user"]["username"], self.service_account.username)
+        self.assertTrue(request["user"]["session"]["token_authenticated"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_erase_enrolled_device_audit_event(self, post_event):
+        self.set_permissions("mdm.add_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("mdm_api:erase_enrolled_device", args=(self.enrolled_device.pk,)),
+                                 {"pin": "012345"})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["name"], "EraseDevice")
+        self.assertEqual(new_value["kwargs"], {"PIN": "<redacted>"})
+        self.assertNotIn("012345", json.dumps(event.payload))
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_send_custom_enrolled_device_command_audit_event(self, post_event):
+        self.set_permissions("mdm.add_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(
+                reverse("mdm_api:send_custom_enrolled_device_command", args=(self.enrolled_device.pk,)),
+                {"command": plistlib.dumps({"RequestType": "ClearPasscode",
+                                            "UnlockToken": "s3cr3t-token"}).decode("utf-8")}
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["name"], "CustomCommand")
+        # only the shape of the operator supplied payload is audited
+        self.assertEqual(
+            new_value["kwargs"],
+            {"command": {"RequestType": "ClearPasscode", "keys": ["UnlockToken"]}}
+        )
+        self.assertNotIn("s3cr3t-token", json.dumps(event.payload))
 
     def test_lock_enrolled_device_ios_default(self):
         self.enrolled_device.platform = Platform.IOS

--- a/tests/mdm/test_command_audit.py
+++ b/tests/mdm/test_command_audit.py
@@ -1,0 +1,140 @@
+import glob
+import json
+import plistlib
+import re
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+from zentral.contrib.inventory.models import MetaBusinessUnit
+from zentral.contrib.mdm.commands import CustomCommand, DeviceLock, EraseDevice, SetFirmwarePassword
+from zentral.contrib.mdm.commands.base import AUDIT_OMITTED, AUDIT_REDACTED, registered_commands
+
+from .utils import force_dep_enrollment_session
+
+
+# Every kwarg the command classes write through the secret engine. The audit policy has to
+# account for all of them, and test_no_encrypted_kwarg_is_missing_from_this_list keeps the
+# list honest when a new command starts encrypting something.
+ENCRYPTED_KWARGS = {"PIN", "new_password", "admin_password", "encryption_key"}
+
+SENTINEL = "sentinel-must-never-be-serialized"
+
+
+class CommandAuditTestCase(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+        cls.mbu.create_enrollment_business_unit()
+        cls.session, _, _ = force_dep_enrollment_session(cls.mbu, completed=True)
+        cls.enrolled_device = cls.session.enrolled_device
+
+    # the policy itself
+
+    def test_no_encrypted_kwarg_is_missing_from_this_list(self):
+        # get_secret_engine_kwargs() declares the encrypted field name in each command
+        # module. Anything new there has to be classified, or it would be serialized
+        # verbatim the moment somebody adds it to audit_public_kwargs.
+        found = set()
+        for path in glob.glob("zentral/contrib/mdm/commands/*.py"):
+            found.update(re.findall(r"""field=["'](\w+)["']""", open(path).read()))
+        self.assertEqual(found - ENCRYPTED_KWARGS, set())
+
+    def test_encrypted_kwargs_are_never_public(self):
+        for db_name, command_class in registered_commands.items():
+            with self.subTest(db_name):
+                self.assertEqual(set(command_class.audit_public_kwargs) & ENCRYPTED_KWARGS, set())
+
+    def test_no_command_class_declares_a_kwarg_twice(self):
+        for db_name, command_class in registered_commands.items():
+            with self.subTest(db_name):
+                self.assertEqual(
+                    set(command_class.audit_public_kwargs) & set(command_class.audit_secret_kwargs),
+                    set()
+                )
+
+    def test_undeclared_and_secret_kwargs_are_never_serialized(self):
+        # Feed every command class a kwargs dict where each value is the sentinel, and
+        # check the sentinel only ever survives under an explicitly public key.
+        keys = ENCRYPTED_KWARGS | {"undeclared", "command"}
+        for db_name, command_class in registered_commands.items():
+            with self.subTest(db_name):
+                kwargs = {key: SENTINEL for key in keys}
+                audit_kwargs = command_class.build_audit_kwargs(kwargs)
+                self.assertEqual(set(audit_kwargs), keys, "a kwarg went missing from the audit trail")
+                for key, value in audit_kwargs.items():
+                    if key in command_class.audit_public_kwargs:
+                        continue
+                    self.assertNotIn(SENTINEL, json.dumps(value))
+
+    def test_secret_kwarg_is_redacted_and_undeclared_is_omitted(self):
+        audit_kwargs = DeviceLock.build_audit_kwargs(
+            {"Message": "lost", "PhoneNumber": "+123", "PIN": "encrypted", "surprise": "encrypted"}
+        )
+        self.assertEqual(
+            audit_kwargs,
+            {"Message": "lost",
+             "PhoneNumber": "+123",
+             "PIN": AUDIT_REDACTED,
+             "surprise": AUDIT_OMITTED}
+        )
+
+    def test_erase_device_public_kwargs(self):
+        self.assertEqual(
+            EraseDevice.build_audit_kwargs(
+                {"DisallowProximitySetup": True, "PreserveDataPlan": False, "PIN": "encrypted"}
+            ),
+            {"DisallowProximitySetup": True, "PreserveDataPlan": False, "PIN": AUDIT_REDACTED}
+        )
+
+    def test_set_firmware_password_has_no_public_kwargs(self):
+        self.assertEqual(
+            SetFirmwarePassword.build_audit_kwargs({"new_password": "encrypted"}),
+            {"new_password": AUDIT_REDACTED}
+        )
+
+    # custom command, where the payload is operator supplied
+
+    def test_custom_command_audit_kwargs_keep_shape_only(self):
+        command = plistlib.dumps({"RequestType": "Settings",
+                                 "Settings": [{"Item": "ApplicationAttributes"}],
+                                  "Password": SENTINEL}).decode("utf-8")
+        audit_kwargs = CustomCommand.build_audit_kwargs({"command": command})
+        self.assertEqual(
+            audit_kwargs,
+            {"command": {"RequestType": "Settings", "keys": ["Password", "Settings"]}}
+        )
+        self.assertNotIn(SENTINEL, json.dumps(audit_kwargs))
+
+    def test_custom_command_audit_kwargs_unparsable_payload(self):
+        self.assertEqual(
+            CustomCommand.build_audit_kwargs({"command": "not a property list"}),
+            {"command": AUDIT_OMITTED}
+        )
+
+    def test_custom_command_audit_kwargs_no_request_type(self):
+        command = plistlib.dumps({"Whatever": SENTINEL}).decode("utf-8")
+        self.assertEqual(CustomCommand.build_audit_kwargs({"command": command}), {"command": AUDIT_OMITTED})
+
+    # serialize_for_event, which is what the audit event carries
+
+    def test_serialize_for_event_redacts_the_pin(self):
+        command = DeviceLock.create_for_device(
+            self.enrolled_device, kwargs={"Message": "lost", "PIN": "encrypted-pin"}, queue=True
+        )
+        serialized = command.db_command.serialize_for_event()
+        self.assertEqual(serialized["kwargs"], {"Message": "lost", "PIN": AUDIT_REDACTED})
+        self.assertNotIn("encrypted-pin", json.dumps(serialized))
+
+    def test_serialize_for_event_without_kwargs_has_no_kwargs_key(self):
+        command = DeviceLock.create_for_device(self.enrolled_device, queue=True)
+        self.assertNotIn("kwargs", command.db_command.serialize_for_event())
+
+    def test_serialize_for_event_unknown_command_name_omits_everything(self):
+        command = DeviceLock.create_for_device(
+            self.enrolled_device, kwargs={"Message": "lost"}, queue=True
+        )
+        db_command = command.db_command
+        db_command.name = "NotARegisteredCommand"
+        db_command.save()
+        self.assertEqual(db_command.serialize_for_event()["kwargs"], {"Message": AUDIT_OMITTED})

--- a/tests/mdm/test_management_enrolled_device.py
+++ b/tests/mdm/test_management_enrolled_device.py
@@ -1,3 +1,4 @@
+import json
 import plistlib
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from zentral.contrib.mdm.models import (
     Platform,
     TargetArtifact,
 )
+from zentral.core.events.base import AuditEvent
 
 from .utils import (
     force_artifact,
@@ -593,6 +595,57 @@ class EnrolledDeviceManagementViewsTestCase(TestCase, LoginCase):
             {"RequestType": "InstalledApplicationList",
              "ManagedAppsOnly": False}
         )
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrolled_device_custom_command_audit_event(self, post_event):
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
+        enrolled_device = session.enrolled_device
+        self.login("mdm.view_enrolleddevice", "mdm.add_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:create_enrolled_device_command",
+                        args=(enrolled_device.pk, "CustomCommand")),
+                {"command": plistlib.dumps({"RequestType": "ClearPasscode",
+                                            "UnlockToken": "s3cr3t-token"}).decode("utf-8")}
+            )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(callbacks), 1)
+        db_command = enrolled_device.commands.first()
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "mdm.devicecommand")
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["name"], "CustomCommand")
+        self.assertEqual(
+            new_value["kwargs"],
+            {"command": {"RequestType": "ClearPasscode", "keys": ["UnlockToken"]}}
+        )
+        self.assertNotIn("s3cr3t-token", json.dumps(event.payload))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], enrolled_device.serial_number)
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(db_command.uuid)]})
+        self.assertEqual(sorted(metadata["tags"]), ["mdm", "zentral"])
+        request = metadata["request"]
+        self.assertEqual(request["method"], "POST")
+        self.assertEqual(request["view"], "mdm:create_enrolled_device_command")
+        self.assertEqual(request["user"]["username"], self.user.username)
+        self.assertFalse(request["user"]["session"]["token_authenticated"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrolled_device_command_invalid_form_posts_no_audit_event(self, post_event):
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
+        self.login("mdm.add_devicecommand")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:create_enrolled_device_command",
+                        args=(session.enrolled_device.pk, "CustomCommand")),
+                {"command": "YOLO"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(session.enrolled_device.commands.count(), 0)
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
 
     # create device information command
 

--- a/zentral/contrib/mdm/api_views/commands.py
+++ b/zentral/contrib/mdm/api_views/commands.py
@@ -33,6 +33,8 @@ class EnrolledDeviceCommand(RetrieveDestroyAPIView):
             raise ValidationError("This command has already been sent to the device and cannot be deleted")
         prev_value = command.serialize_for_event()
         prev_pk = command.pk
+        # resolved here rather than in the callback, which runs outside the transaction
+        serial_number = command.enrolled_device.serial_number
         command.delete()
 
         def on_commit_callback():
@@ -41,6 +43,7 @@ class EnrolledDeviceCommand(RetrieveDestroyAPIView):
                 self.request, command,
                 action=AuditEvent.Action.DELETED,
                 prev_value=prev_value,
+                machine_serial_number=serial_number,
             ).post()
 
         transaction.on_commit(on_commit_callback)

--- a/zentral/contrib/mdm/api_views/enrolled_devices.py
+++ b/zentral/contrib/mdm/api_views/enrolled_devices.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 from accounts.api_authentication import APITokenAuthentication
+from django.db import transaction
 from django.db.models import Exists, JSONField, OuterRef
 from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404
@@ -25,6 +26,7 @@ from zentral.contrib.mdm.serializers import (
     EnrolledDeviceDeviceLockPinSerializer,
     EnrolledDeviceSerializer,
 )
+from zentral.core.events.base import AuditEvent
 from zentral.utils.drf import (
     DefaultDjangoModelPermissions,
     DjangoPermissionRequired,
@@ -189,6 +191,15 @@ class CreateEnrolledDeviceCommandView(APIView):
             queue=True,
             uuid=uuid
         )
+
+        def on_commit_callback():
+            AuditEvent.build_from_request_and_instance(
+                request, command.db_command,
+                action=AuditEvent.Action.CREATED,
+                machine_serial_number=enrolled_device.serial_number,
+            ).post()
+
+        transaction.on_commit(on_commit_callback)
         serializer = DeviceCommandSerializer(command.db_command)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/zentral/contrib/mdm/commands/account_configuration.py
+++ b/zentral/contrib/mdm/commands/account_configuration.py
@@ -19,6 +19,7 @@ def get_secret_engine_kwargs(uuid):
 
 class AccountConfiguration(Command):
     request_type = "AccountConfiguration"
+    audit_secret_kwargs = ("admin_password",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/base.py
+++ b/zentral/contrib/mdm/commands/base.py
@@ -13,6 +13,10 @@ from zentral.contrib.mdm.models import Channel, Command as DBCommand, DeviceComm
 logger = logging.getLogger("zentral.contrib.mdm.commands.base")
 
 
+AUDIT_REDACTED = "<redacted>"
+AUDIT_OMITTED = "<omitted>"
+
+
 class Command:
     request_type = None
     db_name = None
@@ -22,6 +26,26 @@ class Command:
     reschedule_notnow = False
     form_class = None
     serializer_class = None
+
+    # Audit trail. A kwarg is only serialized if it is declared in audit_public_kwargs,
+    # so a command class that forgets to declare anything is silent instead of leaky —
+    # adding a new secret kwarg cannot leak it by omission. Keys in audit_secret_kwargs
+    # are reported as redacted, which tells an auditor the value was there without
+    # disclosing it; anything undeclared is reported as omitted.
+    audit_public_kwargs = ()
+    audit_secret_kwargs = ()
+
+    @classmethod
+    def build_audit_kwargs(cls, kwargs):
+        audit_kwargs = {}
+        for key, value in kwargs.items():
+            if key in cls.audit_public_kwargs:
+                audit_kwargs[key] = value
+            elif key in cls.audit_secret_kwargs:
+                audit_kwargs[key] = AUDIT_REDACTED
+            else:
+                audit_kwargs[key] = AUDIT_OMITTED
+        return audit_kwargs
 
     @classmethod
     def get_db_name(cls):

--- a/zentral/contrib/mdm/commands/certificate_list.py
+++ b/zentral/contrib/mdm/commands/certificate_list.py
@@ -13,6 +13,7 @@ class CertificateList(Command):
     request_type = "CertificateList"
     reschedule_notnow = True
     store_result = True
+    audit_public_kwargs = ("managed_only", "update_inventory")
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/custom.py
+++ b/zentral/contrib/mdm/commands/custom.py
@@ -3,7 +3,7 @@ import plistlib
 from django import forms
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
-from .base import register_command, Command, CommandBaseForm, CommandBaseSerializer
+from .base import AUDIT_OMITTED, register_command, Command, CommandBaseForm, CommandBaseSerializer
 
 
 logger = logging.getLogger("zentral.contrib.mdm.commands.custom")
@@ -67,6 +67,24 @@ class CustomCommand(Command):
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):
         return True
+
+    @classmethod
+    def build_audit_kwargs(cls, kwargs):
+        # The payload is a property list typed by an operator and can hold anything,
+        # a password included, so only its shape is auditable: the request type and
+        # the names of the other top level keys, never their values.
+        audit_kwargs = super().build_audit_kwargs({k: v for k, v in kwargs.items() if k != "command"})
+        command = kwargs.get("command")
+        if command is None:
+            return audit_kwargs
+        try:
+            loaded_command = plistlib.loads(command.encode("utf-8"))
+            request_type = loaded_command.pop("RequestType")
+        except Exception:
+            audit_kwargs["command"] = AUDIT_OMITTED
+        else:
+            audit_kwargs["command"] = {"RequestType": request_type, "keys": sorted(loaded_command)}
+        return audit_kwargs
 
     def load_kwargs(self):
         self.command = plistlib.loads(self.db_command.kwargs["command"].encode("utf-8"))

--- a/zentral/contrib/mdm/commands/declarative_management.py
+++ b/zentral/contrib/mdm/commands/declarative_management.py
@@ -9,6 +9,7 @@ logger = logging.getLogger("zentral.contrib.mdm.commands.declarative_management"
 
 class DeclarativeManagement(Command):
     request_type = "DeclarativeManagement"
+    audit_public_kwargs = ("blueprint_pk",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/device_lock.py
+++ b/zentral/contrib/mdm/commands/device_lock.py
@@ -87,6 +87,8 @@ class DeviceLock(Command):
     reschedule_notnow = True
     form_class = DeviceLockForm
     serializer_class = DeviceLockSerializer
+    audit_public_kwargs = ("Message", "PhoneNumber")
+    audit_secret_kwargs = ("PIN",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/erase_device.py
+++ b/zentral/contrib/mdm/commands/erase_device.py
@@ -85,6 +85,8 @@ class EraseDevice(Command):
     reschedule_notnow = True
     form_class = EraseDeviceForm
     serializer_class = EraseDeviceSerializer
+    audit_public_kwargs = ("DisallowProximitySetup", "PreserveDataPlan")
+    audit_secret_kwargs = ("PIN",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/installed_application_list.py
+++ b/zentral/contrib/mdm/commands/installed_application_list.py
@@ -11,6 +11,7 @@ class InstalledApplicationList(Command):
     request_type = "InstalledApplicationList"
     reschedule_notnow = True
     store_result = True
+    audit_public_kwargs = ("managed_only", "retries", "update_inventory", "apps_to_check")
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/managed_application_list.py
+++ b/zentral/contrib/mdm/commands/managed_application_list.py
@@ -9,6 +9,7 @@ logger = logging.getLogger("zentral.contrib.mdm.commands.managed_application_lis
 class ManagedApplicationList(Command):
     request_type = "ManagedApplicationList"
     reschedule_notnow = True
+    audit_public_kwargs = ("identifiers", "retries")
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/profile_list.py
+++ b/zentral/contrib/mdm/commands/profile_list.py
@@ -13,6 +13,7 @@ class ProfileList(Command):
     request_type = "ProfileList"
     reschedule_notnow = True
     store_result = True
+    audit_public_kwargs = ("managed_only", "update_inventory")
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/reenroll.py
+++ b/zentral/contrib/mdm/commands/reenroll.py
@@ -10,6 +10,7 @@ logger = logging.getLogger("zentral.contrib.mdm.commands.reenroll")
 class Reenroll(Command):
     request_type = "InstallProfile"
     db_name = "Reenroll"
+    audit_public_kwargs = ("session_id",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/restart_device.py
+++ b/zentral/contrib/mdm/commands/restart_device.py
@@ -29,6 +29,7 @@ class RestartDevice(Command):
     request_type = "RestartDevice"
     display_name = "Restart device"
     form_class = RestartDeviceForm
+    audit_public_kwargs = ("NotifyUser",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/rotate_filevault_key.py
+++ b/zentral/contrib/mdm/commands/rotate_filevault_key.py
@@ -52,6 +52,7 @@ class RotateFileVaultKey(Command):
     request_type = "RotateFileVaultKey"
     display_name = "Rotate FileVault key"
     form_class = RotateFileVaultKeyForm
+    audit_secret_kwargs = ("encryption_key",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/set_auto_admin_password.py
+++ b/zentral/contrib/mdm/commands/set_auto_admin_password.py
@@ -61,6 +61,7 @@ class SetAutoAdminPassword(Command):
     display_name = "Set auto admin password"
     reschedule_notnow = True
     form_class = SetAutoAdminPasswordForm
+    audit_secret_kwargs = ("new_password",)
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/commands/set_firmware_password.py
+++ b/zentral/contrib/mdm/commands/set_firmware_password.py
@@ -36,6 +36,7 @@ class SetFirmwarePassword(Command):
     display_name = "Set firmware password"
     reschedule_notnow = True
     form_class = SetFirmwarePasswordForm
+    audit_secret_kwargs = ("new_password",)
 
     @classmethod
     def create_for_automatic_scheduling(cls, target, password=None):

--- a/zentral/contrib/mdm/commands/set_recovery_lock.py
+++ b/zentral/contrib/mdm/commands/set_recovery_lock.py
@@ -58,6 +58,7 @@ class SetRecoveryLock(Command):
     display_name = "Set recovery lock"
     reschedule_notnow = True
     form_class = SetRecoveryLockForm
+    audit_secret_kwargs = ("new_password",)
 
     @classmethod
     def create_for_automatic_scheduling(cls, target, password=None):

--- a/zentral/contrib/mdm/commands/setup_filevault.py
+++ b/zentral/contrib/mdm/commands/setup_filevault.py
@@ -112,6 +112,7 @@ class SetupFileVault(Command):
     request_type = "InstallProfile"
     db_name = "SetupFileVault"
     reschedule_notnow = True
+    audit_public_kwargs = ("filevault_config_pk", "filevault_config_uuid")
 
     @staticmethod
     def verify_channel_and_device(channel, enrolled_device):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3353,6 +3353,16 @@ class Command(models.Model):
     def __str__(self):
         return " - ".join(s for s in (self.name, str(self.uuid), self.status) if s)
 
+    def build_audit_kwargs(self):
+        # Imported here because zentral.contrib.mdm.commands imports this module. Importing
+        # the submodule runs the package __init__, which is what registers every command.
+        from zentral.contrib.mdm.commands.base import AUDIT_OMITTED, registered_commands
+        command_class = registered_commands.get(self.name)
+        if command_class is None:
+            # Unknown command class, so nothing is declared as safe to serialize.
+            return {key: AUDIT_OMITTED for key in self.kwargs}
+        return command_class.build_audit_kwargs(self.kwargs)
+
     def serialize_for_event(self, keys_only=False):
         d = {"pk": self.pk, "uuid": str(self.uuid), "name": self.name}
         if keys_only:
@@ -3361,6 +3371,8 @@ class Command(models.Model):
             d["artifact_version"] = self.artifact_version.serialize_for_event()
         if self.artifact_operation:
             d["artifact_operation"] = self.artifact_operation
+        if self.kwargs:
+            d["kwargs"] = self.build_audit_kwargs()
         for attr in ("not_before", "time", "result_time"):
             value = getattr(self, attr)
             if value:

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -56,6 +56,7 @@ from zentral.contrib.mdm.payloads import (build_configuration_profile_response,
                                           build_profile_service_configuration_profile)
 from zentral.contrib.mdm.software_updates import best_available_software_updates
 from zentral.contrib.mdm.tasks import bulk_assign_location_asset_task
+from zentral.core.events.base import AuditEvent
 from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
 from zentral.utils.storage import file_storage_has_signed_urls, select_dist_storage
 
@@ -1529,12 +1530,21 @@ class CreateEnrolledDeviceCommandView(PermissionRequiredMixin, FormView):
 
     def form_valid(self, form):
         uuid = uuid4()
-        self.command_class.create_for_device(
+        command = self.command_class.create_for_device(
             self.enrolled_device,
             kwargs=form.get_command_kwargs(uuid),
             queue=True,
             uuid=uuid,
         )
+
+        def on_commit_callback():
+            AuditEvent.build_from_request_and_instance(
+                self.request, command.db_command,
+                action=AuditEvent.Action.CREATED,
+                machine_serial_number=self.enrolled_device.serial_number,
+            ).post()
+
+        transaction.on_commit(on_commit_callback)
         messages.info(self.request, f"{self.command_class.get_display_name()} command successfully created")
         return redirect(self.enrolled_device)
 

--- a/zentral/core/events/base.py
+++ b/zentral/core/events/base.py
@@ -560,7 +560,7 @@ class AuditEvent(BaseEvent):
         cls,
         instance, action, prev_value=None,
         event_uuid=None, event_index=None,
-        event_request=None
+        event_request=None, machine_serial_number=None
     ):
         em_kwargs = {"tags": [instance._meta.app_label]}
         if event_uuid is not None:
@@ -569,6 +569,8 @@ class AuditEvent(BaseEvent):
             em_kwargs["index"] = event_index
         if event_request:
             em_kwargs["request"] = event_request
+        if machine_serial_number:
+            em_kwargs["machine_serial_number"] = machine_serial_number
         metadata = EventMetadata(**em_kwargs)
         try:
             metadata.add_objects(instance.linked_objects_keys_for_event())
@@ -592,10 +594,12 @@ class AuditEvent(BaseEvent):
         return cls(metadata, payload)
 
     @classmethod
-    def build_from_request_and_instance(cls, request, instance, action, prev_value=None):
+    def build_from_request_and_instance(cls, request, instance, action, prev_value=None,
+                                        machine_serial_number=None):
         event_request = EventRequest.build_from_request(request)
         return cls.build(
-            instance, action, prev_value, event_request=event_request
+            instance, action, prev_value, event_request=event_request,
+            machine_serial_number=machine_serial_number
         )
 
 


### PR DESCRIPTION
## Why

Creating an MDM command left no trace. Deleting a queued one was already audited, so the trail recorded the destruction of commands but not their creation — an operator could erase a device, lock it, or push an arbitrary custom command, and nothing recorded who did it.

Two entry points create commands on an operator's behalf:

| | View | Covers |
|---|---|---|
| UI | `CreateEnrolledDeviceCommandView` (`views/management.py`) | all 11 registered manual commands |
| API | `CreateEnrolledDeviceCommandView` (`api_views/enrolled_devices.py`) | `erase/`, `lock/`, `send_custom_command/` |

## What changed

**Both paths now post a `zentral_audit` event with the `CREATED` action**, following the `CreateViewWithAudit` / `ListCreateAPIViewWithAudit` convention — built with `AuditEvent.build_from_request_and_instance` and posted in `transaction.on_commit`, so a rolled-back creation emits nothing. The audit sits in the shared base class of each entry point, so the three API subclasses and any future one are covered by construction.

**`AuditEvent.build` takes an optional `machine_serial_number`.** It previously only passed tags/uuid/index/request, so an audit event for a `DeviceCommand` never reached the machine's event timeline. Additive with a default; other contrib modules can use it.

**Command parameters are now serialized through an allowlist.** They're where the audit value is and also where the secrets are, so `Command.serialize_for_event()` reports them via two new declarations on the command classes:

```python
audit_public_kwargs = ()   # serialized verbatim
audit_secret_kwargs = ()   # "<redacted>"
                           # anything undeclared -> "<omitted>"
```

A class that declares nothing is silent rather than leaky, so a new secret kwarg can't leak by being forgotten. `<redacted>` tells an auditor a value was supplied without disclosing it. Both sentinels are plain strings, so a field never changes type between events and the event stores' dynamic mappings stay stable.

Declared across 15 classes from the kwargs each actually writes. Secrets: `PIN` (DeviceLock, EraseDevice), `new_password` (SetFirmwarePassword, SetRecoveryLock, SetAutoAdminPassword), `admin_password` (AccountConfiguration), `encryption_key` (RotateFileVaultKey — an encrypted RSA private key).

**`CustomCommand` overrides the builder.** Its payload is a property list typed by an operator and can hold anything, so only the shape is audited — `RequestType` plus the names of the other top level keys, never a value. An unparsable payload degrades to `<omitted>`.

```json
{"action": "created",
 "object": {"model": "mdm.devicecommand",
            "new_value": {"name": "DeviceLock",
                          "kwargs": {"Message": "Lost laptop", "PIN": "<redacted>"}}}}
```

## Notes for review

**Why redaction and not a digest.** Device lock PINs are six digits (`pin_regex = r"[0-9]{6}"`), so an unkeyed digest sitting in an event store is reversible by exhaustive search — equivalent to logging the PIN. Hashing the ciphertext instead would correlate nothing, since the secret engine's output isn't deterministic. Keyed HMAC fingerprints can be added later behind the same declarations if cross-fleet correlation ("same firmware password on 500 devices?") becomes worth the key management.

**Engine-created commands are deliberately out of scope.** The ~22 creation sites in `commands/scheduling.py` and in command response processing run while a device checks in, with no operator to attribute them to. Auditing the per-check-in inventory refreshes would also dwarf the operator events on a large fleet. `request.view` distinguishes the two audited paths (`mdm:create_enrolled_device_command` vs `mdm_api:lock_enrolled_device`), so no separate provenance field was needed.

**Existing payload assertions are unchanged.** Parameterless commands get no `kwargs` entry, following the surrounding convention of omitting falsy values.

**The registry import in `models.py` is lazy** because `commands` imports `models`. Importing the submodule runs the package `__init__`, which is what registers every command; an unknown command name fails closed to all-omitted.

## Tests

2980 tests pass across `tests.mdm`, `tests.core_events`, `tests.core_stores` and `tests.core_probes`. flake8 clean.

New `tests/mdm/test_command_audit.py` (13 tests). The structural ones:

- `test_no_encrypted_kwarg_is_missing_from_this_list` scans the command modules for the `field="..."` names in their `get_secret_engine_kwargs` helpers and fails if a new encrypted field appears unclassified — the guard that should prevent the next leak.
- `test_undeclared_and_secret_kwargs_are_never_serialized` feeds every registered class a kwargs dict of sentinels and asserts the sentinel only survives under an explicitly public key.
- Plus no-double-declaration and no-encrypted-kwarg-is-public across the whole registry.

Four view-level tests assert the real events: the PIN and a custom-command `UnlockToken` never appear anywhere in the payload, request metadata carries IP / method / path / view / user / token-auth, and an invalid form posts no event at all.

## Not verified

`mkdocs build --strict` could not be run — mkdocs isn't in the container image and `pip install` fails there on venv permissions. The new docs section was checked by hand instead: no links or images (so strict mode's broken-anchor and missing-file classes don't apply), balanced fences, consistent heading levels, and the JSON example parses. Worth one real run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
