### PR TITLE
Audit the enrollment changes made from the web interface

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -575,6 +575,26 @@ Artifacts decide which profiles, apps and declarations get installed, and linkin
 
 Blueprints themselves, along with the FileVault, recovery password and software update enforcement configurations, are audited the same way.
 
+### Enrollments
+
+An enrollment is the path onto the MDM, so creating one, changing it and revoking it are all audited, for the Automated Device Enrollment, OTA and user enrollment types alike, from the web interface as well as the HTTP API. A revocation is reported with the `updated` action, and shows up as the `is_revoked` and `revoked_at` fields of the enrollment secret changing:
+
+```json
+{
+  "action": "updated",
+  "object": {
+    "model": "mdm.otaenrollment",
+    "prev_value": {"name": "…", "enrollment_secret": {"is_revoked": false}},
+    "new_value": {"name": "…", "enrollment_secret": {"is_revoked": true,
+                                                     "revoked_at": "2026-08-01T09:15:22"}}
+  }
+}
+```
+
+The enrollment secret itself is never included — only its metadata, such as its quota, request count, expiry, revocation and the business unit, tags and serial numbers it is restricted to. Revoking an already revoked enrollment changes nothing and records nothing.
+
+For Automated Device Enrollment, the enrollment only exists once Apple has accepted the profile, so a failed call to Apple records nothing either.
+
 ## HTTP API
 
 ### `/api/mdm/dep/devices/`

--- a/tests/mdm/test_enrollment_audit.py
+++ b/tests/mdm/test_enrollment_audit.py
@@ -1,0 +1,255 @@
+import json
+import uuid
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import Group
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+from accounts.models import User
+from tests.zentral_test_utils.login_case import LoginCase
+from zentral.contrib.inventory.models import MetaBusinessUnit
+from zentral.contrib.mdm.dep_client import DEPClientError
+from zentral.core.events.base import AuditEvent
+
+from .utils import (force_acme_issuer, force_ota_enrollment, force_push_certificate,
+                    force_dep_virtual_server, force_realm, force_scep_issuer,
+                    force_user_enrollment)
+
+
+class EnrollmentAuditEventTestCase(TestCase, LoginCase):
+    """An enrollment is the path onto the MDM, so creating, updating or revoking one has to
+    leave a trail. The behaviour of the views is covered by the per view test cases; this
+    only checks the events, and that the enrollment secret never reaches them."""
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        cls.group = Group.objects.create(name=get_random_string(12))
+        cls.user.groups.set([cls.group])
+        cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+        cls.mbu.create_enrollment_business_unit()
+
+    # LoginCase implementation
+
+    def _get_user(self):
+        return self.user
+
+    def _get_group(self):
+        return self.group
+
+    def _get_url_namespace(self):
+        return "mdm"
+
+    def assert_audit_event(self, post_event, action, model, pk, index=0):
+        event = post_event.call_args_list[index].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], action)
+        self.assertEqual(event.payload["object"]["model"], model)
+        self.assertEqual(event.payload["object"]["pk"], str(pk))
+        return event
+
+    def assert_no_secret(self, event, enrollment):
+        # EnrollmentSecret.serialize_for_event() leaves the secret out; the enrollment is the
+        # way onto the MDM, so a regression there would put a live credential in every store
+        self.assertNotIn(enrollment.enrollment_secret.secret, json.dumps(event.payload))
+
+    # OTA enrollments
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_ota_enrollment_audit_event(self, post_event):
+        self.login("mdm.add_otaenrollment", "mdm.view_otaenrollment")
+        name = get_random_string(12)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:create_ota_enrollment"),
+                                        {"oe-name": name,
+                                         "oe-display_name": get_random_string(12),
+                                         "oe-acme_issuer": force_acme_issuer().pk,
+                                         "oe-scep_issuer": force_scep_issuer().pk,
+                                         "oe-push_certificate": force_push_certificate().pk,
+                                         "es-meta_business_unit": self.mbu.pk},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        enrollment = response.context["object"]
+        event = self.assert_audit_event(post_event, "created", "mdm.otaenrollment", enrollment.pk)
+        self.assertEqual(event.payload["object"]["new_value"]["name"], name)
+        self.assert_no_secret(event, enrollment)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_ota_enrollment_audit_event(self, post_event):
+        enrollment = force_ota_enrollment(self.mbu)
+        prev_name = enrollment.name
+        new_name = get_random_string(12)
+        self.login("mdm.change_otaenrollment", "mdm.view_otaenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:update_ota_enrollment", args=(enrollment.pk,)),
+                                        {"oe-name": new_name,
+                                         "oe-display_name": get_random_string(12),
+                                         "oe-scep_issuer": enrollment.scep_issuer.pk,
+                                         "oe-push_certificate": enrollment.push_certificate.pk,
+                                         "es-meta_business_unit": self.mbu.pk},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = self.assert_audit_event(post_event, "updated", "mdm.otaenrollment", enrollment.pk)
+        # the prev_value has to be serialized before the forms validate, or it would already
+        # carry the posted name
+        self.assertEqual(event.payload["object"]["prev_value"]["name"], prev_name)
+        self.assertEqual(event.payload["object"]["new_value"]["name"], new_name)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_revoke_ota_enrollment_audit_event(self, post_event):
+        enrollment = force_ota_enrollment(self.mbu)
+        self.assertIsNone(enrollment.enrollment_secret.revoked_at)
+        self.login("mdm.change_otaenrollment", "mdm.view_otaenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:revoke_ota_enrollment", args=(enrollment.pk,)),
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = self.assert_audit_event(post_event, "updated", "mdm.otaenrollment", enrollment.pk)
+        prev_secret = event.payload["object"]["prev_value"]["enrollment_secret"]
+        new_secret = event.payload["object"]["new_value"]["enrollment_secret"]
+        self.assertFalse(prev_secret["is_revoked"])
+        self.assertTrue(new_secret["is_revoked"])
+        self.assertIsNotNone(new_secret["revoked_at"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_revoke_revoked_ota_enrollment_posts_no_event(self, post_event):
+        enrollment = force_ota_enrollment(self.mbu)
+        enrollment.revoke()
+        self.login("mdm.change_otaenrollment", "mdm.view_otaenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:revoke_ota_enrollment", args=(enrollment.pk,)),
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
+
+    # user enrollments
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_user_enrollment_audit_event(self, post_event):
+        self.login("mdm.add_userenrollment", "mdm.view_userenrollment")
+        name = get_random_string(12)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:create_user_enrollment"),
+                                        {"ue-name": name,
+                                         "ue-display_name": get_random_string(12),
+                                         "ue-realm": force_realm().pk,
+                                         "ue-scep_issuer": force_scep_issuer().pk,
+                                         "ue-push_certificate": force_push_certificate().pk,
+                                         "es-meta_business_unit": self.mbu.pk},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        enrollment = response.context["object"]
+        event = self.assert_audit_event(post_event, "created", "mdm.userenrollment", enrollment.pk)
+        self.assertEqual(event.payload["object"]["new_value"]["name"], name)
+        self.assert_no_secret(event, enrollment)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_user_enrollment_audit_event(self, post_event):
+        enrollment = force_user_enrollment(self.mbu)
+        prev_name = enrollment.name
+        new_name = get_random_string(12)
+        self.login("mdm.change_userenrollment", "mdm.view_userenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:update_user_enrollment", args=(enrollment.pk,)),
+                                        {"ue-name": new_name,
+                                         "ue-display_name": get_random_string(12),
+                                         "ue-realm": force_realm().pk,
+                                         "ue-scep_issuer": enrollment.scep_issuer.pk,
+                                         "ue-push_certificate": enrollment.push_certificate.pk,
+                                         "es-meta_business_unit": self.mbu.pk},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = self.assert_audit_event(post_event, "updated", "mdm.userenrollment", enrollment.pk)
+        self.assertEqual(event.payload["object"]["prev_value"]["name"], prev_name)
+        self.assertEqual(event.payload["object"]["new_value"]["name"], new_name)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_revoke_user_enrollment_audit_event(self, post_event):
+        enrollment = force_user_enrollment(self.mbu)
+        self.login("mdm.change_userenrollment", "mdm.view_userenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:revoke_user_enrollment", args=(enrollment.pk,)),
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = self.assert_audit_event(post_event, "updated", "mdm.userenrollment", enrollment.pk)
+        self.assertTrue(event.payload["object"]["new_value"]["enrollment_secret"]["is_revoked"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_revoke_revoked_user_enrollment_posts_no_event(self, post_event):
+        enrollment = force_user_enrollment(self.mbu)
+        enrollment.revoke()
+        self.login("mdm.change_userenrollment", "mdm.view_userenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:revoke_user_enrollment", args=(enrollment.pk,)),
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
+
+    # DEP enrollments
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_dep_enrollment_audit_event(self, post_event, from_dep_virtual_server):
+        client = Mock()
+        client.add_profile.return_value = {
+            "profile_uuid": str(uuid.uuid4()).upper().replace("-", ""),
+            "devices": {},
+        }
+        from_dep_virtual_server.return_value = client
+        self.login("mdm.add_depenrollment", "mdm.view_depenrollment")
+        name = get_random_string(12)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:create_dep_enrollment"),
+                                        {"de-name": name,
+                                         "de-display_name": get_random_string(12),
+                                         "de-scep_issuer": force_scep_issuer().pk,
+                                         "de-push_certificate": force_push_certificate().pk,
+                                         "de-virtual_server": force_dep_virtual_server().pk,
+                                         "de-is_mdm_removable": "on",
+                                         "de-is_supervised": "",
+                                         "de-admin_password_complexity": 3,
+                                         "de-admin_password_rotation_delay": 60,
+                                         "es-meta_business_unit": self.mbu.pk},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        enrollment = response.context["object"]
+        event = self.assert_audit_event(post_event, "created", "mdm.depenrollment", enrollment.pk)
+        self.assertEqual(event.payload["object"]["new_value"]["name"], name)
+        self.assert_no_secret(event, enrollment)
+
+    @patch("zentral.contrib.mdm.views.dep_enrollments.define_dep_profile")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_dep_enrollment_dep_error_posts_no_event(self, post_event, define_dep_profile):
+        define_dep_profile.side_effect = DEPClientError("Boom")
+        self.login("mdm.add_depenrollment", "mdm.view_depenrollment")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:create_dep_enrollment"),
+                                        {"de-name": get_random_string(12),
+                                         "de-display_name": get_random_string(12),
+                                         "de-scep_issuer": force_scep_issuer().pk,
+                                         "de-push_certificate": force_push_certificate().pk,
+                                         "de-virtual_server": force_dep_virtual_server().pk,
+                                         "de-is_mdm_removable": "on",
+                                         "de-is_supervised": "",
+                                         "de-admin_password_complexity": 3,
+                                         "de-admin_password_rotation_delay": 60,
+                                         "es-meta_business_unit": self.mbu.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response.context["dep_enrollment_form"], None, "Boom")
+        # the enrollment is only persisted by define_dep_profile(), so a failed call to Apple
+        # must not leave a created event behind
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()

--- a/tests/mdm/test_setup_dep_enrollment.py
+++ b/tests/mdm/test_setup_dep_enrollment.py
@@ -507,7 +507,8 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
                                         follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "mdm/depenrollment_detail.html")
-        self.assertEqual(len(callbacks), 1)
+        # the DEP profile push and the audit event
+        self.assertEqual(len(callbacks), 2)
         self.assertContains(response, new_name)
         self.assertContains(response, new_display_name)
         self.assertContains(response, realm.name)
@@ -545,7 +546,8 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
                                         follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "mdm/depenrollment_detail.html")
-        self.assertEqual(len(callbacks), 1)
+        # the DEP profile push and the audit event
+        self.assertEqual(len(callbacks), 2)
         define_dep_profile_task.apply_async.assert_called_once_with((enrollment.pk,))
         enrollment.refresh_from_db()
         self.assertIsNone(enrollment.admin_full_name)
@@ -577,7 +579,8 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
                                         follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "mdm/depenrollment_detail.html")
-        self.assertEqual(len(callbacks), 1)
+        # the DEP profile push and the audit event
+        self.assertEqual(len(callbacks), 2)
         define_dep_profile_task.apply_async.assert_called_once_with((enrollment.pk,))
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.admin_full_name, "yolo2")
@@ -617,7 +620,8 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
                                         follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "mdm/depenrollment_detail.html")
-        self.assertEqual(len(callbacks), 0)  # the DEP profile has not changed
+        # the DEP profile has not changed, so only the audit event is queued
+        self.assertEqual(len(callbacks), 1)
         define_dep_profile_task.apply_async.assert_not_called()
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.admin_full_name, "yolo2")

--- a/zentral/contrib/mdm/views/dep_enrollments.py
+++ b/zentral/contrib/mdm/views/dep_enrollments.py
@@ -10,7 +10,9 @@ from zentral.contrib.mdm.forms import CreateDEPEnrollmentForm, DEPEnrollmentCust
 from zentral.contrib.mdm.models import DEPEnrollment, DEPEnrollmentCustomView
 from zentral.contrib.mdm.skip_keys import skippable_setup_panes
 from zentral.contrib.mdm.tasks import define_dep_profile_task
-from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
+from zentral.core.events.base import AuditEvent
+from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, post_audit_event,
+                                 UpdateViewWithAudit)
 
 
 logger = logging.getLogger("zentral.contrib.mdm.views.dep_enrollments")
@@ -53,6 +55,7 @@ class CreateDEPEnrollmentView(PermissionRequiredMixin, TemplateView):
             except DEPClientError as error:
                 dep_enrollment_form.add_error(None, str(error))
             else:
+                post_audit_event(request, dep_enrollment, AuditEvent.Action.CREATED)
                 return redirect(dep_enrollment)
         return self.render_to_response(
             self.get_context_data(
@@ -128,6 +131,7 @@ class UpdateDEPEnrollmentView(PermissionRequiredMixin, TemplateView):
 
     def post(self, request, *args, **kwargs):
         prev_dep_profile = serialize_dep_profile(self.object)
+        prev_value = self.object.serialize_for_event()
         dep_enrollment_form = UpdateDEPEnrollmentForm(
             request.POST, prefix="de", instance=self.object
         )
@@ -147,6 +151,7 @@ class UpdateDEPEnrollmentView(PermissionRequiredMixin, TemplateView):
                 transaction.on_commit(lambda: define_dep_profile_task.apply_async((dep_enrollment.pk,)))
             else:
                 logger.info("DEP profile %s unchanged", dep_enrollment.pk)
+            post_audit_event(request, dep_enrollment, AuditEvent.Action.UPDATED, prev_value=prev_value)
             return redirect(dep_enrollment)
         return self.render_to_response(
             self.get_context_data(

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -57,7 +57,8 @@ from zentral.contrib.mdm.payloads import (build_configuration_profile_response,
 from zentral.contrib.mdm.software_updates import best_available_software_updates
 from zentral.contrib.mdm.tasks import bulk_assign_location_asset_task
 from zentral.core.events.base import AuditEvent
-from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
+from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, post_audit_event,
+                                 UpdateViewWithAudit, UserPaginationListView)
 from zentral.utils.storage import file_storage_has_signed_urls, select_dist_storage
 
 
@@ -119,6 +120,7 @@ class CreateOTAEnrollmentView(PermissionRequiredMixin, TemplateView):
             ota_enrollment.enrollment_secret = enrollment_secret_form.save()
             enrollment_secret_form.save_m2m()
             ota_enrollment.save()
+            post_audit_event(request, ota_enrollment, AuditEvent.Action.CREATED)
             return redirect(ota_enrollment)
         else:
             return self.render_to_response(
@@ -181,7 +183,13 @@ class RevokeOTAEnrollmentView(PermissionRequiredMixin, TemplateView):
         return ctx
 
     def post(self, request, *args, **kwargs):
-        self.ota_enrollment.revoke()
+        # revoke() is a no-op on an already revoked enrollment, and an audit event whose
+        # prev_value and new_value match records nothing
+        if not self.ota_enrollment.enrollment_secret.revoked_at:
+            prev_value = self.ota_enrollment.serialize_for_event()
+            self.ota_enrollment.revoke()
+            post_audit_event(request, self.ota_enrollment, AuditEvent.Action.UPDATED,
+                             prev_value=prev_value)
         return redirect(self.ota_enrollment)
 
 
@@ -216,6 +224,7 @@ class UpdateOTAEnrollmentView(PermissionRequiredMixin, TemplateView):
         return context
 
     def post(self, request, *args, **kwargs):
+        prev_value = self.ota_enrollment.serialize_for_event()
         ota_enrollment_form = OTAEnrollmentForm(
             request.POST,
             instance=self.ota_enrollment,
@@ -231,6 +240,7 @@ class UpdateOTAEnrollmentView(PermissionRequiredMixin, TemplateView):
             ota_enrollment.enrollment_secret = enrollment_secret_form.save()
             enrollment_secret_form.save_m2m()
             ota_enrollment.save()
+            post_audit_event(request, ota_enrollment, AuditEvent.Action.UPDATED, prev_value=prev_value)
             return redirect(ota_enrollment)
         else:
             return self.render_to_response(
@@ -275,6 +285,7 @@ class CreateUserEnrollmentView(PermissionRequiredMixin, TemplateView):
             user_enrollment.enrollment_secret = enrollment_secret_form.save()
             enrollment_secret_form.save_m2m()
             user_enrollment.save()
+            post_audit_event(request, user_enrollment, AuditEvent.Action.CREATED)
             return redirect(user_enrollment)
         else:
             return self.render_to_response(
@@ -317,7 +328,13 @@ class RevokeUserEnrollmentView(PermissionRequiredMixin, TemplateView):
         return ctx
 
     def post(self, request, *args, **kwargs):
-        self.user_enrollment.revoke()
+        # revoke() is a no-op on an already revoked enrollment, and an audit event whose
+        # prev_value and new_value match records nothing
+        if not self.user_enrollment.enrollment_secret.revoked_at:
+            prev_value = self.user_enrollment.serialize_for_event()
+            self.user_enrollment.revoke()
+            post_audit_event(request, self.user_enrollment, AuditEvent.Action.UPDATED,
+                             prev_value=prev_value)
         return redirect(self.user_enrollment)
 
 
@@ -354,6 +371,7 @@ class UpdateUserEnrollmentView(PermissionRequiredMixin, TemplateView):
         return context
 
     def post(self, request, *args, **kwargs):
+        prev_value = self.user_enrollment.serialize_for_event()
         user_enrollment_form = UserEnrollmentForm(
             request.POST,
             instance=self.user_enrollment,
@@ -371,6 +389,7 @@ class UpdateUserEnrollmentView(PermissionRequiredMixin, TemplateView):
             user_enrollment.enrollment_secret = enrollment_secret_form.save()
             enrollment_secret_form.save_m2m()
             user_enrollment.save()
+            post_audit_event(request, user_enrollment, AuditEvent.Action.UPDATED, prev_value=prev_value)
             return redirect(user_enrollment)
         else:
             return self.render_to_response(

--- a/zentral/utils/views.py
+++ b/zentral/utils/views.py
@@ -35,6 +35,25 @@ class UserPaginationListView(UserPaginationMixin, ListView):
         return ctx
 
 
+def post_audit_event(request, instance, action, prev_value=None, machine_serial_number=None):
+    """Post an audit event once the surrounding transaction has committed.
+
+    For the views that cannot use the mixins below, typically because they drive more than
+    one form and so implement post() themselves. Note that on an update the prev_value has
+    to be serialized before the forms are validated: a ModelForm writes the posted data
+    onto its instance during validation, not in save().
+    """
+    def on_commit_callback():
+        AuditEvent.build_from_request_and_instance(
+            request, instance,
+            action=action,
+            prev_value=prev_value,
+            machine_serial_number=machine_serial_number,
+        ).post()
+
+    transaction.on_commit(on_commit_callback)
+
+
 class CreateViewWithAudit(CreateView):
     def on_commit_callback_extra(self):
         pass


### PR DESCRIPTION
## Why

An enrollment is the path onto the MDM: creating one opens a way in, revoking one closes it. The HTTP API audits DEP and OTA enrollment writes through the DRF mixins, but none of the web interface views did — and `EnrollmentSecret.revoke()` still carried a literal `# TODO events` comment.

Eight views, now audited:

| Type | Views |
|---|---|
| Automated Device Enrollment | create, update |
| OTA | create, update, revoke |
| User | create, update, revoke |

**User enrollments were not in the request** ("DEP / OTA"), but the three types are siblings with near-identical views — auditing two and leaving the third would recreate exactly the drift this closes. Say the word if you'd rather split it out.

## A helper, on the eighth copy

These views all drive two forms (an enrollment form plus an enrollment secret form), so they implement `post()` themselves and can't use the mixins. That made this the eighth hand-rolled copy of the same `transaction.on_commit` block across four PRs, so it's now `post_audit_event()` in `zentral/utils/views.py`, next to the mixins it complements. Existing hand-rolled sites are left alone; they can adopt it incrementally.

## Three things the helper cannot paper over

All three are covered by tests, and each would have produced a quietly wrong audit trail:

**A `ModelForm` writes the posted data onto its instance while validating, not in `save()`.** So `prev_value` has to be serialized at the very top of `post()`, before the forms are constructed. Serialize it later and the event reports the *new* name as the old one. `UpdateViewWithAudit` sidesteps this by re-reading from the DB; the hand-written posts can't.

**`revoke()` is a no-op when already revoked**, so the revoke views only post when the enrollment wasn't revoked yet — otherwise `prev_value == new_value` and the event records nothing. Same shape as the block/unblock case in #1558.

**`define_dep_profile()` is what persists a DEP enrollment, and it talks to Apple.** The `created` event is posted from the `else` branch of the `DEPClientError` handler, so a failed call to Apple can't leave a `created` event behind for an enrollment that doesn't exist. There's a test for exactly that.

## The enrollment secret never reaches the events

Worth stating explicitly since these objects carry a live credential: `EnrollmentSecret.serialize_for_event()` reports the quota, request count, expiry, revocation state, business unit, tags and serial/UDID restrictions — but **not** `secret`. A test asserts the secret string appears nowhere in the payload, so a regression there can't silently put a working enrollment credential into every event store.

It does report `is_revoked` and `revoked_at`, which is why revocation produces a meaningful transition with no model change needed:

```json
{"action": "updated",
 "object": {"model": "mdm.otaenrollment",
            "prev_value": {"enrollment_secret": {"is_revoked": false}},
            "new_value": {"enrollment_secret": {"is_revoked": true, "revoked_at": "…"}}}}
```

## Tests

3053 tests pass across `tests.mdm`, `tests.core_events` and `tests.server_accounts`. flake8 clean.

New `tests/mdm/test_enrollment_audit.py`, 10 tests: the event on each of the eight paths, plus no-event assertions on a repeat revoke and on a failed DEP call.

**Four existing assertions changed** in `test_setup_dep_enrollment.py`. They counted `on_commit` callbacks to check whether the DEP profile push was queued; the audit event adds one. Notably `test_update_dep_enrollment_post_update_admin_update_pwd` asserted *zero* callbacks ("the DEP profile has not changed") and is now 1 — correct, since the enrollment was still updated even though the DEP profile wasn't. Extended rather than loosened.

## Deliberately out of scope

Still unaudited, and each wanting its own decision: the DEP **virtual server** and **token** views in `views/setup.py` (`ConnectDEPVirtualServerView`, `RenewDEPTokenView`, `UpdateDEPVirtualServerView`) — these handle an uploaded encrypted token, so they need a careful look at what `serialize_for_event` would expose, and `DEPToken` has no serializer yet. Also the DEP **device** views (`AssignDEPDeviceProfileView`, `RefreshDEPDeviceView`, `DisownDEPDevice`), which are machine-scoped and want `machine_serial_number` plus a hook on the mixins. Push certificates and locations are neither DEP nor OTA.

## Not verified

`mkdocs build --strict` could not be run — mkdocs is not in the container image and `pip install` fails there on venv permissions. Checked by hand: balanced fences, consistent heading nesting, all three JSON examples parse, no links or images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
