### PR TITLE
Audit the MDM credentials without recording any key material

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -601,7 +601,7 @@ Creating, replacing and deleting the credentials Zentral uses to manage and enro
 
 The fingerprint is what makes a renewal legible: it tells a certificate that was genuinely replaced from one that was uploaded again unchanged.
 
-Connecting a new Automated Device Enrollment virtual server is not audited yet.
+Connecting a virtual server is audited too. Uploading a server token for an account Zentral does not know yet is recorded as a `created` virtual server; uploading one for an account it already has replaces that server's token instead, and is recorded as an `updated` virtual server with the token changing. Starting the connect flow and cancelling it records nothing, because the token it prepares up front carries no credential and no server.
 
 ### Enrollments
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -585,6 +585,24 @@ Artifacts decide which profiles, apps and declarations get installed, and linkin
 
 Blueprints themselves, along with the FileVault, recovery password and software update enforcement configurations, are audited the same way, as are the realm group tag mappings, which decide the tags a device inherits from its user's groups.
 
+### Push certificates, DEP tokens and locations
+
+Creating, replacing and deleting the credentials Zentral uses to manage and enroll devices are audited: the APNs push certificate, the Automated Device Enrollment token, and the Apps and Books locations.
+
+**No key material is ever recorded.** The push certificate's private key, and the DEP token's private key, consumer secret and access secret, are left out of the events entirely, as are the OAuth consumer key and access token. What is recorded is the metadata an auditor can act on — the certificate's topic and validity window, the token's expiry and last sync — and a SHA-256 fingerprint of the certificate in place of the certificate itself:
+
+```json
+{"action": "updated",
+ "object": {"model": "mdm.pushcertificate",
+            "prev_value": {"name": "APNS", "topic": null, "certificate_sha256": "6b86b273…"},
+            "new_value": {"name": "APNS", "topic": "com.apple.mgmt.External.…",
+                          "certificate_sha256": "d4735e3a…"}}}
+```
+
+The fingerprint is what makes a renewal legible: it tells a certificate that was genuinely replaced from one that was uploaded again unchanged.
+
+Connecting a new Automated Device Enrollment virtual server is not audited yet.
+
 ### Enrollments
 
 An enrollment is the path onto the MDM, so creating one, changing it and revoking it are all audited, for the Automated Device Enrollment, OTA and user enrollment types alike, from the web interface as well as the HTTP API. A revocation is reported with the `updated` action, and shows up as the `is_revoked` and `revoked_at` fields of the enrollment secret changing:

--- a/tests/mdm/models/test_credential_models.py
+++ b/tests/mdm/models/test_credential_models.py
@@ -1,0 +1,138 @@
+import hashlib
+import json
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+from tests.mdm.utils import force_dep_virtual_server, force_push_certificate
+from tests.zentral_test_utils.assertions.serialization_assertions import SerializeForEventAssertions
+from zentral.contrib.mdm.crypto import certificate_sha256_fingerprint
+from zentral.contrib.mdm.models import PushCertificate
+
+
+class TestMDMCredentialModelSerialization(TestCase, SerializeForEventAssertions):
+    """The push certificate and the DEP token are the MDM's credentials. Their audit events
+    carry enough to tell one certificate from another, and none of the key material."""
+
+    maxDiff = None
+
+    # fingerprint helper
+
+    def test_certificate_sha256_fingerprint(self):
+        self.assertEqual(
+            certificate_sha256_fingerprint(b"yolo"),
+            hashlib.sha256(b"yolo").hexdigest(),
+        )
+
+    def test_certificate_sha256_fingerprint_accepts_a_memoryview(self):
+        # a BinaryField read back from the database is not always bytes
+        self.assertEqual(
+            certificate_sha256_fingerprint(memoryview(b"yolo")),
+            hashlib.sha256(b"yolo").hexdigest(),
+        )
+
+    def test_certificate_sha256_fingerprint_without_certificate(self):
+        for empty in (None, b"", ""):
+            with self.subTest(empty=empty):
+                self.assertIsNone(certificate_sha256_fingerprint(empty))
+
+    # push certificate
+
+    def test_push_certificate_serialize_for_event_keys_only(self):
+        push_certificate = force_push_certificate()
+        self.assertEqual(
+            push_certificate.serialize_for_event(keys_only=True),
+            {"pk": push_certificate.pk, "name": push_certificate.name},
+        )
+
+    def test_push_certificate_serialize_for_event(self):
+        push_certificate = force_push_certificate(with_material=True)
+        d = push_certificate.serialize_for_event()
+        self.assertEqual(
+            set(d),
+            {"pk", "name", "provisioning_uid", "topic", "not_before", "not_after",
+             "certificate_sha256", "created_at", "updated_at"},
+        )
+        self.assertEqual(d["topic"], push_certificate.topic)
+        self.assertEqual(d["certificate_sha256"],
+                         hashlib.sha256(bytes(push_certificate.certificate)).hexdigest())
+        self.assert_serialize_for_event_is_json_native(push_certificate)
+
+    def test_push_certificate_serialize_for_event_has_no_private_key(self):
+        push_certificate = force_push_certificate(with_material=True)
+        self.assertTrue(push_certificate.private_key)
+        serialized = json.dumps(push_certificate.serialize_for_event())
+        self.assertNotIn("private_key", serialized)
+        # neither the ciphertext nor the key itself
+        self.assertNotIn(push_certificate.private_key, serialized)
+        self.assertNotIn(push_certificate.get_private_key().decode("utf-8"), serialized)
+
+    def test_push_certificate_serialize_for_event_before_the_certificate_is_uploaded(self):
+        # CreatePushCertificateView makes one with only a name, and the certificate is uploaded
+        # later, so every field it reports has to survive being null
+        push_certificate = PushCertificate.objects.create(name=get_random_string(12))
+        d = push_certificate.serialize_for_event()
+        self.assertIsNone(d["certificate_sha256"])
+        self.assertIsNone(d["not_before"])
+        self.assertIsNone(d["not_after"])
+        self.assertIsNone(d["topic"])
+        self.assert_serialize_for_event_is_json_native(push_certificate)
+
+    # DEP token
+
+    def test_dep_token_serialize_for_event(self):
+        dep_token = force_dep_virtual_server().token
+        d = dep_token.serialize_for_event()
+        self.assertEqual(
+            set(d),
+            {"pk", "certificate_sha256", "access_token_expiry", "has_expired", "expires_soon",
+             "last_synced_at", "created_at", "updated_at"},
+        )
+        self.assertIsInstance(d["has_expired"], bool)
+        self.assertIsInstance(d["expires_soon"], bool)
+        self.assert_serialize_for_event_is_json_native(dep_token)
+
+    def test_dep_token_serialize_for_event_keys_only(self):
+        dep_token = force_dep_virtual_server().token
+        self.assertEqual(dep_token.serialize_for_event(keys_only=True), {"pk": dep_token.pk})
+
+    def test_dep_token_serialize_for_event_has_no_secrets(self):
+        dep_token = force_dep_virtual_server().token
+        dep_token.set_private_key(b"PRIVATE-KEY-MATERIAL")
+        dep_token.set_consumer_secret("CONSUMER-SECRET-MATERIAL")
+        dep_token.set_access_secret("ACCESS-SECRET-MATERIAL")
+        dep_token.consumer_key = "CONSUMER-KEY"
+        dep_token.access_token = "ACCESS-TOKEN"
+        dep_token.sync_cursor = "SYNC-CURSOR"
+        dep_token.save()
+        serialized = json.dumps(dep_token.serialize_for_event())
+        for absent in ("PRIVATE-KEY-MATERIAL", "CONSUMER-SECRET-MATERIAL", "ACCESS-SECRET-MATERIAL",
+                       dep_token.private_key, dep_token.consumer_secret, dep_token.access_secret,
+                       "CONSUMER-KEY", "ACCESS-TOKEN", "SYNC-CURSOR"):
+            with self.subTest(absent=absent[:24]):
+                self.assertNotIn(absent, serialized)
+
+    # DEP virtual server, whose only editable field is the default enrollment
+
+    def test_dep_virtual_server_serialize_for_event(self):
+        virtual_server = force_dep_virtual_server()
+        d = virtual_server.serialize_for_event()
+        self.assertEqual(
+            set(d),
+            {"pk", "uuid", "name", "default_enrollment", "token", "created_at", "updated_at"},
+        )
+        self.assertIsNone(d["default_enrollment"])
+        self.assertEqual(d["token"], {"pk": virtual_server.token.pk})
+        self.assert_serialize_for_event_is_json_native(virtual_server)
+
+    def test_dep_virtual_server_serialize_for_event_keys_only(self):
+        virtual_server = force_dep_virtual_server()
+        self.assertEqual(
+            virtual_server.serialize_for_event(keys_only=True),
+            {"pk": virtual_server.pk, "uuid": str(virtual_server.uuid), "name": virtual_server.name},
+        )
+
+    def test_dep_virtual_server_serialize_for_event_has_no_token_secrets(self):
+        virtual_server = force_dep_virtual_server()
+        virtual_server.token.set_access_secret(get_random_string(12))
+        virtual_server.token.save()
+        serialized = json.dumps(virtual_server.serialize_for_event())
+        self.assertNotIn(virtual_server.token.access_secret, serialized)

--- a/tests/mdm/test_setup_credential_audit.py
+++ b/tests/mdm/test_setup_credential_audit.py
@@ -1,0 +1,164 @@
+import hashlib
+import json
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+from accounts.models import User
+from tests.zentral_test_utils.login_case import LoginCase
+from zentral.contrib.inventory.models import MetaBusinessUnit
+from zentral.contrib.mdm.models import PushCertificate
+from zentral.core.events.base import AuditEvent
+
+from .utils import force_dep_enrollment, force_push_certificate, force_push_certificate_material
+
+
+class CredentialAuditEventTestCase(TestCase, LoginCase):
+    """The push certificate and the DEP token are what let Zentral manage and enroll devices,
+    so replacing or deleting one has to leave a trail — without the key material."""
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        cls.group = Group.objects.create(name=get_random_string(12))
+        cls.user.groups.set([cls.group])
+        cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+        cls.mbu.create_enrollment_business_unit()
+
+    # LoginCase implementation
+
+    def _get_user(self):
+        return self.user
+
+    def _get_group(self):
+        return self.group
+
+    def _get_url_namespace(self):
+        return "mdm"
+
+    def get_audit_event(self, post_event):
+        events = [c.args[0] for c in post_event.call_args_list if isinstance(c.args[0], AuditEvent)]
+        self.assertEqual(len(events), 1)
+        return events[0]
+
+    # push certificates
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_push_certificate_audit_event(self, post_event):
+        self.login("mdm.add_pushcertificate", "mdm.view_pushcertificate")
+        name = get_random_string(12)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("mdm:create_push_certificate"), {"name": name}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.get_audit_event(post_event)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "mdm.pushcertificate")
+        self.assertEqual(event.payload["object"]["pk"], str(PushCertificate.objects.get(name=name).pk))
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["name"], name)
+        # created before any material is uploaded
+        self.assertIsNone(new_value["certificate_sha256"])
+        self.assertIsNone(new_value["topic"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_upload_push_certificate_audit_event(self, post_event):
+        self.login("mdm.add_pushcertificate", "mdm.view_pushcertificate")
+        name = get_random_string(12)
+        cert_pem, privkey_pem, privkey_password = force_push_certificate_material()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("mdm:upload_push_certificate"),
+                                        {"name": name,
+                                         "certificate_file": SimpleUploadedFile("cert.pem", cert_pem),
+                                         "key_file": SimpleUploadedFile("key.pem", privkey_pem),
+                                         "key_password": privkey_password.decode("utf-8")},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        push_certificate = PushCertificate.objects.get(name=name)
+        event = self.get_audit_event(post_event)
+        self.assertEqual(event.payload["action"], "created")
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["certificate_sha256"],
+                         hashlib.sha256(bytes(push_certificate.certificate)).hexdigest())
+        self.assert_no_key_material(event, push_certificate)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_upload_push_certificate_certificate_audit_event(self, post_event):
+        # the audit value of the fingerprint: it changes when the certificate is replaced
+        push_certificate = force_push_certificate()
+        push_certificate.topic = None
+        push_certificate.save()
+        prev_fingerprint = hashlib.sha256(bytes(push_certificate.certificate)).hexdigest()
+        topic = get_random_string(12)
+        cert_pem, privkey_pem, _ = force_push_certificate_material(topic=topic, encrypt_key=False)
+        push_certificate.set_private_key(privkey_pem)
+        push_certificate.save()
+        self.login("mdm.change_pushcertificate", "mdm.view_pushcertificate")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("mdm:upload_push_certificate_certificate", args=(push_certificate.pk,)),
+                {"name": push_certificate.name,
+                 "certificate_file": SimpleUploadedFile("cert.pem", cert_pem)},
+                follow=True)
+        self.assertEqual(response.status_code, 200)
+        push_certificate.refresh_from_db()
+        event = self.get_audit_event(post_event)
+        self.assertEqual(event.payload["action"], "updated")
+        prev_value = event.payload["object"]["prev_value"]
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(prev_value["certificate_sha256"], prev_fingerprint)
+        self.assertEqual(new_value["certificate_sha256"],
+                         hashlib.sha256(bytes(push_certificate.certificate)).hexdigest())
+        self.assertNotEqual(prev_value["certificate_sha256"], new_value["certificate_sha256"])
+        self.assertIsNone(prev_value["topic"])
+        self.assertEqual(new_value["topic"], topic)
+        self.assert_no_key_material(event, push_certificate)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_push_certificate_audit_event(self, post_event):
+        push_certificate = force_push_certificate(with_material=True)
+        self.login("mdm.delete_pushcertificate", "mdm.view_pushcertificate")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("mdm:delete_push_certificate", args=(push_certificate.pk,)),
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.get_audit_event(post_event)
+        self.assertEqual(event.payload["action"], "deleted")
+        self.assertEqual(event.payload["object"]["prev_value"]["name"], push_certificate.name)
+        self.assert_no_key_material(event, push_certificate)
+
+    def assert_no_key_material(self, event, push_certificate):
+        serialized = json.dumps(event.payload)
+        self.assertNotIn("private_key", serialized)
+        self.assertNotIn(push_certificate.private_key, serialized)
+
+    # DEP virtual server
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_dep_virtual_server_audit_event(self, post_event):
+        # UpdateDEPVirtualServerForm only offers the enrollments of that virtual server, so the
+        # enrollment force helper, which makes its own, will not do here
+        enrollment = force_dep_enrollment(self.mbu)
+        virtual_server = enrollment.virtual_server
+        # the fixture leaves the token secrets unset, so set one to make the assertion below bite
+        virtual_server.token.set_access_secret(get_random_string(12))
+        virtual_server.token.save()
+        self.login("mdm.change_depvirtualserver", "mdm.view_depvirtualserver")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("mdm:update_dep_virtual_server", args=(virtual_server.pk,)),
+                                        {"default_enrollment": enrollment.pk},
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        event = self.get_audit_event(post_event)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depvirtualserver")
+        # default_enrollment is the only editable field, so without it in the serialization the
+        # prev_value and the new_value would have matched
+        self.assertIsNone(event.payload["object"]["prev_value"]["default_enrollment"])
+        self.assertEqual(event.payload["object"]["new_value"]["default_enrollment"]["pk"], enrollment.pk)
+        self.assertNotIn(virtual_server.token.access_secret, json.dumps(event.payload))

--- a/tests/mdm/test_setup_dep_virtual_server.py
+++ b/tests/mdm/test_setup_dep_virtual_server.py
@@ -13,6 +13,7 @@ from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.crypto import encrypt_cms_payload
 from zentral.contrib.mdm.dep import add_dep_token_certificate
 from zentral.contrib.mdm.models import DEPToken, DEPVirtualServer
+from zentral.core.events.base import AuditEvent
 from .utils import force_dep_enrollment, force_dep_virtual_server
 
 
@@ -289,6 +290,81 @@ class SetupDEPVirtualServerViewsTestCase(TestCase, LoginCase):
         self.assertEqual(dep_token.virtual_server.uuid, server_uuid)
         self.assertEqual(dep_token.virtual_server.organization.name, "Example ORG")
         mock_dep_client.get_account.assert_called_once()
+
+    @patch("zentral.contrib.mdm.forms.DEPClient")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_connect_dep_virtual_server_post_audit_event(self, post_event, DEPClient):
+        mock_dep_client, server_name, server_uuid = self._build_mock_dep_client()
+        DEPClient.return_value = mock_dep_client
+        self.login("mdm.add_depvirtualserver", "mdm.view_depvirtualserver")
+        session = self.client.session
+        dep_token = DEPToken.objects.create()
+        add_dep_token_certificate(dep_token)
+        session["current_dep_token_id"] = dep_token.pk
+        session.save()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:connect_dep_virtual_server"),
+                                        {"action": "upload",
+                                         "encrypted_token": self._build_encrypted_token(dep_token)})
+        dep_token.refresh_from_db()
+        self.assertRedirects(response, dep_token.virtual_server.get_absolute_url())
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depvirtualserver")
+        new_value = event.payload["object"]["new_value"]
+        self.assertEqual(new_value["name"], server_name)
+        self.assertEqual(new_value["uuid"], str(server_uuid))
+        self.assertEqual(new_value["token"], {"pk": dep_token.pk})
+        # the decrypted token never reaches the event
+        serialized = json.dumps(event.payload)
+        for secret in ("csecret", "asecret", "ckey", "atoken",
+                       dep_token.consumer_secret, dep_token.access_secret):
+            with self.subTest(secret=secret[:12]):
+                self.assertNotIn(secret, serialized)
+
+    @patch("zentral.contrib.mdm.forms.DEPClient")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_reconnect_dep_virtual_server_post_audit_event(self, post_event, DEPClient):
+        # uploading a token for an already connected server swaps its token instead of making a
+        # new server, so the event has to say updated and show the token changing
+        virtual_server = force_dep_virtual_server()
+        old_token = virtual_server.token
+        mock_dep_client, server_name, _ = self._build_mock_dep_client()
+        mock_dep_client.get_account.return_value["server_uuid"] = str(virtual_server.uuid)
+        DEPClient.return_value = mock_dep_client
+        self.login("mdm.add_depvirtualserver", "mdm.view_depvirtualserver")
+        session = self.client.session
+        dep_token = DEPToken.objects.create()
+        add_dep_token_certificate(dep_token)
+        session["current_dep_token_id"] = dep_token.pk
+        session.save()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:connect_dep_virtual_server"),
+                                        {"action": "upload",
+                                         "encrypted_token": self._build_encrypted_token(dep_token)})
+        virtual_server.refresh_from_db()
+        self.assertRedirects(response, virtual_server.get_absolute_url())
+        self.assertEqual(virtual_server.token, dep_token)
+        self.assertEqual(DEPToken.objects.filter(pk=old_token.pk).count(), 0)  # the old one is gone
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["prev_value"]["token"], {"pk": old_token.pk})
+        self.assertEqual(event.payload["object"]["new_value"]["token"], {"pk": dep_token.pk})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_connect_dep_virtual_server_post_cancel_posts_no_event(self, post_event):
+        # the token the flow creates up front has no credential and no server, so abandoning
+        # the flow deletes scaffolding rather than anything an auditor would look for
+        self.login("mdm.add_depvirtualserver", "mdm.view_depvirtualserver")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:connect_dep_virtual_server"), {"action": "cancel"})
+        self.assertRedirects(response, reverse("mdm:dep_virtual_servers"))
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
 
     # download DEP token public key
 

--- a/zentral/contrib/mdm/crypto.py
+++ b/zentral/contrib/mdm/crypto.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
@@ -209,6 +210,18 @@ def encrypt_cms_payload(payload, public_key_bytes, raw_output=False):
 
 
 # push certificate
+
+
+def certificate_sha256_fingerprint(certificate_bytes):
+    """Hex SHA-256 of a certificate, for the event payloads.
+
+    A certificate is public, but it is also bulky and binary, so the audit trail carries its
+    fingerprint instead: enough to tell a certificate that was replaced from one that was
+    uploaded again unchanged.
+    """
+    if not certificate_bytes:
+        return None
+    return hashlib.sha256(bytes(certificate_bytes)).hexdigest()
 
 
 def generate_push_certificate_key_bytes(key_size=2048):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -32,6 +32,7 @@ from zentral.contrib.inventory.models import (
     MetaMachine,
     Tag,
 )
+from zentral.contrib.mdm.crypto import certificate_sha256_fingerprint
 from zentral.core.incidents.models import Severity
 from zentral.core.secret_engines import (
     decrypt,
@@ -135,6 +136,23 @@ class PushCertificate(models.Model):
 
     def rewrap_secrets(self):
         self.private_key = rewrap(self.private_key, **self._get_secret_engine_kwargs("private_key"))
+
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "name": self.name}
+        if keys_only:
+            return d
+        # the fields PushCertificateSerializer already exposes over the HTTP API, except that
+        # the certificate is reported by fingerprint and the private key not at all
+        d.update({
+            "provisioning_uid": self.provisioning_uid,
+            "topic": self.topic,
+            "not_before": self.not_before.isoformat() if self.not_before else None,
+            "not_after": self.not_after.isoformat() if self.not_after else None,
+            "certificate_sha256": certificate_sha256_fingerprint(self.certificate),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
 
 
 # FileVault
@@ -689,7 +707,7 @@ class Location(models.Model):
     def get_absolute_url(self):
         return reverse("mdm:location", args=(self.pk,))
 
-    def serialize_for_event(self, keys_only=True):
+    def serialize_for_event(self, keys_only=False):
         d = {
             "pk": self.pk,
             "mdm_info_id": str(self.mdm_info_id),
@@ -781,7 +799,7 @@ class Asset(models.Model):
             platforms.append(Platform.IPADOS)
         return platforms
 
-    def serialize_for_event(self, keys_only=True):
+    def serialize_for_event(self, keys_only=False):
         d = {
             "pk": self.pk,
             "adam_id": self.adam_id,
@@ -1900,6 +1918,25 @@ class DEPToken(models.Model):
         if self.access_secret:
             self.access_secret = rewrap(self.access_secret, **self._get_secret_engine_kwargs("access_secret"))
 
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk}
+        if keys_only:
+            return d
+        # Only the metadata an auditor can act on. The three secrets are left out, and so are
+        # consumer_key and access_token: they are the public halves of the OAuth credential,
+        # but there is one token per virtual server, so naming them tells an auditor nothing.
+        # sync_cursor is operational state.
+        d.update({
+            "certificate_sha256": certificate_sha256_fingerprint(self.certificate),
+            "access_token_expiry": self.access_token_expiry.isoformat() if self.access_token_expiry else None,
+            "has_expired": bool(self.has_expired()),
+            "expires_soon": bool(self.expires_soon()),
+            "last_synced_at": self.last_synced_at.isoformat() if self.last_synced_at else None,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
+
 
 class DEPVirtualServer(models.Model):
     name = models.TextField(editable=False)
@@ -1921,7 +1958,17 @@ class DEPVirtualServer(models.Model):
         return reverse("mdm:dep_virtual_server", args=(self.pk,))
 
     def serialize_for_event(self, keys_only=False):
-        return {"pk": self.pk, "uuid": str(self.uuid), "name": self.name}
+        d = {"pk": self.pk, "uuid": str(self.uuid), "name": self.name}
+        if keys_only:
+            return d
+        d.update({
+            "default_enrollment": (self.default_enrollment.serialize_for_event(keys_only=True)
+                                   if self.default_enrollment else None),
+            "token": self.token.serialize_for_event(keys_only=True) if self.token else None,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
 
 
 class DEPEnrollment(MDMEnrollment):

--- a/zentral/contrib/mdm/preprocessors.py
+++ b/zentral/contrib/mdm/preprocessors.py
@@ -48,7 +48,7 @@ class AppsBooksNotificationPreprocessor:
             self._get_event_metadata(raw_event),
             {"asset": {"adam_id": adam_id,
                        "pricing_param": pricing_param},
-             "location": location.serialize_for_event(),
+             "location": location.serialize_for_event(keys_only=True),
              "count_delta": count_delta,
              "notification_id": notification_id}
         )
@@ -92,7 +92,7 @@ class AppsBooksNotificationPreprocessor:
             return
         event_metadata = self._get_event_metadata(raw_event)
         payload = {
-            "location": location.serialize_for_event(),
+            "location": location.serialize_for_event(keys_only=True),
             "notification_id": notification_id,
         }
         event_id = notification.get("eventId")

--- a/zentral/contrib/mdm/views/setup.py
+++ b/zentral/contrib/mdm/views/setup.py
@@ -18,7 +18,9 @@ from zentral.contrib.mdm.payloads import (build_configuration_profile_response,
 from zentral.contrib.mdm.push_csr_signers import signer as push_csr_signer
 from zentral.contrib.mdm.terraform import iter_resources
 from zentral.utils.terraform import build_config_response
-from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
+from zentral.core.events.base import AuditEvent
+from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, post_audit_event,
+                                 UpdateViewWithAudit)
 
 
 logger = logging.getLogger('zentral.contrib.mdm.views.setup')
@@ -240,9 +242,22 @@ class ConnectDEPVirtualServerView(PermissionRequiredMixin, View):
             form = EncryptedDEPTokenForm(instance=self.current_dep_token,
                                          data=request.POST, files=request.FILES)
             if form.is_valid():
+                # The form either connects a new virtual server or swaps the token of the one
+                # that already has this uuid, deleting the old token, so which action the event
+                # carries depends on that. server_uuid has to be read before save(), which pops
+                # it, and the prev_value before it too.
+                server_uuid = form.cleaned_data["account"]["server_uuid"]
+                prev_virtual_server = DEPVirtualServer.objects.filter(uuid=server_uuid).first()
+                prev_value = prev_virtual_server.serialize_for_event() if prev_virtual_server else None
                 dep_token = form.save()
                 request.session.pop("current_dep_token_id")
-                return HttpResponseRedirect(dep_token.virtual_server.get_absolute_url())
+                virtual_server = dep_token.virtual_server
+                post_audit_event(
+                    request, virtual_server,
+                    AuditEvent.Action.UPDATED if prev_value else AuditEvent.Action.CREATED,
+                    prev_value=prev_value,
+                )
+                return HttpResponseRedirect(virtual_server.get_absolute_url())
         else:
             # start
             form = EncryptedDEPTokenForm(instance=self.current_dep_token)

--- a/zentral/contrib/mdm/views/setup.py
+++ b/zentral/contrib/mdm/views/setup.py
@@ -5,7 +5,7 @@ from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import FileResponse, Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse, reverse_lazy
-from django.views.generic import CreateView, DeleteView, DetailView, ListView, TemplateView, UpdateView, View
+from django.views.generic import DetailView, ListView, TemplateView, View
 from zentral.contrib.mdm.crypto import generate_push_certificate_csr_der_bytes
 from zentral.contrib.mdm.dep import add_dep_token_certificate
 from zentral.contrib.mdm.forms import (CreatePushCertificateForm,
@@ -18,6 +18,7 @@ from zentral.contrib.mdm.payloads import (build_configuration_profile_response,
 from zentral.contrib.mdm.push_csr_signers import signer as push_csr_signer
 from zentral.contrib.mdm.terraform import iter_resources
 from zentral.utils.terraform import build_config_response
+from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
 
 
 logger = logging.getLogger('zentral.contrib.mdm.views.setup')
@@ -64,13 +65,13 @@ class PushCertificatesView(PermissionRequiredMixin, ListView):
     model = PushCertificate
 
 
-class UploadPushCertificateView(PermissionRequiredMixin, CreateView):
+class UploadPushCertificateView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "mdm.add_pushcertificate"
     model = PushCertificate
     form_class = PushCertificateForm
 
 
-class CreatePushCertificateView(PermissionRequiredMixin, CreateView):
+class CreatePushCertificateView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "mdm.add_pushcertificate"
     model = PushCertificate
     form_class = CreatePushCertificateForm
@@ -120,19 +121,19 @@ class PushCertificateSignedCSRView(PermissionRequiredMixin, View):
                             filename=f"push_certificate_{push_certificate.pk}_signed_csr.b64")
 
 
-class UploadPushCertificateCertificateView(PermissionRequiredMixin, UpdateView):
+class UploadPushCertificateCertificateView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_pushcertificate"
     model = PushCertificate
     form_class = PushCertificateCertificateForm
 
 
-class RenewPushCertificateView(PermissionRequiredMixin, UpdateView):
+class RenewPushCertificateView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_pushcertificate"
     model = PushCertificate
     form_class = PushCertificateForm
 
 
-class DeletePushCertificateView(PermissionRequiredMixin, DeleteView):
+class DeletePushCertificateView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "mdm.delete_pushcertificate"
     model = PushCertificate
     success_url = reverse_lazy("mdm:push_certificates")
@@ -166,7 +167,7 @@ class DownloadDEPTokenPublicKeyView(PermissionRequiredMixin, View):
                             filename=filename)
 
 
-class RenewDEPTokenView(PermissionRequiredMixin, UpdateView):
+class RenewDEPTokenView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_depvirtualserver"
     model = DEPToken
     template_name = "mdm/deptoken_renew.html"
@@ -268,7 +269,7 @@ class DEPVirtualServerView(PermissionRequiredMixin, DetailView):
         return context
 
 
-class UpdateDEPVirtualServerView(PermissionRequiredMixin, UpdateView):
+class UpdateDEPVirtualServerView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_depvirtualserver"
     model = DEPVirtualServer
     form_class = UpdateDEPVirtualServerForm
@@ -282,7 +283,7 @@ class LocationsView(PermissionRequiredMixin, ListView):
     model = Location
 
 
-class CreateLocationView(PermissionRequiredMixin, CreateView):
+class CreateLocationView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "mdm.add_location"
     model = Location
     form_class = LocationForm
@@ -293,13 +294,13 @@ class LocationView(PermissionRequiredMixin, DetailView):
     model = Location
 
 
-class UpdateLocationView(PermissionRequiredMixin, UpdateView):
+class UpdateLocationView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "mdm.change_location"
     model = Location
     form_class = LocationForm
 
 
-class DeleteLocationView(PermissionRequiredMixin, DeleteView):
+class DeleteLocationView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "mdm.delete_location"
     model = Location
     success_url = reverse_lazy("mdm:locations")


### PR DESCRIPTION
> **Stacked PR.** Merge order: #1566 → #1563 → #1564. This one targets `fix-flaky-monolith-s3-netloc`, so its diff shows only its own commits. GitHub retargets each PR to `main` automatically as the one below it merges.

## Why

The APNs push certificate, the Automated Device Enrollment token and the Apps and Books locations are what let Zentral manage and enroll devices. Replacing or deleting one is the most consequential thing an operator can do in the MDM setup views — and none of it was audited, because `AuditEvent.build` calls `serialize_for_event()` unconditionally and two of the three models had none.

Eleven views are now audited: 5 push certificate, `RenewDEPTokenView`, `UpdateDEPVirtualServerView`, `ConnectDEPVirtualServerView`, and 3 location. Two commits: the serializers plus the ten model views, then the connect flow on its own.

## What goes into the events, and what does not

**`PushCertificate`** reports the fields `PushCertificateSerializer` already exposes over the read-only HTTP API, so the API and the audit trail agree on what is publishable about a certificate — with two differences: **no private key**, and the certificate as a **SHA-256 fingerprint**.

Fingerprint rather than certificate for three reasons:

- the field is a `BinaryField`, and raw bytes in a payload are exactly the kombu-envelope bug #1556 removed — `assert_serialize_for_event_is_json_native` would fail on it
- base64 would be JSON-safe but adds a couple of KB per event with nothing readable in it
- the fingerprint answers what a renewal audit actually asks: *was the certificate replaced, or uploaded again unchanged?*

**`DEPToken`** reports the certificate fingerprint, `access_token_expiry` with the `has_expired`/`expires_soon` predicates the model already computes, and `last_synced_at`. Left out: `private_key`, `consumer_secret`, `access_secret` (secrets), plus `consumer_key` and `access_token` — the public halves of the OAuth1 credential, but there's one token per virtual server so naming them tells an auditor nothing — and `sync_cursor`, which is operational state.

The `has_expired`/`expires_soon` pair mirrors how `EnrollmentSecret` already exposes `is_revoked`/`is_expired` next to the raw timestamps, which is what makes a renewal legible in a diff.

## Two serializations that would have produced empty events

**`DEPVirtualServer`** reported only `pk`, `uuid`, `name` — but every other field is `editable=False`, so `default_enrollment` is the only thing its form can change. It now reports the default enrollment and the token, otherwise an update event would have carried a `prev_value` and `new_value` that match.

**`Location`** — with `Asset`, the only two models in the codebase whose `serialize_for_event` defaulted to `keys_only=True`. The audit machinery calls it with no argument, so every location event would have carried just `pk` and `mdm_info_id`. Both defaults now match every other model, and the two `apps_books` preprocessor callers that relied on the old default ask for `keys_only=True` explicitly — that's the entire blast radius, and `Asset` is aligned for consistency even though it isn't audited yet.

That's the fifth time in this series a serializer needed a field before auditing a view meant anything (`kwargs`, `blocked_at`, `blueprint`, `default_enrollment`, `Location`'s default). Worth treating as the default expectation rather than a surprise.

## Notes for review

**`ConnectDEPVirtualServerView` (second commit) posts its own event**, being the one setup view that isn't a model view: a plain `View` that creates a bare DEP token, keeps its id in the session while the operator downloads the public key and uploads the encrypted server token, and only then has anything worth recording.

The audited object is the **virtual server**, not the token — it's what the interface lists, what `UpdateDEPVirtualServerView` already audits, and its serialization now carries the token, so a token swap is visible without auditing the token separately.

The branch worth reviewing: `EncryptedDEPTokenForm.save()` either creates a virtual server *or*, when Zentral already knows the account, moves the new token onto the existing server and deletes the old one ([forms.py:418](zentral/contrib/mdm/forms.py:418)). Those are different things to an auditor, so the action follows — `created` for an account never seen, `updated` with the token changing for one already connected. Reporting a token replacement as `created` would have been wrong, and there's a test for each branch. Note `server_uuid` has to be read from `cleaned_data` *before* `save()`, which pops it.

**Cancelling the connect flow records nothing**, deliberately: the token it prepares up front has no credential and no server, so deleting it discards scaffolding rather than a credential. Also covered by a test.

**One test fixture surprise worth knowing:** `force_push_certificate()` without `with_material=True` stores `certificate=b"1"` and real `not_before`/`not_after` dates, so it is *not* a "no certificate yet" fixture. The genuinely uncovered state — a certificate created by `CreatePushCertificateView` before its material is uploaded — is tested with a bare `PushCertificate.objects.create(name=…)`, and every reported field survives being null there.

## Tests

3312 tests pass across `tests.mdm`, `tests.inventory`, `tests.core_events` and `tests.utils`. flake8 clean. No existing test needed changing.

- `tests/mdm/models/test_credential_models.py` — 13 tests: the fingerprint helper (including a `memoryview`, since a `BinaryField` read back from Postgres isn't always `bytes`), each serializer's exact field set, `assert_serialize_for_event_is_json_native` on all four, and explicit assertions that no private key, consumer secret, access secret, consumer key, access token or sync cursor appears in the JSON.
- `tests/mdm/test_setup_credential_audit.py` — 5 view-level tests, including the fingerprint changing across a certificate replacement, and that the DEP virtual server update produces a real `default_enrollment` transition.
- `tests/mdm/test_setup_dep_virtual_server.py` — 3 more for the connect flow: a new account, a reconnect that swaps the token (asserting the old token is gone and the event says `updated`), and a cancel that posts nothing. The first also asserts none of the decrypted OAuth material reaches the payload.

## Not verified

`mkdocs build --strict` could not be run — mkdocs is not in the container image and `pip install` fails there on venv permissions. Checked by hand: balanced fences, consistent heading nesting, all four JSON examples parse, no links or images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

