### PR TITLE
Audit the Automated Device Enrollment device changes

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -575,6 +575,14 @@ A request that would not change anything — blocking a blocked device, or unblo
 
 Note that a device can also become unblocked without an operator: a full state purge, which happens when a device re-enrolls, clears `blocked_at` along with the rest of the device state. That is not an operator action and is not audited here, so a device that appears blocked in the audit trail may since have been released by re-enrolling.
 
+### Automated Device Enrollment devices
+
+Assigning an enrollment profile to a device, and refreshing its record from Apple, are recorded with the `updated` action, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved.
+
+A refresh that Apple answers with an unknown serial number still marks the record as deleted, so it is recorded too. A profile assignment Apple refuses changes nothing and records nothing.
+
+Disowning a device has its own event, `dep_device_disowned`, rather than an audit event.
+
 ### Artifacts and blueprints
 
 Artifacts decide which profiles, apps and declarations get installed, and linking one to a blueprint deploys it to every device using that blueprint. Both are audited with the `created`, `updated` and `deleted` actions, from the web interface as well as from the HTTP API:

--- a/tests/mdm/models/test_dep_device_model.py
+++ b/tests/mdm/models/test_dep_device_model.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+from django.test import TestCase
+from tests.mdm.utils import force_dep_device
+from tests.zentral_test_utils.assertions.serialization_assertions import SerializeForEventAssertions
+
+
+class TestMDMDEPDeviceModel(TestCase, SerializeForEventAssertions):
+    maxDiff = None
+
+    def test_dep_device_serialize_for_event_keys_only(self):
+        dep_device = force_dep_device()
+        self.assertEqual(
+            dep_device.serialize_for_event(keys_only=True),
+            {"pk": dep_device.pk, "serial_number": dep_device.serial_number},
+        )
+
+    def test_dep_device_serialize_for_event(self):
+        dep_device = force_dep_device()
+        d = dep_device.serialize_for_event()
+        self.assertEqual(d["serial_number"], dep_device.serial_number)
+        self.assertEqual(d["virtual_server"]["pk"], dep_device.virtual_server.pk)
+        # every attribute a profile assignment or a refresh can change has to be reported
+        self.assertEqual(
+            set(d),
+            {"pk", "serial_number", "virtual_server", "enrollment",
+             "asset_tag", "color", "description", "device_family", "model", "os",
+             "device_assigned_by", "device_assigned_date", "last_op_type", "last_op_date",
+             "profile_status", "profile_uuid", "profile_assign_time", "profile_push_time",
+             "disowned_at", "created_at", "updated_at"},
+        )
+        self.assert_serialize_for_event_is_json_native(dep_device)
+
+    def test_dep_device_serialize_for_event_makes_the_datetimes_naive(self):
+        # dep_device_update_dict() assigns the datetimes it parses from the DEP API straight onto
+        # the model, so they are aware, while the same field read back from the database is naive
+        # because USE_TZ is off. The payload must not depend on which one it was built from.
+        dep_device = force_dep_device()
+        for profile_assign_time in (datetime(2023, 6, 17, 15, 41, 6, tzinfo=timezone.utc),
+                                    datetime(2023, 6, 17, 15, 41, 6)):
+            with self.subTest(tzinfo=profile_assign_time.tzinfo):
+                dep_device.profile_assign_time = profile_assign_time
+                self.assertEqual(dep_device.serialize_for_event()["profile_assign_time"],
+                                 "2023-06-17T15:41:06")
+
+    def test_dep_device_serialize_for_event_without_enrollment(self):
+        dep_device = force_dep_device()
+        self.assertIsNone(dep_device.enrollment)
+        self.assertIsNone(dep_device.serialize_for_event()["enrollment"])
+        self.assert_serialize_for_event_is_json_native(dep_device)

--- a/tests/mdm/test_management_dep_device.py
+++ b/tests/mdm/test_management_dep_device.py
@@ -9,6 +9,7 @@ from accounts.models import User
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.models import DEPDevice
+from zentral.core.events.base import AuditEvent
 from .utils import force_dep_device, force_dep_enrollment
 
 
@@ -258,6 +259,63 @@ class DEPDeviceManagementViewsTestCase(TestCase, LoginCase):
         client.assign_profile.assert_called_once_with(enrollment.uuid, [device.serial_number])
         client.get_devices.assert_called_once_with([device.serial_number])
 
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_profile_post_audit_event(self, from_dep_virtual_server, post_event):
+        enrollment = force_dep_enrollment(self.mbu)
+        device = force_dep_device(server=enrollment.virtual_server)
+        client = Mock()
+        client.assign_profile.return_value = {"devices": {device.serial_number: "SUCCESS"}}
+        client.get_devices.return_value = {
+            device.serial_number: {
+                "serial_number": device.serial_number,
+                "profile_status": DEPDevice.PROFILE_STATUS_ASSIGNED,
+                "profile_uuid": str(enrollment.uuid).upper().replace("-", ""),
+                "profile_assign_time": "2023-06-17T15:41:06Z",
+            }
+        }
+        from_dep_virtual_server.return_value = client
+        self.login("mdm.change_depdevice", "mdm.view_depdevice")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:assign_dep_device_profile", args=(device.pk,)),
+                {"enrollment": enrollment.pk},
+                follow=True,
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depdevice")
+        prev_value = event.payload["object"]["prev_value"]
+        new_value = event.payload["object"]["new_value"]
+        self.assertIsNone(prev_value["enrollment"])
+        self.assertEqual(new_value["enrollment"]["pk"], enrollment.pk)
+        self.assertEqual(new_value["profile_status"], DEPDevice.PROFILE_STATUS_ASSIGNED)
+        self.assertEqual(new_value["profile_assign_time"], "2023-06-17T15:41:06")
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], device.serial_number)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_profile_post_err_posts_no_event(self, from_dep_virtual_server, post_event):
+        enrollment = force_dep_enrollment(self.mbu)
+        device = force_dep_device(server=enrollment.virtual_server)
+        client = Mock()
+        client.assign_profile.return_value = {"devices": {device.serial_number: "FAILED"}}
+        from_dep_virtual_server.return_value = client
+        self.login("mdm.change_depdevice", "mdm.view_depdevice")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("mdm:assign_dep_device_profile", args=(device.pk,)),
+                {"enrollment": enrollment.pk},
+            )
+        self.assertEqual(response.status_code, 200)
+        # assign_dep_device_profile() raises before saving, so nothing changed
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
+
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
     def test_assign_profile_post_err(self, from_dep_virtual_server):
         enrollment = force_dep_enrollment(self.mbu)
@@ -336,3 +394,52 @@ class DEPDeviceManagementViewsTestCase(TestCase, LoginCase):
         device.refresh_from_db()
         self.assertFalse(device.is_deleted())
         self.assertEqual(device.model, "iPhone 14333")
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_refresh_audit_event(self, from_dep_virtual_server, post_event):
+        device = force_dep_device()
+        client = Mock()
+        client.get_devices.return_value = {
+            device.serial_number: {
+                "serial_number": device.serial_number,
+                "model": "iPhone 14333",
+                "profile_status": "empty",
+            }
+        }
+        from_dep_virtual_server.return_value = client
+        self.login("mdm.change_depdevice", "mdm.view_depdevice")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:refresh_dep_device", args=(device.pk,)), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depdevice")
+        self.assertEqual(event.payload["object"]["new_value"]["model"], "iPhone 14333")
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], device.serial_number)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_refresh_deleted_audit_event(self, from_dep_virtual_server, post_event):
+        # the failure path saves too: refresh_dep_device() marks the record deleted before it
+        # raises, so it has to be audited as well
+        client = Mock()
+        client.get_devices.return_value = {"devices": {}}
+        from_dep_virtual_server.return_value = client
+        device = force_dep_device()
+        self.assertFalse(device.is_deleted())
+        self.login("mdm.change_depdevice", "mdm.view_depdevice")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("mdm:refresh_dep_device", args=(device.pk,)), follow=True)
+        self.assertContains(response, "Could not find the device.")
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertNotEqual(event.payload["object"]["prev_value"]["last_op_type"],
+                            DEPDevice.OP_TYPE_DELETED)
+        self.assertEqual(event.payload["object"]["new_value"]["last_op_type"],
+                         DEPDevice.OP_TYPE_DELETED)

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -2114,6 +2114,20 @@ class DEPEnrollment(MDMEnrollment):
         return self.depenrollmentsession_set.count() == 0 and self.reenrollmentsession_set.count() == 0
 
 
+def _dep_device_isoformat(t):
+    """Isoformat a DEP device datetime as naive UTC.
+
+    dep_device_update_dict() assigns the datetimes it parses from the DEP API straight onto the
+    model, so they are aware, while the same field read back from the database is naive because
+    USE_TZ is off. An event payload must not depend on which of the two it was built from.
+    """
+    if t is None:
+        return None
+    if timezone.is_aware(t):
+        t = timezone.make_naive(t)
+    return t.isoformat()
+
+
 class DEPDevice(models.Model):
     PROFILE_STATUS_EMPTY = "empty"
     PROFILE_STATUS_ASSIGNED = "assigned"
@@ -2187,6 +2201,35 @@ class DEPDevice(models.Model):
 
     def get_urlsafe_serial_number(self):
         return MetaMachine(self.serial_number).get_urlsafe_serial_number()
+
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "serial_number": self.serial_number}
+        if keys_only:
+            return d
+        # every attribute dep_device_update_dict() can change, so that assigning a profile or
+        # refreshing the record from Apple shows what moved
+        d.update({
+            "virtual_server": self.virtual_server.serialize_for_event(keys_only=True),
+            "enrollment": self.enrollment.serialize_for_event(keys_only=True) if self.enrollment else None,
+            "asset_tag": self.asset_tag,
+            "color": self.color,
+            "description": self.description,
+            "device_family": self.device_family,
+            "model": self.model,
+            "os": self.os,
+            "device_assigned_by": self.device_assigned_by,
+            "device_assigned_date": _dep_device_isoformat(self.device_assigned_date),
+            "last_op_type": self.last_op_type,
+            "last_op_date": _dep_device_isoformat(self.last_op_date),
+            "profile_status": self.profile_status,
+            "profile_uuid": str(self.profile_uuid) if self.profile_uuid else None,
+            "profile_assign_time": _dep_device_isoformat(self.profile_assign_time),
+            "profile_push_time": _dep_device_isoformat(self.profile_push_time),
+            "disowned_at": _dep_device_isoformat(self.disowned_at),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
 
 
 class DEPEnrollmentSessionManager(models.Manager):

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -1689,13 +1689,18 @@ class AssignDEPDeviceProfileView(PermissionRequiredMixin, UpdateView):
     form_class = AssignDEPDeviceEnrollmentForm
 
     def form_valid(self, form):
+        prev_value = self.get_object().serialize_for_event()
         dep_device = form.save(commit=False)
         try:
             assign_dep_device_profile(dep_device, dep_device.enrollment)
         except DEPClientError as e:
+            # nothing was saved
             form.add_error(None, str(e))
             return self.form_invalid(form)
         else:
+            post_audit_event(self.request, dep_device, AuditEvent.Action.UPDATED,
+                             prev_value=prev_value,
+                             machine_serial_number=dep_device.serial_number)
             messages.info(self.request, "Profile {} successfully assigned to device {}.".format(
                 dep_device.enrollment, dep_device.serial_number
             ))
@@ -1707,10 +1712,16 @@ class RefreshDEPDeviceView(PermissionRequiredMixin, View):
 
     def post(self, request, *args, **kwargs):
         dep_device = get_object_or_404(DEPDevice, pk=kwargs["pk"])
+        prev_value = dep_device.serialize_for_event()
         try:
             refresh_dep_device(dep_device)
         except DEPClientError as error:
+            # refresh_dep_device() marks the record deleted and saves it before raising when
+            # Apple no longer knows the serial number, so this path changes it too
             messages.error(request, str(error))
         else:
             messages.info(request, "DEP device refreshed.")
+        post_audit_event(request, dep_device, AuditEvent.Action.UPDATED,
+                         prev_value=prev_value,
+                         machine_serial_number=dep_device.serial_number)
         return redirect(dep_device)


### PR DESCRIPTION
> **Stacked PR.** Merge order: #1566 → #1563 → #1564. This one targets `mdm-credential-audit-serializers`, so its diff shows only its own commits. GitHub retargets each PR to `main` automatically as the one below it merges.

## Why

Assigning an enrollment profile to an Automated Device Enrollment device, and refreshing its record from Apple, both write to the record — and neither left a trace. `DEPDevice` had no `serialize_for_event()`, so there was nothing for `AuditEvent` to carry, which is why this was the last MDM gap left after #1563.

Both events are tagged with the device serial number, so they land on the device's timeline next to its commands, blueprint changes and blocks.

## Notes for review

**Neither view could take an audit mixin, for different reasons.**

`AssignDEPDeviceProfileView.form_valid()` never calls `super().form_valid()` — the save happens inside `assign_dep_device_profile()` once Apple has accepted the assignment ([dep.py:303](zentral/contrib/mdm/dep.py:303)). Swapping its base to `UpdateViewWithAudit` would have looked correct and silently never fired. `RefreshDEPDeviceView` is a plain `View`. Both use `post_audit_event()` explicitly.

**The refresh failure path is audited on purpose.** `refresh_dep_device()` marks the record deleted and saves it *before* raising, when Apple no longer knows the serial number ([dep.py:371](zentral/contrib/mdm/dep.py:371)) — so that path changes the record as much as the success path. There's a test asserting `last_op_type` transitions to `DELETED` in the event. The *assignment* failure path is not audited: it raises before saving anything, and there's a test for that too.

**The datetimes needed normalising.** `dep_device_update_dict()` assigns the values it parses from the DEP API straight onto the model, so they're aware, while the same field read back from the database is naive because `USE_TZ` is off. The audit event is built from the in-memory instance, so serializing whichever happened to be there would have put `2023-06-17T15:41:06+00:00` and `2023-06-17T15:41:06` into the stores for the same field. A small `_dep_device_isoformat()` makes them naive first. This surfaced as a real test failure, not a hypothetical.

**`DisownDEPDevice` is deliberately untouched** — it already posts a purpose-built `dep_device_disowned` event with the serial number and full request context ([events/management.py:100](zentral/contrib/mdm/events/management.py:100)), which is the right design, the same as the machine tag events. My earlier survey listing it as a gap was an artifact of grepping only for `AuditEvent`, the same false-positive class as the Santa rules.

## What the serializer reports

Every attribute `dep_device_update_dict()` can change — enrollment, profile status/uuid/assign time/push time, the device attributes Apple reports, `last_op_type`/`last_op_date`, `disowned_at` — so a refresh shows what actually moved rather than only that a refresh happened.

## Tests

3299 tests pass across `tests.mdm`, `tests.inventory`, `tests.core_events` and `tests.utils`. flake8 clean. No existing test needed changing.

- `tests/mdm/models/test_dep_device_model.py` — 4 tests: the exact field set, `assert_serialize_for_event_is_json_native`, and the aware/naive normalisation pinned both ways.
- `tests/mdm/test_management_dep_device.py` — 4 more: the audit event on assign and on refresh (both with the serial number), plus no-event on a refused assignment and the `DELETED` transition on a refresh Apple can't answer.

## Not verified

`mkdocs build --strict` could not be run — mkdocs is not in the container image and `pip install` fails there on venv permissions. Checked by hand: balanced fences, consistent heading nesting, all JSON examples parse, no links or images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

