### PR TITLE
Stop the monolith S3 redirect tests failing on an unlucky bucket name

### DIFF
--- a/tests/monolith/test_munki_api_views.py
+++ b/tests/monolith/test_munki_api_views.py
@@ -522,13 +522,13 @@ class MonolithAPIViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         p = urlparse(response.url)
         self.assertEqual(p.scheme, "https")
-        self.assertEqual(p.netloc, "s3.amazonaws.com")
         s3_repo_kwargs = self.s3_repository.get_backend_kwargs()
+        # a DNS compatible bucket name puts the bucket in the host, not in the path
+        self.assertEqual(p.netloc, s3_repo_kwargs["bucket"] + ".s3.amazonaws.com")
         self.assertEqual(
             p.path,
             os.path.join(
                 "/",
-                s3_repo_kwargs["bucket"],
                 s3_repo_kwargs["prefix"],
                 "pkgs",
                 pkg_info.data["installer_item_location"]
@@ -586,13 +586,12 @@ class MonolithAPIViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         p = urlparse(response.url)
         self.assertEqual(p.scheme, "https")
-        self.assertEqual(p.netloc, "s3.amazonaws.com")
         s3_repo_kwargs = repository.get_backend_kwargs()
+        self.assertEqual(p.netloc, s3_repo_kwargs["bucket"] + ".s3.amazonaws.com")
         self.assertEqual(
             p.path,
             os.path.join(
                 "/",
-                s3_repo_kwargs["bucket"],
                 s3_repo_kwargs.get("prefix", ""),
                 "client_resources",
                 "yolo.zip"

--- a/tests/monolith/utils.py
+++ b/tests/monolith/utils.py
@@ -48,7 +48,12 @@ def force_repository(
     )
     if not virtual:
         kwargs = {
-            "bucket": get_random_string(12),
+            # Lowercase on purpose, which is also what S3 requires of a real bucket. boto3 picks
+            # the addressing style from the name: virtual hosted for a DNS compatible name, path
+            # style otherwise. get_random_string()'s default alphabet includes uppercase, so this
+            # used to draw a path style name in all but about one run in seven hundred, and the
+            # redirect assertions in test_munki_api_views expected that style.
+            "bucket": get_random_string(12, "abcdefghijklmnopqrstuvwxyz0123456789"),
             "region_name": "us-east1",
             "prefix": "munki_repo/",
             "access_key_id": get_random_string(20),


### PR DESCRIPTION
> **Stacked PR.** Merge order: #1566 → #1563 → #1564. This one targets `main`, so its diff shows only its own commits. GitHub retargets each PR to `main` automatically as the one below it merges.

## The flake

`force_repository()` named the test bucket with `get_random_string(12)`, whose default alphabet is letters **and uppercase** and digits.

boto3 picks the S3 addressing style from the bucket name: virtual-hosted (`bucket.s3.amazonaws.com`) when the name is DNS-compatible, path-style (`s3.amazonaws.com/bucket`) when it isn't — and an uppercase letter is what makes a name incompatible.

`test_repository_package` and `test_client_resource_redirect` both asserted the path-style host, so **they only passed when the random name happened to contain an uppercase letter**:

```
P(no uppercase in 12 chars) = (36/62)^12 = 0.00147   ->  about 1 run in 681
```

It came up on the CI run for #1564 (`qqyzjt42cn49` — all lowercase and digits), where the failure looked alarming and had nothing to do with that branch. Main was green and #1563 passed from the same base commit, consistent with a ~0.15% failure rate.

It also explains why only *one* of the two identical assertions failed: `test_client_resource_redirect` builds its own repository with its own independent random bucket, which drew an uppercase letter that run.

## The fix

The fixture now draws from lowercase and digits only — which is what S3 requires of a real bucket anyway, since AWS has mandated lowercase names in every region for years. The name is therefore always DNS-compatible and the addressing style always virtual-hosted.

The two assertions follow: the bucket is in the host and no longer in the path.

```python
self.assertEqual(p.netloc, s3_repo_kwargs["bucket"] + ".s3.amazonaws.com")
self.assertEqual(p.path, os.path.join("/", s3_repo_kwargs["prefix"], "pkgs", …))
```

The upshot is that these tests now cover the addressing style Zentral actually produces in production, rather than boto3's fallback for a bucket name that couldn't exist.

**Verified against boto3 directly** rather than from the docs:

| bucket | netloc |
|---|---|
| `qqyzjt42cn49` (the failing name) | `qqyzjt42cn49.s3.amazonaws.com` |
| `QqyzjT42cn49` | `s3.amazonaws.com` |
| `has.a.dot.name` | `s3.amazonaws.com` |

And 200 random draws of the new name all produce the virtual-hosted host.

No test asserts anything about the bucket's form and the length stays at 12, so the blast radius is limited to which addressing style boto3 chooses. All 558 monolith tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

