### PR TITLE
Audit the artifact and blueprint artifact changes made from the web interface

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -506,7 +506,7 @@ A Recovery Password Configuration can only be deleted if it is not linked to any
 
 ## Audit trail
 
-Operator actions on a device are recorded as `zentral_audit` events. Each one carries the full request context — the authenticated user (including whether an API token was used, and which one), the source IP, the user agent, the HTTP method, the path and the resolved view name — and is tagged with the device serial number, so it also appears in the device's event timeline.
+Operator actions are recorded as `zentral_audit` events. Each one carries the full request context — the authenticated user (including whether an API token was used, and which one), the source IP, the user agent, the HTTP method, the path and the resolved view name. Actions that target a single device are also tagged with its serial number, so they appear in that device's event timeline.
 
 Actions Zentral takes on its own — the inventory refreshes, artifact installations and other work scheduled while a device checks in — are not part of this audit trail. It records operator actions.
 
@@ -564,6 +564,16 @@ Blocking and unblocking a device are recorded with the `updated` action, from th
 A request that would not change anything — blocking a blocked device, or unblocking one that is not blocked — is rejected and records nothing.
 
 Note that a device can also become unblocked without an operator: a full state purge, which happens when a device re-enrolls, clears `blocked_at` along with the rest of the device state. That is not an operator action and is not audited here, so a device that appears blocked in the audit trail may since have been released by re-enrolling.
+
+### Artifacts and blueprints
+
+Artifacts decide which profiles, apps and declarations get installed, and linking one to a blueprint deploys it to every device using that blueprint. Both are audited with the `created`, `updated` and `deleted` actions, from the web interface as well as from the HTTP API:
+
+- creating, updating and deleting an **artifact**, whichever form was used — declaration, certificate asset, data asset, enterprise app, profile, provisioning profile or an app from the Apps and Books catalog
+- creating a new **artifact version**, through the upgrade forms, and updating or deleting an existing one
+- linking an artifact to a **blueprint**, changing how it is scoped there, and unlinking it
+
+Blueprints themselves, along with the FileVault, recovery password and software update enforcement configurations, are audited the same way.
 
 ## HTTP API
 

--- a/tests/mdm/test_management_artifact_audit.py
+++ b/tests/mdm/test_management_artifact_audit.py
@@ -1,0 +1,227 @@
+import json
+import plistlib
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+from accounts.models import User
+from tests.zentral_test_utils.login_case import LoginCase
+from zentral.contrib.mdm.models import Artifact, Channel, Platform
+from zentral.core.events.base import AuditEvent
+
+from .utils import force_artifact, force_blueprint, force_blueprint_artifact, force_location_asset
+
+
+class ArtifactAuditEventTestCase(TestCase, LoginCase):
+    """The artifact views deploy profiles and apps to every device in a blueprint, so each
+    one has to leave an audit trail. The behaviour of the views themselves is covered by
+    the per view test cases; this only checks that the event is emitted."""
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        cls.group = Group.objects.create(name=get_random_string(12))
+        cls.user.groups.set([cls.group])
+
+    # LoginCase implementation
+
+    def _get_user(self):
+        return self.user
+
+    def _get_group(self):
+        return self.group
+
+    def _get_url_namespace(self):
+        return "mdm"
+
+    def assert_audit_event(self, post_event, callbacks, action, model, pk):
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], action)
+        self.assertEqual(event.payload["object"]["model"], model)
+        self.assertEqual(event.payload["object"]["pk"], str(pk))
+        return event
+
+    # artifacts
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_artifact_audit_event(self, post_event):
+        # BaseCreateArtifactView, so every artifact creation form is covered
+        data_asset_artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.login("mdm.add_artifact", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:create_configuration"),
+                                        {"source": json.dumps({
+                                            "Identifier": get_random_string(12),
+                                            "Type": "com.apple.configuration.services.configuration-files",
+                                            "Payload": {
+                                                "ServiceType": "com.apple.sudo",
+                                                "DataAssetReference": f"ztl:{data_asset_artifact.pk}"
+                                            },
+                                         }),
+                                         "name": get_random_string(12),
+                                         "channel": str(Channel.DEVICE),
+                                         "platforms": [str(Platform.MACOS)]},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        artifact = response.context["object"]
+        self.assert_audit_event(post_event, callbacks, "created", "mdm.artifact", artifact.pk)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_artifact_audit_event(self, post_event):
+        artifact, _ = force_artifact()
+        prev_name = artifact.name
+        new_name = get_random_string(12)
+        self.login("mdm.change_artifact", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:update_artifact", args=(artifact.pk,)),
+                                        {"name": new_name,
+                                         "platforms": [Platform.MACOS.value],
+                                         "reinstall_interval": 0,
+                                         "reinstall_on_os_update": Artifact.ReinstallOnOSUpdate.NO.value},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.assert_audit_event(post_event, callbacks, "updated", "mdm.artifact", artifact.pk)
+        self.assertEqual(event.payload["object"]["prev_value"]["name"], prev_name)
+        self.assertEqual(event.payload["object"]["new_value"]["name"], new_name)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_artifact_audit_event(self, post_event):
+        artifact, _ = force_artifact()
+        self.login("mdm.delete_artifact", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:delete_artifact", args=(artifact.pk,)), follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.assert_audit_event(post_event, callbacks, "deleted", "mdm.artifact", artifact.pk)
+        self.assertEqual(event.payload["object"]["prev_value"]["name"], artifact.name)
+
+    # blueprint artifacts
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_blueprint_artifact_audit_event(self, post_event):
+        artifact, _ = force_artifact()
+        blueprint = force_blueprint()
+        self.login("mdm.add_blueprintartifact", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:create_blueprint_artifact", args=(artifact.pk,)),
+                                        {"blueprint": blueprint.pk,
+                                         "shard_modulo": 10,
+                                         "default_shard": 5,
+                                         "macos": "on"},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        blueprint_artifact = blueprint.blueprintartifact_set.get(artifact=artifact)
+        self.assert_audit_event(post_event, callbacks, "created",
+                                "mdm.blueprintartifact", blueprint_artifact.pk)
+        # the audit event must not get in the way of the blueprint refresh
+        blueprint.refresh_from_db()
+        self.assertEqual(set(blueprint.serialized_artifacts), {str(artifact.pk)})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_blueprint_artifact_audit_event(self, post_event):
+        blueprint_artifact, artifact, _ = force_blueprint_artifact()
+        self.login("mdm.change_blueprintartifact", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:update_blueprint_artifact", args=(artifact.pk, blueprint_artifact.pk)),
+                {"blueprint": blueprint_artifact.blueprint.pk,
+                 "shard_modulo": 20,
+                 "default_shard": 4,
+                 "macos": "on"},
+                follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.assert_audit_event(post_event, callbacks, "updated",
+                                        "mdm.blueprintartifact", blueprint_artifact.pk)
+        self.assertEqual(event.payload["object"]["new_value"]["shard_modulo"], 20)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_blueprint_artifact_audit_event(self, post_event):
+        blueprint_artifact, artifact, _ = force_blueprint_artifact()
+        blueprint = blueprint_artifact.blueprint
+        self.login("mdm.delete_blueprintartifact", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:delete_blueprint_artifact", args=(artifact.pk, blueprint_artifact.pk)),
+                follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assert_audit_event(post_event, callbacks, "deleted",
+                                "mdm.blueprintartifact", blueprint_artifact.pk)
+        # the event is built before the delete, and the blueprint refresh still runs after it
+        blueprint.refresh_from_db()
+        self.assertEqual(blueprint.serialized_artifacts, {})
+
+    # artifact versions
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_artifact_version_audit_event(self, post_event):
+        artifact, (artifact_version,) = force_artifact()
+        self.login("mdm.change_artifactversion", "mdm.view_artifactversion")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:update_artifact_version", args=(artifact.pk, artifact_version.pk)),
+                {"default_shard": 8, "shard_modulo": 88, "macos": "on"},
+                follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.assert_audit_event(post_event, callbacks, "updated",
+                                        "mdm.artifactversion", artifact_version.pk)
+        self.assertEqual(event.payload["object"]["new_value"]["shard_modulo"], 88)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_artifact_version_audit_event(self, post_event):
+        artifact, (artifact_version, artifact_version2) = force_artifact(version_count=2)
+        self.login("mdm.delete_artifactversion", "mdm.view_artifact")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:delete_artifact_version", args=(artifact.pk, artifact_version2.pk)),
+                follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assert_audit_event(post_event, callbacks, "deleted",
+                                "mdm.artifactversion", artifact_version2.pk)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_upgrade_artifact_version_audit_event(self, post_event):
+        # BaseUpgradeArtifactVersionView, so every upgrade form is covered
+        bpa, artifact, (artifact_version,) = force_blueprint_artifact(artifact_type=Artifact.Type.CONFIGURATION)
+        declaration = artifact_version.declaration
+        self.login("mdm.add_artifactversion", "mdm.view_artifactversion")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:upgrade_declaration", args=(artifact.pk,)),
+                                        {"source": json.dumps({
+                                            "Identifier": declaration.identifier,
+                                            "Type": declaration.type,
+                                            "Payload": {"Restrictions": {"ExternalStorage": "Disallowed"}}}),
+                                         "default_shard": 9,
+                                         "shard_modulo": 99,
+                                         "macos": "on"},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        new_artifact_version = response.context["object"]
+        self.assertEqual(new_artifact_version.version, 2)
+        self.assert_audit_event(post_event, callbacks, "created",
+                                "mdm.artifactversion", new_artifact_version.pk)
+
+    # store app artifact, created from an asset
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_asset_artifact_audit_event(self, post_event):
+        location_asset = force_location_asset()
+        self.login("mdm.view_asset", "mdm.add_artifact", "mdm.view_artifact")
+        name = get_random_string(12)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:create_asset_artifact", args=(location_asset.asset.pk,)),
+                {"name": name,
+                 "location_asset": location_asset.pk,
+                 "configuration": plistlib.dumps({"yolo": "fomo"}).decode("utf-8"),
+                 "remove_on_unenroll": "on",
+                 "prevent_backup": "on"},
+                follow=True)
+        self.assertEqual(response.status_code, 200)
+        artifact = Artifact.objects.get(name=name)
+        self.assert_audit_event(post_event, callbacks, "created", "mdm.artifact", artifact.pk)

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -473,6 +473,14 @@ class BaseCreateArtifactView(PermissionRequiredMixin, FormView):
 
     def form_valid(self, form):
         self.artifact = form.save()
+
+        def on_commit_callback():
+            AuditEvent.build_from_request_and_instance(
+                self.request, self.artifact,
+                action=AuditEvent.Action.CREATED,
+            ).post()
+
+        transaction.on_commit(on_commit_callback)
         messages.info(self.request, "Artifact created")
         return redirect(self.artifact)
 
@@ -603,13 +611,13 @@ class ArtifactView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateArtifactView(PermissionRequiredMixin, UpdateView):
+class UpdateArtifactView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_artifact"
     model = Artifact
     form_class = UpdateArtifactForm
 
 
-class DeleteArtifactView(PermissionRequiredMixin, DeleteView):
+class DeleteArtifactView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "mdm.delete_artifact"
     model = Artifact
     success_url = reverse_lazy("mdm:artifacts")
@@ -621,7 +629,7 @@ class DeleteArtifactView(PermissionRequiredMixin, DeleteView):
 # Blueprint artifacts
 
 
-class CreateBlueprintArtifactView(PermissionRequiredMixin, CreateView):
+class CreateBlueprintArtifactView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "mdm.add_blueprintartifact"
     model = BlueprintArtifact
     form_class = BlueprintArtifactForm
@@ -651,7 +659,7 @@ class CreateBlueprintArtifactView(PermissionRequiredMixin, CreateView):
         return response
 
 
-class UpdateBlueprintArtifactView(PermissionRequiredMixin, UpdateView):
+class UpdateBlueprintArtifactView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_blueprintartifact"
     model = BlueprintArtifact
     form_class = BlueprintArtifactForm
@@ -674,7 +682,7 @@ class UpdateBlueprintArtifactView(PermissionRequiredMixin, UpdateView):
         return ctx
 
 
-class DeleteBlueprintArtifactView(PermissionRequiredMixin, DeleteView):
+class DeleteBlueprintArtifactView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "mdm.delete_blueprintartifact"
     model = BlueprintArtifact
 
@@ -734,7 +742,7 @@ class ArtifactVersionView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateArtifactVersionView(PermissionRequiredMixin, UpdateView):
+class UpdateArtifactVersionView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_artifactversion"
     model = ArtifactVersion
     form_class = ArtifactVersionForm
@@ -807,6 +815,14 @@ class BaseUpgradeArtifactVersionView(PermissionRequiredMixin, TemplateView):
         object_form.save(artifact_version=artifact_version)
         for blueprint in self.artifact.blueprints():
             update_blueprint_serialized_artifacts(blueprint)
+
+        def on_commit_callback():
+            AuditEvent.build_from_request_and_instance(
+                self.request, artifact_version,
+                action=AuditEvent.Action.CREATED,
+            ).post()
+
+        transaction.on_commit(on_commit_callback)
         return HttpResponseRedirect(artifact_version.get_absolute_url())
 
     def forms_invalid(self, object_form, version_form):
@@ -878,7 +894,7 @@ class UpgradeStoreAppView(BaseUpgradeArtifactVersionView):
     model_display = "Store app"
 
 
-class DeleteArtifactVersionView(PermissionRequiredMixin, DeleteView):
+class DeleteArtifactVersionView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "mdm.delete_artifactversion"
     model = ArtifactVersion
 
@@ -1042,8 +1058,17 @@ class CreateAssetArtifactView(PermissionRequiredMixin, FormView):
 
     def form_valid(self, form):
         store_app = form.save()
+        artifact = store_app.artifact_version.artifact
+
+        def on_commit_callback():
+            AuditEvent.build_from_request_and_instance(
+                self.request, artifact,
+                action=AuditEvent.Action.CREATED,
+            ).post()
+
+        transaction.on_commit(on_commit_callback)
         messages.info(self.request, "Artifact created")
-        return redirect(store_app.artifact_version.artifact)
+        return redirect(artifact)
 
 
 # Blueprints


### PR DESCRIPTION
## Why

Artifacts decide which profiles, apps and declarations get installed, and linking one to a blueprint deploys it to every device using that blueprint. None of that was audited from the web interface.

What makes this drift rather than a decision is the coverage pattern:

- the **HTTP API** audits all of it, via `ListCreateAPIViewWithAudit` / `RetrieveUpdateDestroyAPIViewWithAudit` in `api_views/artifacts.py` and `blueprints.py`
- in the **same web interface module**, 12 views already audit — blueprint, FileVault config, recovery password config and software update enforcement CRUD
- the artifact views, sitting between them, did not

## What changed

**Seven views only needed their base swapped** for the audit variant — `UpdateArtifactView`, `DeleteArtifactView`, `CreateBlueprintArtifactView`, `UpdateBlueprintArtifactView`, `DeleteBlueprintArtifactView`, `UpdateArtifactVersionView`, `DeleteArtifactVersionView`.

**Three build the event themselves**, being `FormView`/`TemplateView` based rather than model views. Two are base classes, so every concrete form is covered by construction:

| View | Covers |
|---|---|
| `BaseCreateArtifactView` | declaration, cert asset, data asset, enterprise app, profile, provisioning profile creation |
| `BaseUpgradeArtifactVersionView` | all seven upgrade forms |
| `CreateAssetArtifactView` | an app created from the Apps and Books catalog |

## Notes for review

**The blueprint refresh still runs after the event is built.** Four of these views reserialize the blueprint after saving, and the delete views do it *after* the row is gone — `DeleteViewWithAudit` builds the event from `self.object` before deleting, then the override reserializes from the in-memory instance. Two tests assert the refresh still happens, so the audit can't silently break deployment.

**`AssociateLocationAssetView` is deliberately excluded.** It launches a Celery task and mutates nothing during the request, so an `updated` event would carry an identical `prev_value` and `new_value` — the same empty-event shape that `blocked_at` had to be added to `serialize_for_event()` to avoid in #1558.

**Two views were invisible to a first pass.** `UpdateArtifactView`, `DeleteArtifactView` and `UpdateBlueprintArtifactView` define no methods at all — they inherit everything from the generic base — so a scan looking for mutating methods misses them. Worth knowing if anyone audits the remaining gaps the same way.

**Still unaudited, deliberately out of scope**: the enrollment views (OTA, user, DEP), the push certificate and DEP token views in `views/setup.py`, `ChangeEnrolledDeviceBlueprintView`, `AssignDEPDeviceProfileView`, and the realm group tag mapping views — whose model has no `serialize_for_event()` yet, so it needs that first.

## Tests

2595 tests pass across `tests.mdm` and `tests.core_events`. flake8 clean.

New `tests/mdm/test_management_artifact_audit.py`, 10 tests — one per audited path, asserting a single event with the right action, model and pk, plus the prev/new transition where it is meaningful. The existing per-view test cases already cover the behaviour of these views in detail, so these only check the event; extending ten long existing tests would have destabilised them for no extra signal.

## Not verified

`mkdocs build --strict` could not be run — mkdocs is not in the container image and `pip install` fails there on venv permissions. Checked by hand: balanced fences, consistent heading nesting, both JSON examples parse, no links or images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
