### PR TITLE
Update aiohttp, cryptography and fast-uri to clear OSV findings

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiosignal==1.4.0
 amqp==5.2.0
 anyio==4.6.2.post1

--- a/constraints.txt
+++ b/constraints.txt
@@ -26,7 +26,7 @@ click-plugins==1.1.1
 click-repl==0.3.0
 clickhouse-connect==1.0.0
 coverage==7.14.0
-cryptography==48.0.1
+cryptography==50.0.0
 decorator==5.1.1
 defusedxml==0.7.1
 Django==5.2.16
@@ -89,7 +89,7 @@ microsoft-kiota-serialization-form==1.10.1
 microsoft-kiota-serialization-json==1.10.1
 microsoft-kiota-serialization-multipart==1.10.1
 microsoft-kiota-serialization-text==1.10.1
-msal==1.34.0
+msal==1.37.0
 msal-extensions==1.3.1
 msgraph-core==1.3.8
 msgraph-sdk==1.57.0
@@ -120,7 +120,7 @@ pycparser==3.0
 pycurl==7.46.0
 Pygments==2.20.0
 PyJWT==2.13.0
-pyOpenSSL==26.2.0
+pyOpenSSL==26.4.0
 pyotp==2.9.0
 pyparsing==3.2.5
 pysaml2==7.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,9 +1183,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

Clears the seven advisories currently reported by the OSV scanner. One commit per package.

| Advisory | CVSS | Package | From | Fixed in |
|---|---|---|---|---|
| [GHSA-cq5v-8q36-5273](https://osv.dev/GHSA-cq5v-8q36-5273) | 7.1 | aiohttp | 3.14.1 | 3.14.3 |
| [GHSA-mfx4-hv73-q22v](https://osv.dev/GHSA-mfx4-hv73-q22v) | 6.3 | aiohttp | 3.14.1 | 3.14.2 |
| [GHSA-mq44-7p77-q5h7](https://osv.dev/GHSA-mq44-7p77-q5h7) | 6.9 | aiohttp | 3.14.1 | 3.14.2 |
| [GHSA-g6cj-pr64-35w5](https://osv.dev/GHSA-g6cj-pr64-35w5) | 8.2 | cryptography | 48.0.1 | 50.0.0 |
| [GHSA-jwv3-5hgf-82ww](https://osv.dev/GHSA-jwv3-5hgf-82ww) | 8.7 | cryptography | 48.0.1 | 49.0.0 |
| [GHSA-m2h6-j472-rp4c](https://osv.dev/GHSA-m2h6-j472-rp4c) | 6.9 | cryptography | 48.0.1 | 49.0.0 |
| [GHSA-7p8r-x3mc-p8w7](https://osv.dev/GHSA-7p8r-x3mc-p8w7) | 7.5 | fast-uri (dev) | 3.1.4 | 3.1.5 |

## Commits

1. **Update aiohttp to 3.14.3** — patch bump, transitive dependency, requirements unchanged and still satisfied by the existing pins.
2. **Update cryptography to 50.0.0** — also moves pyOpenSSL 26.2.0 → 26.4.0, see below.
3. **Update fast-uri to 3.1.5** — transitive dev-only dependency via ajv.

## Things worth a reviewer's attention

**Two other pins move inside the cryptography commit.** They are the only packages in the tree that put a ceiling on cryptography, and moving either alone leaves `constraints.txt` unresolvable at that commit, so they cannot be split out:

| Package | From | To | Why |
|---|---|---|---|
| pyOpenSSL | 26.2.0 | 26.4.0 | 26.2.0 requires `cryptography<49`; 26.4.0 requires `>=49,<51` |
| msal | 1.34.0 | 1.37.0 | 1.34.0 requires `cryptography<49`; 1.37.0 relaxes to `<51` |

msal 1.37.0 still satisfies `azure-identity` (`msal>=1.30.0`) and `msal-extensions` (`msal>=1.29,<2`).

Rather than eyeballing the likely suspects, **every one of the 157 pinned packages was checked** for a cryptography requirement: 14 declare one, and only those two set an upper bound. One to be aware of: `celery` declares `cryptography==42.0.5` under its `auth` extra, which this project does not enable — enabling it later would conflict hard.

**cryptography crosses two major versions.** Reviewed the 49.0.0 backwards incompatible changes against this code base:

- the removed `PUBLIC_KEY_TYPES` / `PRIVATE_KEY_TYPES` / `CERTIFICATE_PRIVATE_KEY_TYPES` aliases are not used anywhere
- the ChaCha20 nonce semantics change does not apply, ChaCha20 is not used
- **X.509 parsing is stricter**: certificates with ECDSA/DSA signatures carrying encoded NULL parameters now raise `ValueError`, and certificates that were previously accepted with a deprecation warning are now rejected. This is the one I would keep an eye on, since this code base parses certificates it receives from devices rather than only ones it issues.

50.0.0 itself lists no backwards incompatible changes; it is where `GHSA-g6cj-pr64-35w5` is fixed (a Bleichenbacher-style oracle in `pkcs7_decrypt_der` error/timing behaviour).

**Intel Mac dev note:** 49.0.0 dropped x86_64 macOS wheels, so local installs on those machines now build cryptography from source.

**The lockfile change is verified against real npm.** Edited in place rather than regenerated, which keeps the diff to the single package instead of whatever else a full lock refresh would move. Confirmed with npm 10.9.8 in a `node:22-alpine` container, repo mounted read-only:

- `npm update fast-uri --package-lock-only` against the pre-bump lock produces a **byte-identical** `package-lock.json` — same three lines, nothing else
- `npm ci` installs cleanly, which validates every integrity hash in the tree against the registry
- `npm audit` goes from `1 high severity vulnerability` (GHSA-7p8r-x3mc-p8w7, "host confusion via backslash authority introducer") to **`found 0 vulnerabilities`**
- `npm run build` (webpack 5.105.4) compiles with the same 26 warnings before and after, so the asset build is unchanged

fast-uri 3.1.5 declares no dependencies and keeps the same BSD-3-Clause license, so only `version`, `resolved` and `integrity` change.

## Verification

**Python — full resolution, not just metadata reading.** All four requirements files resolved together against `constraints.txt` with pip on `python:3.14-trixie`, at each commit, so every commit on the branch is individually installable:

| State | Result |
|---|---|
| `origin/main` (baseline) | RESOLVED, 158 packages |
| commit 1 — aiohttp | RESOLVED |
| commit 2 — cryptography / pyOpenSSL / msal | RESOLVED, 158 packages |
| commit 3 — fast-uri (tip) | RESOLVED, 158 packages |

The check has teeth: an earlier version of commit 2 that bumped cryptography and pyOpenSSL but *not* msal fails with `ResolutionImpossible`, which is how the msal ceiling was found.

**npm — verified in a `node:22-alpine` container** (see above): lock regenerates byte-identically, `npm ci` clean, `npm audit` 1 high → 0, `npm run build` unchanged at 26 warnings.

Still not covered: nothing here runs the Python test suite against the new pins, which needs an image rebuild. Given the cryptography major jump and its stricter X.509 parsing, the MDM, SCEP and monolith suites are the ones to watch in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
