### PR TITLE
Stop logging the Authorization header in the JSON log records

### DIFF
--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,11 +1,21 @@
 from collections import namedtuple
 import json
 import logging
-from django.test import SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase
 from zentral.utils.logging import CustomJSONEncoder, DatadogJSONFormatter, JSONFormatter
 
 
 class LoggingTestCase(SimpleTestCase):
+    @staticmethod
+    def build_request_with_credentials():
+        return RequestFactory().get(
+            "/public/munki/job_details/",
+            HTTP_AUTHORIZATION="Bearer 8ceaf2d1a5b04e1cbf51b1c8e0e2e2f0",
+            HTTP_COOKIE="sessionid=17f16b4e10b64b8f9e0d0e0a3e5e1c2b",
+            HTTP_MDM_SIGNATURE="MIAGCSqGSIb3DQEHAqCAMIACAQExDzAN",
+            HTTP_USER_AGENT="Zentral/1.2.3",
+        )
+
     def test_custom_json_encoder(self):
         enc = CustomJSONEncoder()
         MyType = namedtuple("MyType", "un")
@@ -24,3 +34,33 @@ class LoggingTestCase(SimpleTestCase):
         msg = json.loads(fmt.format(rec))
         self.assertEqual(msg["message"], "ceci est une erreur")
         self.assertEqual(msg["status_code"], 400)
+
+    def test_json_formatter_redacts_sensitive_request_headers(self):
+        request = self.build_request_with_credentials()
+        fmt = JSONFormatter()
+        rec = logging.makeLogRecord({"msg": "Forbidden", "status_code": 403, "request": request})
+        # assert on the serialized record, to also catch a value leaked somewhere else in the payload
+        formatted = fmt.format(rec)
+        for secret in ("8ceaf2d1a5b04e1cbf51b1c8e0e2e2f0",
+                       "17f16b4e10b64b8f9e0d0e0a3e5e1c2b",
+                       "MIAGCSqGSIb3DQEHAqCAMIACAQExDzAN"):
+            self.assertNotIn(secret, formatted)
+        req = json.loads(formatted)["request"]
+        for key in ("HTTP_AUTHORIZATION", "HTTP_COOKIE", "HTTP_MDM_SIGNATURE"):
+            self.assertIn(key, req)
+            self.assertEqual(req[key], "*" * 20)
+        self.assertEqual(req["HTTP_USER_AGENT"], "Zentral/1.2.3")
+        self.assertEqual(req["PATH_INFO"], "/public/munki/job_details/")
+
+    def test_datadog_json_formatter_without_sensitive_request_headers(self):
+        request = self.build_request_with_credentials()
+        fmt = DatadogJSONFormatter()
+        rec = logging.makeLogRecord({"msg": "Forbidden", "status_code": 403, "request": request})
+        formatted = fmt.format(rec)
+        for secret in ("8ceaf2d1a5b04e1cbf51b1c8e0e2e2f0",
+                       "17f16b4e10b64b8f9e0d0e0a3e5e1c2b",
+                       "MIAGCSqGSIb3DQEHAqCAMIACAQExDzAN"):
+            self.assertNotIn(secret, formatted)
+        msg = json.loads(formatted)
+        self.assertEqual(msg["http"]["status_code"], 403)
+        self.assertEqual(msg["http"]["useragent"], "Zentral/1.2.3")

--- a/zentral/utils/logging.py
+++ b/zentral/utils/logging.py
@@ -3,6 +3,7 @@ import logging
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpRequest
 from django.http.request import split_domain_port
+from django.views.debug import get_exception_reporter_filter
 
 from zentral.utils.time import naive_utcnow
 
@@ -24,7 +25,11 @@ class JSONFormatter(logging.Formatter):
 
     @staticmethod
     def add_request(rd, request):
-        rd["request"] = request.META
+        # Django's filter redacts the values of the META keys matching API|AUTH|TOKEN|KEY|SECRET|
+        # PASS|SIGNATURE|HTTP_COOKIE, so a new credential-carrying header cannot leak by omission.
+        # The keys are kept: on a 401, "header present but rejected" vs. "header absent" is the
+        # whole diagnosis.
+        rd["request"] = get_exception_reporter_filter(request).get_safe_request_meta(request)
 
     @staticmethod
     def add_status_code(rd, status_code):


### PR DESCRIPTION
`JSONFormatter.add_request` copied the whole WSGI environ into the log record:

```python
rd["request"] = request.META
```

So any log line carrying a request also carried `HTTP_AUTHORIZATION` — Bearer API tokens, enrollment secrets, Basic `user:password` (base64 is not redaction) — plus `HTTP_COOKIE`/`CSRF_COOKIE` (a live admin session) and `HTTP_MDM_SIGNATURE`.

The reach is wider than the explicit `extra={"request": request}` call sites, because Django's `log_response` attaches the request to *every* 4xx/5xx it logs on `django.request`. A 401 from any public endpoint — MDM, munki, osquery, santa, monolith, turbo — wrote to stdout the very credential the client had just failed to authenticate with, and 401 is precisely the case where the header is present and interesting.

Only deployments that set `django.LOG_FORMATTER` to `zentral.utils.logging.JSONFormatter` are affected; the default plain-text formatter ignores `record.request`.

## The fix

Redact at the formatter — the one choke point, which also covers `log_response` — and reuse Django's `SafeExceptionReporterFilter` instead of keeping a denylist of our own:

```python
rd["request"] = get_exception_reporter_filter(request).get_safe_request_meta(request)
```

Its `hidden_settings` regex is `API|AUTH|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE`, so it catches `HTTP_AUTHORIZATION`, both cookie keys, the MDM signature, and any future `HTTP_X_ZENTRAL_API_TOKEN`-style header without anyone remembering to extend a list — the same "cannot leak by omission" property as `audit_secret_kwargs` in `mdm/commands/base.py`. It honours a deployment's `DEFAULT_EXCEPTION_REPORTER_FILTER` override, and the default instance is `lru_cache`d, so there is no per-record cost. It also drops the `wsgi.*` file objects that `CustomJSONEncoder` used to `str()` into the logs.

Two deliberate choices:

- **Redact, don't drop.** The key stays, with `********************` as its value. On a 401, "header present but rejected" vs. "header absent" is the whole diagnosis.
- **Denylist, not allowlist.** An allowlist is stricter but would silently drop the `HTTP_CF_*`, `HTTP_X_FORWARDED_*` and ALB trace headers used for debugging.

`DatadogJSONFormatter` overrides `add_request` and never copied the environ, so it was already clean — it gets a test pinning that.

## Tests

`tests/utils/test_logging.py` formats a record built from a `RequestFactory` request carrying an Authorization header, a session cookie and an MDM signature, then asserts the secrets are absent from the **serialized** JSON — asserting on the string rather than the parsed dict is what would catch a future regression leaking a value elsewhere in the payload — while the keys are still present and redacted, and `HTTP_USER_AGENT`/`PATH_INFO` survive untouched.

Verified the test fails against the old code, with the credentials in plaintext in the failure output:

```
AssertionError: '8ceaf...' unexpectedly found in '{"message": "Forbidden", ...
"HTTP_AUTHORIZATION": "Bearer 8ceaf...", "HTTP_MDM_SIGNATURE": "MIAGC...", ...}'
```

`tests.utils.test_logging` and `tests.core_terraform` (the heaviest user of `extra={"request": ...}`) pass — 53 tests. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
