### PR TITLE
mdm: back off exponentially when polling for app installs

### DIFF
--- a/tests/mdm/test_installed_application_list_command.py
+++ b/tests/mdm/test_installed_application_list_command.py
@@ -4,11 +4,17 @@ from datetime import datetime
 from unittest.mock import call, patch
 
 from django.test import TestCase
+from django.utils import timezone
 from django.utils.crypto import get_random_string
 
 from zentral.contrib.inventory.models import MetaBusinessUnit, MetaMachine
 from zentral.contrib.mdm.artifacts import Target
 from zentral.contrib.mdm.commands import InstalledApplicationList
+from zentral.contrib.mdm.commands.installed_application_list import (
+    FIRST_RETRY_DELAY_SECONDS,
+    MAX_RETRIES,
+    get_retry_delay_seconds,
+)
 from zentral.contrib.mdm.commands.scheduling import _update_extra_inventory, load_command
 from zentral.contrib.mdm.models import (
     Artifact,
@@ -309,7 +315,7 @@ class InstalledApplicationListCommandTestCase(TestCase):
             target,
             artifact_version,
             kwargs={"apps_to_check": [{"Identifier": "yolo.fomo", "ShortVersion": "1.0"}],
-                    "retries": 10},
+                    "retries": MAX_RETRIES},
             queue=False,
         )
         cmd.process_response(
@@ -327,6 +333,67 @@ class InstalledApplicationListCommandTestCase(TestCase):
             [call("Artifact version %s was not found.", artifact_version.pk),
              call("Stop rescheduling %s command for artifact version %s", cmd.request_type, artifact_version.pk)]
         )
+
+    # retry delay
+
+    def test_get_retry_delay_seconds_grows(self):
+        self.assertEqual(
+            [get_retry_delay_seconds(r) for r in range(8)],
+            [15, 20, 27, 37, 50, 67, 91, 123]
+        )
+
+    def test_get_retry_delay_seconds_starts_at_first_delay(self):
+        self.assertEqual(get_retry_delay_seconds(0), FIRST_RETRY_DELAY_SECONDS)
+
+    def test_get_retry_delay_seconds_is_not_capped(self):
+        delays = [get_retry_delay_seconds(r) for r in range(MAX_RETRIES)]
+        self.assertEqual(delays, sorted(delays))
+        self.assertGreater(delays[-1], delays[-2])
+
+    def test_get_retry_delay_seconds_total_window_about_a_week(self):
+        total = sum(get_retry_delay_seconds(r) for r in range(MAX_RETRIES))
+        self.assertGreater(total, 7 * 86400)
+        self.assertLess(total, 8 * 86400)
+
+    def test_get_retry_delay_seconds_keeps_the_previous_early_cadence(self):
+        # the schedule this replaces grew linearly and stopped after 10 retries. Every check it used
+        # to make must still happen at least as early, so nothing regresses for a quick install.
+        elapsed = previous_elapsed = 0
+        for r in range(10):
+            elapsed += get_retry_delay_seconds(r)
+            previous_elapsed += FIRST_RETRY_DELAY_SECONDS * (r + 1)
+            self.assertLessEqual(elapsed, previous_elapsed)
+
+    def test_update_device_artifact_reschedule_uses_backoff_delay(self):
+        _, artifact, [artifact_version] = force_blueprint_artifact(artifact_type=Artifact.Type.ENTERPRISE_APP,
+                                                                   blueprint=self.blueprint)
+        target = Target(self.enrolled_device)
+        target.update_target_artifact(
+            artifact_version,
+            TargetArtifact.Status.AWAITING_CONFIRMATION
+        )
+        cmd = InstalledApplicationList.create_for_target(
+            target,
+            artifact_version,
+            kwargs={"apps_to_check": [{"Identifier": "yolo.fomo", "ShortVersion": "1.0"}],
+                    "retries": 6},
+            queue=False,
+        )
+        cmd.process_response(
+            {"Status": "Acknowledged",
+             "InstalledApplicationList": [
+                 {"Identifier": "yolo.fomo", "ShortVersion": "1.0", "Installing": True}
+             ]},
+            self.dep_enrollment_session,
+            self.mbu
+        )
+        db_command = DeviceCommand.objects.get(
+            enrolled_device=self.enrolled_device,
+            time__isnull=True
+        )
+        delay = (db_command.not_before - timezone.now()).total_seconds()
+        self.assertAlmostEqual(delay, get_retry_delay_seconds(6), delta=30)
+        self.assertEqual(load_command(db_command).retries, 7)
 
     def test_update_device_artifact_installing_new_command(self):
         _, artifact, [artifact_version] = force_blueprint_artifact(artifact_type=Artifact.Type.ENTERPRISE_APP,

--- a/tests/mdm/test_managed_application_list_command.py
+++ b/tests/mdm/test_managed_application_list_command.py
@@ -5,10 +5,16 @@ import plistlib
 import uuid
 from unittest.mock import patch
 from django.test import TestCase
+from django.utils import timezone
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.commands import ManagedApplicationList
 from zentral.contrib.mdm.commands.base import load_command
+from zentral.contrib.mdm.commands.managed_application_list import (
+    FIRST_RETRY_DELAY_SECONDS,
+    MAX_RETRIES,
+    get_retry_delay_seconds,
+)
 from zentral.contrib.mdm.models import (
     Artifact,
     ArtifactVersion,
@@ -377,9 +383,9 @@ class ManagedApplicationListCommandTestCase(TestCase):
             self.enrolled_device,
             artifact_version,
             kwargs={"identifiers": [store_app.location_asset.asset.bundle_id],
-                    "retries": 10}
+                    "retries": MAX_RETRIES}
         )
-        self.assertEqual(cmd.retries, 10)
+        self.assertEqual(cmd.retries, MAX_RETRIES)
         response = self._get_response(cmd, status="Installing")
         cmd.process_response(response, self.dep_enrollment_session, self.mbu)
         self.assertEqual(da_qs.count(), 1)
@@ -395,3 +401,51 @@ class ManagedApplicationListCommandTestCase(TestCase):
             time__isnull=True
         )
         self.assertEqual(dcmd_qs.count(), 0)
+
+    # retry delay
+
+    def test_get_retry_delay_seconds_grows(self):
+        self.assertEqual(
+            [get_retry_delay_seconds(r) for r in range(8)],
+            [20, 40, 80, 160, 320, 640, 1280, 2560]
+        )
+
+    def test_get_retry_delay_seconds_starts_at_first_delay(self):
+        self.assertEqual(get_retry_delay_seconds(0), FIRST_RETRY_DELAY_SECONDS)
+
+    def test_get_retry_delay_seconds_is_not_capped(self):
+        # no ceiling: the last delay is the largest one
+        delays = [get_retry_delay_seconds(r) for r in range(MAX_RETRIES)]
+        self.assertEqual(delays, sorted(delays))
+        self.assertGreater(delays[-1], delays[-2])
+
+    def test_get_retry_delay_seconds_total_window_about_a_week(self):
+        total = sum(get_retry_delay_seconds(r) for r in range(MAX_RETRIES))
+        self.assertGreater(total, 7 * 86400)
+        self.assertLess(total, 8.5 * 86400)
+
+    def test_get_retry_delay_seconds_last_gap_bounds_staleness(self):
+        # with no ceiling the last gap is what bounds how stale a status can get
+        self.assertLess(get_retry_delay_seconds(MAX_RETRIES - 1), 4 * 86400)
+
+    def test_update_device_artifact_reschedule_uses_backoff_delay(self):
+        artifact_version, store_app = self._force_store_app(
+            status=TargetArtifact.Status.AWAITING_CONFIRMATION
+        )
+        cmd = ManagedApplicationList.create_for_device(
+            self.enrolled_device,
+            artifact_version,
+            kwargs={"identifiers": [store_app.location_asset.asset.bundle_id],
+                    "retries": 5}
+        )
+        response = self._get_response(cmd, status="Installing")
+        cmd.process_response(response, self.dep_enrollment_session, self.mbu)
+        dcmd_qs = DeviceCommand.objects.filter(
+            enrolled_device=self.enrolled_device,
+            time__isnull=True
+        )
+        self.assertEqual(dcmd_qs.count(), 1)
+        db_command = dcmd_qs.first()
+        delay = (db_command.not_before - timezone.now()).total_seconds()
+        self.assertAlmostEqual(delay, get_retry_delay_seconds(5), delta=30)
+        self.assertEqual(load_command(db_command).retries, 6)

--- a/zentral/contrib/mdm/commands/installed_application_list.py
+++ b/zentral/contrib/mdm/commands/installed_application_list.py
@@ -7,6 +7,25 @@ from .base import register_command, Command
 logger = logging.getLogger("zentral.contrib.mdm.commands.installed_application_list")
 
 
+# An app install can take much longer than the install command takes to acknowledge, and a device can
+# stay unreachable for days. The previous schedule grew linearly and gave up after ~14 minutes, so a
+# slow install was never observed and the target artifact stayed at AwaitingConfirmation even though
+# the app did install, with nothing to revisit it.
+#
+# The growth factor is well below the one used for store apps: it keeps the early cadence of the
+# linear schedule it replaces — every check in the first quarter hour happens at least as early as it
+# used to — while still reaching about a week. Deliberately not shared with ManagedApplicationList:
+# enterprise apps are locally hosted packages rather than App Store downloads, so there is no reason
+# for the two to move together, and only the install check path retries at all here.
+FIRST_RETRY_DELAY_SECONDS = 15
+RETRY_DELAY_GROWTH_FACTOR = 1.35
+MAX_RETRIES = 32
+
+
+def get_retry_delay_seconds(retries):
+    return round(FIRST_RETRY_DELAY_SECONDS * RETRY_DELAY_GROWTH_FACTOR ** retries)
+
+
 class InstalledApplicationList(Command):
     request_type = "InstalledApplicationList"
     reschedule_notnow = True
@@ -87,19 +106,18 @@ class InstalledApplicationList(Command):
         else:
             if not found:
                 logger.warning("Artifact version %s was not found.", self.artifact_version.pk)
-            if self.retries >= 10:  # TODO hardcoded
+            if self.retries >= MAX_RETRIES:
                 logger.warning("Stop rescheduling %s command for artifact version %s",
                                self.request_type,
                                self.artifact_version.pk)
                 return
             # queue a new installed application list command
-            first_delay_seconds = 15  # TODO hardcoded
             self.create_for_target(
                 self.target,
                 self.artifact_version,
                 kwargs={"apps_to_check": self.apps_to_check,
                         "retries": self.retries + 1},
-                queue=True, delay=first_delay_seconds * (self.retries + 1)
+                queue=True, delay=get_retry_delay_seconds(self.retries)
             )
 
     def get_inventory_partial_tree(self):

--- a/zentral/contrib/mdm/commands/managed_application_list.py
+++ b/zentral/contrib/mdm/commands/managed_application_list.py
@@ -6,6 +6,24 @@ from .base import register_command, Command
 logger = logging.getLogger("zentral.contrib.mdm.commands.managed_application_list")
 
 
+# An app install can take much longer than the install command takes to acknowledge, and a device
+# can stay unreachable for days. Poll densely at first, since most installs complete within minutes,
+# then double the delay so the schedule spans about a week. A fixed short delay stops observing the
+# device long before a slow install finishes, which leaves the target artifact stuck at
+# AwaitingConfirmation even though the app did install, and nothing ever revisits it.
+#
+# There is no ceiling, so the last gap — half the window, with doubling — is what bounds how stale a
+# status can get. Retries are cheap because the chain stops as soon as the device reports a terminal
+# status, so only an install that never resolves walks the whole schedule.
+FIRST_RETRY_DELAY_SECONDS = 20
+RETRY_DELAY_GROWTH_FACTOR = 2
+MAX_RETRIES = 15
+
+
+def get_retry_delay_seconds(retries):
+    return FIRST_RETRY_DELAY_SECONDS * RETRY_DELAY_GROWTH_FACTOR ** retries
+
+
 class ManagedApplicationList(Command):
     request_type = "ManagedApplicationList"
     reschedule_notnow = True
@@ -70,20 +88,19 @@ class ManagedApplicationList(Command):
             logger.warning("Artifact version %s was not found on device %s.",
                            self.artifact_version.pk, self.enrolled_device.serial_number)
         if retry:
-            if self.retries >= 10:  # TODO hardcoded
+            if self.retries >= MAX_RETRIES:
                 logger.warning("Stop rescheduling %s command on device %s for artifact version %s.",
                                self.request_type,
                                self.enrolled_device.serial_number,
                                self.artifact_version.pk)
             else:
                 # queue a new managed application list command
-                delay_seconds = 15  # TODO hardcoded
                 self.create_for_target(
                     self.target,
                     self.artifact_version,
                     kwargs={"identifiers": self.identifiers,
                             "retries": self.retries + 1},
-                    queue=True, delay=delay_seconds
+                    queue=True, delay=get_retry_delay_seconds(self.retries)
                 )
 
     def command_acknowledged(self):


### PR DESCRIPTION
## Why

`ManagedApplicationList` reschedules itself while an app install is pending, but used a **fixed 15s delay with a cap of 10 retries** — so it stopped observing the device after ~2.5 minutes. Any install taking longer than that was never seen, and the `TargetArtifact` stayed at `AwaitingConfirmation` indefinitely even though the app had installed.

Large App Store apps routinely need far more than 2.5 minutes, and a device can stay unreachable for days, so the window was too short by construction. Two things make the consequence worse than a cosmetic delay:

- **It never self-corrects.** Once the command stops rescheduling, nothing re-examines that artifact, so the wrong status is permanent until something else triggers a new install.
- **The status reads as pending, not failed**, so the artifact looks like it is still progressing rather than surfacing as something to investigate.

The result is that a successful install of a large app is indistinguishable from one that never happened.

## What changed — commit 1, store apps (`ManagedApplicationList`)

```python
FIRST_RETRY_DELAY_SECONDS = 20
RETRY_DELAY_GROWTH_FACTOR = 2
MAX_RETRIES = 15


def get_retry_delay_seconds(retries):
    return FIRST_RETRY_DELAY_SECONDS * RETRY_DELAY_GROWTH_FACTOR ** retries
```

Doubling with **no ceiling**, so the schedule spans about a week: **16 checks over ~7.6 days**, versus 11 checks over 2.5 minutes.

| # | delay | at | | # | delay | at |
|---|---|---|---|---|---|---|
| 1 | — | 15s | | 9 | +42m40s | 1h25m |
| 2 | +20s | 35s | | 10 | +1h25m | 2h50m |
| 3 | +40s | 1m15s | | 11 | +2h50m | 5h41m |
| 4 | +1m20s | 2m35s | | 12 | +5h41m | 11h22m |
| 5 | +2m40s | 5m15s | | 13 | +11h22m | 22h45m |
| 6 | +5m20s | 10m35s | | 14 | +22h45m | 1.90d |
| 7 | +10m40s | 21m15s | | 15 | +1.90d | 3.79d |
| 8 | +21m20s | 42m35s | | 16 | +3.79d | **7.59d** |

Shape of the curve, and why these constants:

- **8 checks inside the first hour**, 4 inside the first 3 minutes, so a quick install is still confirmed about as fast as before.
- **No ceiling**, which keeps the schedule a single closed-form expression with no clamp. The consequence is that the last gap — half the window, with doubling — is what bounds how stale a status can get: 3.8d here.
- **The extra retries are close to free.** The chain stops as soon as the device reports a terminal status, so a normal install ends after a handful of checks; only one that never resolves walks the full schedule.
- Delays are exact integers (`20 · 2ⁿ`), so no rounding is involved.
- Both the delay and the retry cap replace inline `# TODO hardcoded` markers.

A gentler factor is available if the tail gap ever matters more than the command count: ×1.5 over 24 retries spans the same ~7.8d in 25 checks and holds the last gap to 2.6d (a third of the window) with 12 checks in the first hour. Doubling was chosen as the simpler schedule, since the extra sampling only ever applies to artifacts that never resolve.

## What changed — commit 2, enterprise apps (`InstalledApplicationList`)

Same defect: it grew the delay linearly and gave up after 10 retries, ~14 minutes.

```python
FIRST_RETRY_DELAY_SECONDS = 15
RETRY_DELAY_GROWTH_FACTOR = 1.35
MAX_RETRIES = 32
```

**Nothing is shared between the two commands, on purpose.** Enterprise apps are locally hosted packages rather than App Store downloads, so there is no reason for the two schedules to move together, and only the install-check path retries here at all — this command also collects the app inventory, which never reschedules. Beyond the retry block the two have little in common: one reads a single `Status` string per identifier, the other infers state from five download/install booleans across a key-matched list. A shared mixin would own about six lines and add more indirection than it removes.

The factor is 1.35 rather than 2 so the curve stays dense exactly where the linear one was. **Every check the old schedule made still happens at least as early:**

| check | old (linear, stops at 11) | new (×1.35) |
|---|---|---|
| 2–3 | 30s · 1m | 30s · 50s |
| 4–6 | 1m45s · 2m45s · 4m | 1m17s · 1m54s · 2m44s |
| 7–9 | 5m30s · 7m15s · 9m15s | 3m51s · 5m22s · 7m25s |
| 10–11 | 11m30s · **14m — gives up** | 10m10s · 13m53s |
| … | | continues to **7.35d** |

33 checks over 7.35 days, largest gap 1.9d (26% of the window). A test pins the early-cadence property directly, so a future tweak cannot quietly make the first quarter hour sparser than it used to be.

## Notes for the reviewer

- `first_delay_seconds = 15` in `install_application.py` is the delay before the first check and is intentionally untouched, which is why check #1 lands at 15s rather than 20s.
- Batching identifiers across artifacts is **not** a safe way to cut command volume: the command binds a single `artifact_version`, while `_update_device_artifact` loops `self.identifiers` and overwrites `ta_status` last-wins, so a batch would write one app's status onto another artifact and could also stop polling early for an app still installing. Making that safe needs an identifier→artifact_version map, which is out of scope.
- **Existing stuck artifacts are not migrated.** Re-polling them resolves the state, since where the app did install the first response reports `Managed`.

## Tests

Updated the one test pinning the old cap (`retries: 10` → `MAX_RETRIES`) and added five covering the schedule: the doubling sequence, the first delay, that it is genuinely uncapped (monotonic, last delay largest), a guard on the total window (7–8.5 days), the staleness bound (last gap under 4 days), and one asserting the rescheduled command's `not_before` reflects the backoff delay.

Both commands get the same coverage: growth sequence, first delay, genuinely uncapped, total window, and the rescheduled command's `not_before`. `InstalledApplicationList` adds the early-cadence guard described above.

```
tests.mdm.test_managed_application_list_command
tests.mdm.test_installed_application_list_command
tests.mdm.test_install_application_command
tests.mdm.test_install_enterprise_application_command .... 59 tests OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
