### PR TITLE
Attribute the APNs notifications an operator asks for

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -549,6 +549,12 @@ Commands that carry no parameters have no parameters entry at all.
 
 Assigning a device to another blueprint, or removing it from one, is recorded with the `updated` action, with the previous and the new blueprint in the event.
 
+### Poking a device
+
+Poking a device or a user sends it an APNs notification so that it checks in. It changes nothing, so there is no audit event for it — but the `mdm_device_notification` event it produces carries the request context of the operator who asked, alongside the device serial number and whether Apple accepted the notification.
+
+The notifications Zentral sends on its own, while reconciling artifacts or handling an Apps and Books notification, carry no request, which is how an operator poke can be told apart from one Zentral decided on.
+
 ### Blocking a device
 
 Blocking and unblocking a device are recorded with the `updated` action, from the *Block*/*Unblock* buttons on the device detail page as well as from the `block/` and `unblock/` HTTP API endpoints. The transition is visible in the `blocked_at` field, which is `null` when the device is not blocked:

--- a/tests/mdm/test_api_enrolled_devices_views.py
+++ b/tests/mdm/test_api_enrolled_devices_views.py
@@ -481,7 +481,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         # the push notification and the audit event
         self.assertEqual(len(callbacks), 2)
-        send_enrolled_device_notification.assert_called_once_with(self.enrolled_device)
+        send_enrolled_device_notification.assert_called_once()
+        self.assertEqual(send_enrolled_device_notification.call_args.args, (self.enrolled_device,))
+        # the operator request travels with the notification, so its event is attributable
+        self.assertEqual(send_enrolled_device_notification.call_args.kwargs["request"].method, "POST")
         self.enrolled_device.refresh_from_db()
         event = post_event.call_args_list[0].args[0]
         self.assertIsInstance(event, AuditEvent)

--- a/tests/mdm/test_management_enrolled_device.py
+++ b/tests/mdm/test_management_enrolled_device.py
@@ -1,6 +1,6 @@
 import json
 import plistlib
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import Group
 from django.test import TestCase
@@ -18,6 +18,7 @@ from zentral.contrib.mdm.models import (
     Platform,
     TargetArtifact,
 )
+from zentral.contrib.mdm.events import MDMDeviceNotificationEvent
 from zentral.core.events.base import AuditEvent
 
 from .utils import (
@@ -25,6 +26,8 @@ from .utils import (
     force_blueprint,
     force_blueprint_artifact,
     force_dep_enrollment_session,
+    force_enrolled_user,
+    force_push_certificate,
     force_ota_enrollment_session,
     force_user_enrollment_session,
 )
@@ -38,6 +41,8 @@ class EnrolledDeviceManagementViewsTestCase(TestCase, LoginCase):
         cls.user.groups.set([cls.group])
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
+        # the reduced key size the other fixtures use cannot build an SSL context
+        cls.apns_push_certificate = force_push_certificate(with_material=True, reduced_key_size=False)
 
     # LoginCase implementation
 
@@ -1820,7 +1825,10 @@ class EnrolledDeviceManagementViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "mdm/enrolleddevice_detail.html")
         # the push notification and the audit event
         self.assertEqual(len(callbacks), 2)
-        send_enrolled_device_notification.assert_called_once_with(enrolled_device)
+        send_enrolled_device_notification.assert_called_once()
+        self.assertEqual(send_enrolled_device_notification.call_args.args, (enrolled_device,))
+        # the operator request travels with the notification, so its event is attributable
+        self.assertEqual(send_enrolled_device_notification.call_args.kwargs["request"].method, "POST")
         enrolled_device.refresh_from_db()
         self.assertEqual(enrolled_device.blueprint, blueprint)
         self.assertContains(response, blueprint.name)
@@ -1836,6 +1844,71 @@ class EnrolledDeviceManagementViewsTestCase(TestCase, LoginCase):
         # get_audit_machine_serial_number(), so the change lands on the device timeline
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], enrolled_device.serial_number)
+
+    # poke
+
+    def test_poke_enrolled_device_redirect(self):
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
+        self.login_redirect("poke_enrolled_device", session.enrolled_device.pk)
+
+    def test_poke_enrolled_device_permission_denied(self):
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
+        self.login()
+        response = self.client.post(reverse("mdm:poke_enrolled_device", args=(session.enrolled_device.pk,)))
+        self.assertEqual(response.status_code, 403)
+
+    @patch("zentral.contrib.mdm.apns.httpx.Client.post")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_poke_enrolled_device_post_event_is_attributable(self, post_event, post):
+        # poking changes nothing, so the notification event is the only record of it: it has to
+        # say who asked
+        mocked_response = Mock()
+        mocked_response.status_code = 200
+        post.return_value = mocked_response
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True,
+                                                     push_certificate=self.apns_push_certificate)
+        enrolled_device = session.enrolled_device
+        self.login("mdm.change_enrolleddevice", "mdm.view_enrolleddevice")
+        response = self.client.post(reverse("mdm:poke_enrolled_device", args=(enrolled_device.pk,)),
+                                    follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Device poked!")
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, MDMDeviceNotificationEvent)
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], enrolled_device.serial_number)
+        self.assertEqual(metadata["request"]["user"]["username"], self.user.username)
+        self.assertEqual(metadata["request"]["method"], "POST")
+        self.assertEqual(metadata["request"]["view"], "mdm:poke_enrolled_device")
+
+    def test_poke_enrolled_user_redirect(self):
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
+        enrolled_user = force_enrolled_user(session.enrolled_device)
+        self.login_redirect("poke_enrolled_user", session.enrolled_device.pk, enrolled_user.pk)
+
+    @patch("zentral.contrib.mdm.apns.httpx.Client.post")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_poke_enrolled_user_post_event_is_attributable(self, post_event, post):
+        mocked_response = Mock()
+        mocked_response.status_code = 200
+        post.return_value = mocked_response
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True,
+                                                     push_certificate=self.apns_push_certificate)
+        enrolled_device = session.enrolled_device
+        enrolled_user = force_enrolled_user(enrolled_device)
+        self.login("mdm.change_enrolleduser", "mdm.view_enrolleduser")
+        response = self.client.post(
+            reverse("mdm:poke_enrolled_user", args=(enrolled_device.pk, enrolled_user.pk)),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, MDMDeviceNotificationEvent)
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], enrolled_device.serial_number)
+        self.assertEqual(metadata["request"]["user"]["username"], self.user.username)
+        self.assertEqual(metadata["request"]["view"], "mdm:poke_enrolled_user")
+        self.assertEqual(event.payload["user_id"], enrolled_user.user_id)
 
     # block
 
@@ -1881,7 +1954,10 @@ class EnrolledDeviceManagementViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "mdm/enrolleddevice_detail.html")
         # the push notification and the audit event
         self.assertEqual(len(callbacks), 2)
-        send_enrolled_device_notification.assert_called_once_with(enrolled_device)
+        send_enrolled_device_notification.assert_called_once()
+        self.assertEqual(send_enrolled_device_notification.call_args.args, (enrolled_device,))
+        # the operator request travels with the notification, so its event is attributable
+        self.assertEqual(send_enrolled_device_notification.call_args.kwargs["request"].method, "POST")
         enrolled_device.refresh_from_db()
         self.assertIsNotNone(enrolled_device.blocked_at)
         event = post_event.call_args_list[0].args[0]

--- a/zentral/contrib/mdm/api_views/enrolled_devices.py
+++ b/zentral/contrib/mdm/api_views/enrolled_devices.py
@@ -178,7 +178,9 @@ class BlockEnrolledDevice(UpdateEnrolledDeviceBlockView):
         enrolled_device.block()
         # The device is still reachable at this point: notify it so that it connects and
         # gets the 401 now, instead of staying managed until its next check-in.
-        transaction.on_commit(lambda: send_enrolled_device_notification(enrolled_device))
+        transaction.on_commit(
+            lambda: send_enrolled_device_notification(enrolled_device, request=self.request)
+        )
 
 
 class UnblockEnrolledDevice(UpdateEnrolledDeviceBlockView):

--- a/zentral/contrib/mdm/apns.py
+++ b/zentral/contrib/mdm/apns.py
@@ -112,7 +112,8 @@ apns_client_cache = SimpleLazyObject(lambda: APNSClientCache())
 # utils
 
 
-def _send_target_notification(enrolled_device, token, user_id=None, priority=10, expiration_seconds=3600):
+def _send_target_notification(enrolled_device, token, user_id=None, priority=10, expiration_seconds=3600,
+                              request=None):
     target_type = "device" if user_id is None else "user"
     target_pk = enrolled_device.pk if user_id is None else user_id
     if not enrolled_device.can_be_poked() or not token:
@@ -123,22 +124,22 @@ def _send_target_notification(enrolled_device, token, user_id=None, priority=10,
     return success, build_mdm_device_notification_event(
         enrolled_device.serial_number, enrolled_device.udid,
         priority, expiration_seconds,
-        success, user_id
+        success, user_id, request
     )
 
 
-def send_enrolled_user_notification(enrolled_user, post_event=True):
+def send_enrolled_user_notification(enrolled_user, post_event=True, request=None):
     success, event = _send_target_notification(
-        enrolled_user.enrolled_device, enrolled_user.token, enrolled_user.user_id
+        enrolled_user.enrolled_device, enrolled_user.token, enrolled_user.user_id, request=request
     )
     if post_event and event:
         event.post()
     return success, event
 
 
-def send_enrolled_device_notification(enrolled_device, post_event=True):
+def send_enrolled_device_notification(enrolled_device, post_event=True, request=None):
     success, event = _send_target_notification(
-        enrolled_device, enrolled_device.token
+        enrolled_device, enrolled_device.token, request=request
     )
     if post_event and event:
         event.post()

--- a/zentral/contrib/mdm/events/mdm.py
+++ b/zentral/contrib/mdm/events/mdm.py
@@ -1,6 +1,6 @@
 import logging
 from zentral.core.events import register_event_type
-from zentral.core.events.base import BaseEvent, EventMetadata
+from zentral.core.events.base import BaseEvent, EventMetadata, EventRequest
 
 
 logger = logging.getLogger('zentral.contrib.mdm.events.mdm')
@@ -46,8 +46,14 @@ class MDMDeviceNotificationEvent(BaseEvent):
 register_event_type(MDMDeviceNotificationEvent)
 
 
-def build_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id=None):
-    event_metadata = EventMetadata(machine_serial_number=serial_number)
+def build_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success,
+                                        user_id=None, request=None):
+    # request is only set when an operator asked for the notification, so that poking a device,
+    # which changes nothing and therefore has no audit event, is still attributable
+    event_metadata = EventMetadata(
+        machine_serial_number=serial_number,
+        request=EventRequest.build_from_request(request) if request else None,
+    )
     event_payload = {
         "udid": udid,
         "apns_priority": priority,
@@ -59,6 +65,9 @@ def build_mdm_device_notification_event(serial_number, udid, priority, expiratio
     return MDMDeviceNotificationEvent(event_metadata, event_payload)
 
 
-def post_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id=None):
-    event = build_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success, user_id)
+def post_mdm_device_notification_event(serial_number, udid, priority, expiration_seconds, success,
+                                       user_id=None, request=None):
+    event = build_mdm_device_notification_event(
+        serial_number, udid, priority, expiration_seconds, success, user_id, request
+    )
     event.post()

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -1412,7 +1412,7 @@ class PokeEnrolledDeviceView(PermissionRequiredMixin, View):
 
     def post(self, request, *args, **kwargs):
         enrolled_device = get_object_or_404(EnrolledDevice, pk=kwargs["pk"])
-        send_enrolled_device_notification(enrolled_device)
+        send_enrolled_device_notification(enrolled_device, request=request)
         messages.info(request, "Device poked!")
         return redirect(enrolled_device)
 
@@ -1428,7 +1428,9 @@ class ChangeEnrolledDeviceBlueprintView(PermissionRequiredMixin, UpdateViewWithA
     def form_valid(self, form):
         old_blueprint = EnrolledDevice.objects.get(pk=self.object.pk).blueprint
         if self.object.blueprint != old_blueprint:
-            transaction.on_commit(lambda: send_enrolled_device_notification(self.object))
+            transaction.on_commit(
+                lambda: send_enrolled_device_notification(self.object, request=self.request)
+            )
         return super().form_valid(form)
 
 
@@ -1461,7 +1463,9 @@ class BlockEnrolledDeviceView(UpdateEnrolledDeviceBlockView):
 
     def update_block_state(self, enrolled_device):
         enrolled_device.block()
-        transaction.on_commit(lambda: send_enrolled_device_notification(enrolled_device))
+        transaction.on_commit(
+            lambda: send_enrolled_device_notification(enrolled_device, request=self.request)
+        )
 
 
 class UnblockEnrolledDeviceView(UpdateEnrolledDeviceBlockView):
@@ -1548,7 +1552,7 @@ class PokeEnrolledUserView(PermissionRequiredMixin, View):
             EnrolledUser.objects.select_related("enrolled_device__push_certificate"),
             pk=kwargs["pk"]
         )
-        send_enrolled_user_notification(enrolled_user)
+        send_enrolled_user_notification(enrolled_user, request=request)
         messages.info(request, "User poked!")
         return redirect(enrolled_user)
 


### PR DESCRIPTION
## Why

Poking a device or a user changes no state, so it has no audit event — the `mdm_device_notification` event it produces is the only record that it happened. And that event was built with `EventMetadata(machine_serial_number=serial_number)` alone: it said a device was poked, and never who poked it.

## What changed

`build_mdm_device_notification_event()` takes an optional `request` and builds an `EventRequest` from it. The parameter is threaded down through `send_enrolled_device_notification()` / `send_enrolled_user_notification()` / `_send_target_notification()`.

**The request is passed from every operator entry point, not only the two poke views** — blocking a device from the web interface or the API, and changing a device's blueprint, all notify the device too. Those already have an audit event carrying the attribution, so the notification event is not the sole record there, but an event that names the request which caused the push is strictly more useful than one that doesn't, and the alternative is an inconsistency with no principle behind it.

**The engine callers deliberately pass nothing** — artifact reconciliation ([artifacts.py:1048](zentral/contrib/mdm/artifacts.py:1048)), the Apps and Books preprocessor, and the `send_device_notification` management command. So the presence of a request is what distinguishes a poke an operator asked for from one Zentral decided on by itself.

## Notes for review

**The two poke views had no tests at all** — `grep poke_enrolled_device tests/` came back empty. They now have the usual redirect and permission checks plus an attribution test each.

Those attribution tests drive the **real APNs code path** with only `httpx.Client.post` mocked, following `test_apns.py`, so the event is genuinely built and posted rather than asserted against a mocked helper. They need a full-size push certificate key: `force_push_certificate(with_material=True)` defaults to `reduced_key_size=True`, and a 512-bit key makes `create_client_ssl_context` raise `EE_KEY_TOO_SMALL`. That's built once in `setUpTestData` with a comment, since it's slow.

**Three existing assertions changed.** `send_enrolled_device_notification.assert_called_once_with(enrolled_device)` no longer matches now that the call carries `request=`. Rather than just adding the argument — the request object isn't conveniently available in those tests, since `response.wsgi_request` after `follow=True` is the redirect target, not the POST — they now assert the positional argument and that the passed request's method is `POST`, which is the property that actually matters.

The five assertions in `test_artifacts.py` are untouched: those cover the engine path, which still calls without a request.

## Tests

2611 tests pass across `tests.mdm` and `tests.core_events`. flake8 clean.

## Not verified

`mkdocs build --strict` could not be run — mkdocs is not in the container image and `pip install` fails there on venv permissions. Checked by hand: balanced fences, consistent heading nesting, JSON examples parse, no links or images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
