### PR TITLE
Sync the monolith repositories in a background task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
 ## 2026.5
 
 
+### Features
+
+#### Monolith
+
+Repository syncs now run in the background. Repositories that need more than the request timeout to sync are supported, and concurrent syncs of the same repository are prevented.
+
+
+### Backward incompatibilities
+
+#### 🧨 Monolith repository sync API endpoint
+
+`/api/monolith/repositories/<int:pk>/sync/` launches a background task instead of syncing the repository during the request. It responds with `201` and a `task_id`/`task_result_url` pair, in place of the `200 {"status": 0}` and `500 {"status": 1, "error": "…"}` responses it used to return. Poll `task_result_url` to know the outcome of the sync.
+
+
 ### Bug fixes
 
 Fixed a 500 error on bulk machine tag changes made through the API with an expiring token.
+
+Monolith repository syncs launched via the API now refresh the caches, like the ones launched in the UI already did.
 
 
 ## 2026.4

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -130,6 +130,8 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 
 During a sync, monolith will import all the available [pkginfo files](https://github.com/munki/munki/wiki/Glossary#info-file-or-pkginfo-file), their [catalogs](https://github.com/munki/munki/wiki/Glossary#catalog), categories, and make them available to the app. It will also import the icon hashes, and get a list of the client resources.
 
+The sync is carried out in the background. A task ID and a URL to poll the task status are returned.
+
 * method: POST
 * Content-Type: application/json
 * PBAC action:
@@ -146,7 +148,40 @@ curl -X POST \
 Response:
 
 ```json
-{"status": 0}
+{
+  "task_id": "b1512b8d-1e17-4181-a1c3-93a7243fddd3",
+  "task_result_url": "/api/task_result/b1512b8d-1e17-4181-a1c3-93a7243fddd3/"
+}
+```
+
+Poll the `task_result_url` until `unready` is `false`. The result of a successful sync contains the number of objects created or updated per model:
+
+```json
+{
+  "name": "zentral.contrib.monolith.tasks.sync_repository_task",
+  "id": "b1512b8d-1e17-4181-a1c3-93a7243fddd3",
+  "status": "SUCCESS",
+  "unready": false,
+  "result": {
+    "repository": {"pk": 1, "name": "Main repository"},
+    "operations": {
+      "catalog": {"created": 1},
+      "manifest": {"updated": 2},
+      "pkginfo": {"created": 12, "updated": 3},
+      "pkginfoname": {"created": 5}
+    },
+    "status": "SUCCESS"
+  }
+}
+```
+
+Only one sync runs at a time for a given repository. If a sync is already in progress, the task returns immediately with a `SKIPPED` status, and no second sync is carried out:
+
+```json
+{
+  "repository": {"pk": 1, "name": "Main repository"},
+  "status": "SKIPPED"
+}
 ```
 
 ### /api/monolith/manifests/

--- a/tests/monolith/test_api_views.py
+++ b/tests/monolith/test_api_views.py
@@ -1,4 +1,5 @@
 import plistlib
+import uuid
 from unittest.mock import patch
 
 from django.contrib.auth.models import Group
@@ -21,8 +22,6 @@ from zentral.contrib.monolith.models import (
     Manifest,
     ManifestCatalog,
     ManifestSubManifest,
-    PkgInfo,
-    PkgInfoName,
     Repository,
     SubManifest,
     SubManifestPkgInfo,
@@ -750,76 +749,44 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.post(reverse("monolith_api:sync_repository", args=(repository.pk,)), {})
         self.assertEqual(response.status_code, 403)
 
-    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.sync_catalogs")
-    def test_sync_repository_internal_server_error(self, sync_catalogs):
-        sync_catalogs.side_effect = Exception("yolo")
+    @patch("zentral.contrib.monolith.tasks.sync_repository_task.apply_async")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_sync_repository(self, post_event, apply_async):
+        task_id = uuid.uuid4()
+        apply_async.return_value.id = task_id
         repository = force_repository()
         self.set_permissions("monolith.sync_repository")
         response = self.post(reverse("monolith_api:sync_repository", args=(repository.pk,)), {})
-        self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.json(), {"status": 1, "error": "yolo"})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json(),
+            {"task_id": str(task_id),
+             "task_result_url": f"/api/task_result/{task_id}/"}
+        )
+        task_args, task_kwargs = apply_async.call_args.args
+        self.assertEqual(task_args, (repository.pk,))
+        # the task carries the request, so that the audit events stay linked to the caller
+        self.assertEqual(task_kwargs["task_user"], self.service_account.pk)
+        self.assertEqual(
+            task_kwargs["serialized_event_request"]["user"]["username"],
+            self.service_account.username
+        )
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, MonolithSyncCatalogsRequestEvent)
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"monolith_repository": [str(repository.pk)]})
 
+    @patch("zentral.contrib.monolith.tasks.sync_repository_task.apply_async")
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_all_catalog_content")
-    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_icon_hashes_content")
-    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.iter_client_resources")
-    def test_sync_repository(
-        self,
-        iter_client_resources,
-        get_icon_hashes_content,
-        get_all_catalog_content,
-        post_event
-    ):
+    def test_sync_repository_session_authentication(self, post_event, apply_async):
+        apply_async.return_value.id = uuid.uuid4()
         repository = force_repository()
-        catalog_name = get_random_string(12)
-        pkg_info_name = get_random_string(12)
-        iter_client_resources.return_value = ["site_default.zip",]
-        get_icon_hashes_content.return_value = plistlib.dumps({
-            f"{pkg_info_name}.png": "a" * 64
-        })
-        get_all_catalog_content.return_value = plistlib.dumps([
-            {"catalogs": [catalog_name],
-             "name": pkg_info_name,
-             "version": "1.0"}
-        ])
-        self.set_permissions("monolith.sync_repository")
-        with self.captureOnCommitCallbacks(execute=True) as callbacks:
-            response = self.post(reverse("monolith_api:sync_repository", args=(repository.pk,)), {})
-        self.assertEqual(response.status_code, 200)
-        json_response = response.json()
-        self.assertEqual(json_response, {"status": 0})
-        pkg_infos = PkgInfo.objects.filter(name__name=pkg_info_name)
-        self.assertEqual(pkg_infos.count(), 1)
-        pkg_info = pkg_infos.first()
-        self.assertEqual(pkg_info.repository, repository)
-        self.assertEqual(list(c.name for c in pkg_info.catalogs.filter(repository=repository)),
-                         [catalog_name])
-        repository.refresh_from_db()
-        self.assertEqual(repository.client_resources, ["site_default.zip"])
-        self.assertEqual(repository.icon_hashes, {f"icon.{pkg_info.pk}.{pkg_info_name}.png": "a" * 64})
-        self.assertEqual(len(callbacks), 1)
-        self.assertEqual(len(post_event.call_args_list), 4)
-        mscr_evt = post_event.call_args_list[0].args[0]
-        self.assertIsInstance(mscr_evt, MonolithSyncCatalogsRequestEvent)
-        mca_evt = post_event.call_args_list[1].args[0]
-        self.assertIsInstance(mca_evt, AuditEvent)
-        self.assertEqual(mca_evt.payload["action"], "created")
-        self.assertEqual(mca_evt.payload["object"]["model"], "monolith.catalog")
-        self.assertEqual(mca_evt.payload["object"]["pk"],
-                         str(Catalog.objects.get(name=catalog_name).pk))
-        mpina_evt = post_event.call_args_list[2].args[0]
-        self.assertIsInstance(mpina_evt, AuditEvent)
-        self.assertEqual(mpina_evt.payload["action"], "created")
-        self.assertEqual(mpina_evt.payload["object"]["model"], "monolith.pkginfoname")
-        self.assertEqual(mpina_evt.payload["object"]["pk"],
-                         str(PkgInfoName.objects.get(name=pkg_info_name).pk))
-        mpia_evt = post_event.call_args_list[3].args[0]
-        self.assertIsInstance(mpia_evt, AuditEvent)
-        self.assertEqual(mpia_evt.payload["action"], "created")
-        self.assertEqual(mpia_evt.payload["object"]["model"], "monolith.pkginfo")
-        self.assertEqual(mpia_evt.payload["object"]["pk"],
-                         str(PkgInfo.objects.get(name__name=pkg_info_name,
-                                                 version="1.0").pk))
+        self.login("monolith.sync_repository")
+        response = self.client.post(reverse("monolith_api:sync_repository", args=(repository.pk,)))
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(sorted(response.json().keys()), ["task_id", "task_result_url"])
+        _, task_kwargs = apply_async.call_args.args
+        self.assertEqual(task_kwargs["task_user"], self.user.pk)
 
     # update cache server
 

--- a/tests/monolith/test_repositories.py
+++ b/tests/monolith/test_repositories.py
@@ -61,7 +61,7 @@ class MonolithRepositoriesTestCase(TestCase):
               "version": "3.0",
               "yolo": now}]
         )
-        repository.sync_catalogs(audit_callback)
+        repository.sync_catalogs()
         pkg_info = PkgInfo.objects.get(name__name=name, version="3.0")
         pin = PkgInfoName.objects.get(name=name)
         category = PkgInfoCategory.objects.get(repository=db_repository, name=category_name)
@@ -98,7 +98,7 @@ class MonolithRepositoriesTestCase(TestCase):
             [{"name": get_random_string(12),
               "version": "1.0"}]
         )
-        repository.sync_catalogs(audit_callback)
+        repository.sync_catalogs()
         self.assertEqual(len(audit_callback.call_args_list), 0)
 
     @patch("zentral.contrib.monolith.repository_backends.base.SyncEventManager.audit_callback")
@@ -118,7 +118,7 @@ class MonolithRepositoriesTestCase(TestCase):
               "name": pkg_info.name.name,
               "version": "1.0"}]
         )
-        repository.sync_catalogs(audit_callback)
+        repository.sync_catalogs()
         self.assertEqual(
             audit_callback.call_args_list,
             [call(new_catalog, AuditEvent.Action.UPDATED, nc_prev_value),
@@ -149,7 +149,7 @@ class MonolithRepositoriesTestCase(TestCase):
               "name": new_name,
               "version": "3.0"}]
         )
-        repository.sync_catalogs(audit_callback)
+        repository.sync_catalogs()
         pkg_info = PkgInfo.objects.get(name__name=new_name, version="3.0")
         self.assertEqual(
             audit_callback.call_args_list,
@@ -183,7 +183,7 @@ class MonolithRepositoriesTestCase(TestCase):
               "name": pkg_info_to_unarchive.name.name,
               "version": pkg_info_to_unarchive.version}]
         )
-        repository.sync_catalogs(audit_callback)
+        repository.sync_catalogs()
         # pkg_info_to_unarchive archived at is None, because present in the catalog
         pkg_info_to_unarchive.refresh_from_db()
         self.assertIsNone(pkg_info_to_unarchive.archived_at)

--- a/tests/monolith/test_setup_views.py
+++ b/tests/monolith/test_setup_views.py
@@ -14,7 +14,6 @@ from django.utils.text import slugify
 from tests.utils.packages import build_dummy_package
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit, Tag
-from zentral.contrib.monolith.events import MonolithSyncCatalogsRequestEvent
 from zentral.contrib.monolith.models import (
     Catalog,
     Condition,
@@ -398,7 +397,7 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, repository.get_backend_kwargs()["secret_access_key"])
         self.assertContains(response, reverse("monolith:update_repository", args=(repository.pk,)))
         self.assertContains(response, reverse("monolith:delete_repository", args=(repository.pk,)))
-        self.assertContains(response, reverse("monolith:sync_repository", args=(repository.pk,)))
+        self.assertContains(response, reverse("monolith_api:sync_repository", args=(repository.pk,)))
 
     def test_provisioned_repository_get_sync_only_no_secrets(self):
         repository = force_repository(provisioning_uid=get_random_string(12))
@@ -415,7 +414,7 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertNotContains(response, repository.get_backend_kwargs()["secret_access_key"])
         self.assertNotContains(response, reverse("monolith:update_repository", args=(repository.pk,)))
         self.assertNotContains(response, reverse("monolith:delete_repository", args=(repository.pk,)))
-        self.assertContains(response, reverse("monolith:sync_repository", args=(repository.pk,)))
+        self.assertContains(response, reverse("monolith_api:sync_repository", args=(repository.pk,)))
 
     def test_repository_get_no_links(self):
         repository = force_repository()
@@ -426,7 +425,7 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, repository.name)
         self.assertNotContains(response, reverse("monolith:update_repository", args=(repository.pk,)))
         self.assertNotContains(response, reverse("monolith:delete_repository", args=(repository.pk,)))
-        self.assertNotContains(response, reverse("monolith:sync_repository", args=(repository.pk,)))
+        self.assertNotContains(response, reverse("monolith_api:sync_repository", args=(repository.pk,)))
 
     def test_repository_get_update_only(self):
         repository = force_repository()
@@ -437,7 +436,7 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, repository.name)
         self.assertContains(response, reverse("monolith:update_repository", args=(repository.pk,)))
         self.assertNotContains(response, reverse("monolith:delete_repository", args=(repository.pk,)))
-        self.assertNotContains(response, reverse("monolith:sync_repository", args=(repository.pk,)))
+        self.assertNotContains(response, reverse("monolith_api:sync_repository", args=(repository.pk,)))
 
     def test_repository_get_delete_only(self):
         repository = force_repository()
@@ -448,7 +447,7 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, repository.name)
         self.assertNotContains(response, reverse("monolith:update_repository", args=(repository.pk,)))
         self.assertContains(response, reverse("monolith:delete_repository", args=(repository.pk,)))
-        self.assertNotContains(response, reverse("monolith:sync_repository", args=(repository.pk,)))
+        self.assertNotContains(response, reverse("monolith_api:sync_repository", args=(repository.pk,)))
 
     # update repository
 
@@ -727,60 +726,6 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertEqual(metadata["objects"], {"monolith_repository": [str(repository.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["monolith", "zentral"])
         send_notification.assert_called_once_with("monolith.repository", str(repository.pk))
-
-    # sync repository
-
-    def test_sync_repository_redirect(self):
-        repository = force_repository()
-        self.login_redirect("sync_repository", repository.pk)
-
-    def test_sync_repository_permission_denied(self):
-        repository = force_repository()
-        self.login("monolith.change_repository")
-        response = self.client.get(reverse("monolith:sync_repository", args=(repository.pk,)))
-        self.assertEqual(response.status_code, 403)
-
-    @patch("base.notifier.Notifier.send_notification")
-    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    @patch("zentral.contrib.monolith.views.load_repository_backend")
-    def test_sync_repository(self, load_repository_backend, post_event, send_notification):
-        repository = force_repository()
-        self.login("monolith.sync_repository", "monolith.view_repository")
-        with self.captureOnCommitCallbacks(execute=True) as callbacks:
-            response = self.client.post(reverse("monolith:sync_repository", args=(repository.pk,)), follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(callbacks), 1)
-        self.assertTemplateUsed(response, "monolith/repository_detail.html")
-        self.assertContains(response, repository.name)
-        self.assertContains(response, "Repository synced")
-        event = post_event.call_args_list[0].args[0]
-        self.assertIsInstance(event, MonolithSyncCatalogsRequestEvent)
-        metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"monolith_repository": [str(repository.pk)]})
-        self.assertEqual(sorted(metadata["tags"]), ["monolith", "zentral"])
-        send_notification.assert_called_once_with("monolith.repository", str(repository.pk))
-
-    @patch("base.notifier.Notifier.send_notification")
-    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    @patch("zentral.contrib.monolith.views.load_repository_backend")
-    def test_sync_repository_error(self, load_repository_backend, post_event, send_notification):
-        load_repository_backend.return_value.sync_catalogs.side_effect = ValueError("YoLoFoMo")
-        repository = force_repository()
-        self.login("monolith.sync_repository", "monolith.view_repository")
-        with self.captureOnCommitCallbacks(execute=True) as callbacks:
-            response = self.client.post(reverse("monolith:sync_repository", args=(repository.pk,)), follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(callbacks), 0)
-        self.assertTemplateUsed(response, "monolith/repository_detail.html")
-        self.assertContains(response, repository.name)
-        self.assertNotContains(response, "Repository synced")
-        self.assertContains(response, "Could not sync repository: YoLoFoMo")
-        event = post_event.call_args_list[0].args[0]
-        self.assertIsInstance(event, MonolithSyncCatalogsRequestEvent)
-        metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"monolith_repository": [str(repository.pk)]})
-        self.assertEqual(sorted(metadata["tags"]), ["monolith", "zentral"])
-        send_notification.assert_not_called()
 
     # pkg infos
 

--- a/tests/monolith/test_sync_monolith_repositories_cmd.py
+++ b/tests/monolith/test_sync_monolith_repositories_cmd.py
@@ -1,7 +1,9 @@
 from io import StringIO
 from unittest.mock import patch
 from django.core.management import call_command
+from django.db import connections
 from django.test import TestCase
+from zentral.contrib.monolith.tasks import SYNC_REPOSITORY_LOCK_ID
 from .utils import force_repository
 
 
@@ -42,6 +44,23 @@ class SyncMonolithRepositoriesTestCase(TestCase):
         sync_catalogs.assert_called_once()
         self.assertEqual(len(callbacks), 1)
         send_notification.assert_called_once_with("monolith.repository", str(repository.pk))
+
+    @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
+    @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")
+    def test_sync_already_running(self, sync_catalogs, send_notification):
+        repository = force_repository()
+        # a second connection is required: advisory locks are only conflicting between sessions
+        lock_connection = connections.create_connection("default")
+        with lock_connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_lock(%s, %s)", [SYNC_REPOSITORY_LOCK_ID, repository.pk])
+        self.addCleanup(lock_connection.close)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            stdout, stderr = self.call_command()
+        self.assertEqual(stdout, f"Sync {repository.name} repository\n")
+        self.assertEqual(stderr, f"Could not sync {repository.name}: a sync is already running\n")
+        sync_catalogs.assert_not_called()
+        self.assertEqual(len(callbacks), 0)
+        send_notification.assert_not_called()
 
     @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
     @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")

--- a/tests/monolith/test_tasks.py
+++ b/tests/monolith/test_tasks.py
@@ -1,0 +1,174 @@
+import plistlib
+from unittest.mock import patch
+
+from django.db import connections
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from zentral.contrib.monolith.models import Catalog, PkgInfo, PkgInfoName
+from zentral.contrib.monolith.tasks import SYNC_REPOSITORY_LOCK_ID, sync_repository_task
+from zentral.core.events.base import AuditEvent
+
+from .utils import force_repository
+
+
+class MonolithTasksTestCase(TestCase):
+    maxDiff = None
+
+    # utility methods
+
+    def _mock_repository_content(self, iter_client_resources, get_icon_hashes_content, get_all_catalog_content):
+        catalog_name = get_random_string(12)
+        pkg_info_name = get_random_string(12)
+        iter_client_resources.return_value = ["site_default.zip",]
+        get_icon_hashes_content.return_value = plistlib.dumps({
+            f"{pkg_info_name}.png": "a" * 64
+        })
+        get_all_catalog_content.return_value = plistlib.dumps([
+            {"catalogs": [catalog_name],
+             "name": pkg_info_name,
+             "version": "1.0"}
+        ])
+        return catalog_name, pkg_info_name
+
+    def _hold_sync_lock(self, repository):
+        # a second connection is required: advisory locks are only conflicting between sessions
+        lock_connection = connections.create_connection("default")
+        with lock_connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_lock(%s, %s)", [SYNC_REPOSITORY_LOCK_ID, repository.pk])
+        self.addCleanup(lock_connection.close)
+
+    # sync repository task
+
+    @patch("base.notifier.Notifier.send_notification")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_all_catalog_content")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_icon_hashes_content")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.iter_client_resources")
+    def test_sync_repository_task(
+        self,
+        iter_client_resources,
+        get_icon_hashes_content,
+        get_all_catalog_content,
+        post_event,
+        send_notification
+    ):
+        repository = force_repository()
+        catalog_name, pkg_info_name = self._mock_repository_content(
+            iter_client_resources, get_icon_hashes_content, get_all_catalog_content
+        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            result = sync_repository_task(repository.pk)
+        self.assertEqual(
+            result,
+            {"repository": {"pk": repository.pk, "name": repository.name},
+             "operations": {"catalog": {"created": 1},
+                            "pkginfoname": {"created": 1},
+                            "pkginfo": {"created": 1}},
+             "status": "SUCCESS"}
+        )
+        pkg_infos = PkgInfo.objects.filter(name__name=pkg_info_name)
+        self.assertEqual(pkg_infos.count(), 1)
+        pkg_info = pkg_infos.first()
+        self.assertEqual(pkg_info.repository, repository)
+        self.assertEqual(list(c.name for c in pkg_info.catalogs.filter(repository=repository)),
+                         [catalog_name])
+        repository.refresh_from_db()
+        self.assertEqual(repository.client_resources, ["site_default.zip"])
+        self.assertEqual(repository.icon_hashes, {f"icon.{pkg_info.pk}.{pkg_info_name}.png": "a" * 64})
+        self.assertEqual(len(callbacks), 1)
+        self.assertEqual(len(post_event.call_args_list), 3)
+        mca_evt = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(mca_evt, AuditEvent)
+        self.assertEqual(mca_evt.payload["action"], "created")
+        self.assertEqual(mca_evt.payload["object"]["model"], "monolith.catalog")
+        self.assertEqual(mca_evt.payload["object"]["pk"],
+                         str(Catalog.objects.get(name=catalog_name).pk))
+        mpina_evt = post_event.call_args_list[1].args[0]
+        self.assertIsInstance(mpina_evt, AuditEvent)
+        self.assertEqual(mpina_evt.payload["action"], "created")
+        self.assertEqual(mpina_evt.payload["object"]["model"], "monolith.pkginfoname")
+        self.assertEqual(mpina_evt.payload["object"]["pk"],
+                         str(PkgInfoName.objects.get(name=pkg_info_name).pk))
+        mpia_evt = post_event.call_args_list[2].args[0]
+        self.assertIsInstance(mpia_evt, AuditEvent)
+        self.assertEqual(mpia_evt.payload["action"], "created")
+        self.assertEqual(mpia_evt.payload["object"]["model"], "monolith.pkginfo")
+        self.assertEqual(mpia_evt.payload["object"]["pk"], str(pkg_info.pk))
+        send_notification.assert_called_once_with("monolith.repository", str(repository.pk))
+
+    @patch("base.notifier.Notifier.send_notification")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_all_catalog_content")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_icon_hashes_content")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.iter_client_resources")
+    def test_sync_repository_task_serialized_event_request(
+        self,
+        iter_client_resources,
+        get_icon_hashes_content,
+        get_all_catalog_content,
+        post_event,
+        send_notification
+    ):
+        repository = force_repository()
+        self._mock_repository_content(
+            iter_client_resources, get_icon_hashes_content, get_all_catalog_content
+        )
+        username = get_random_string(12)
+        serialized_event_request = {
+            "user_agent": "Zentral/tests",
+            "ip": "127.0.0.1",
+            "method": "POST",
+            "path": f"/api/monolith/repositories/{repository.pk}/sync/",
+            "view": "monolith_api:sync_repository",
+            "user": {"id": 42, "username": username},
+        }
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_repository_task(repository.pk, serialized_event_request)
+        self.assertEqual(result["status"], "SUCCESS")
+        for call in post_event.call_args_list:
+            metadata = call.args[0].metadata.serialize()
+            self.assertEqual(metadata["request"]["user"]["username"], username)
+            self.assertEqual(metadata["request"]["ip"], "127.0.0.1")
+
+    @patch("base.notifier.Notifier.send_notification")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_all_catalog_content")
+    def test_sync_repository_task_skipped(self, get_all_catalog_content, post_event, send_notification):
+        repository = force_repository()
+        self._hold_sync_lock(repository)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            result = sync_repository_task(repository.pk)
+        self.assertEqual(
+            result,
+            {"repository": {"pk": repository.pk, "name": repository.name},
+             "status": "SKIPPED"}
+        )
+        get_all_catalog_content.assert_not_called()
+        self.assertEqual(PkgInfo.objects.filter(repository=repository).count(), 0)
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
+        send_notification.assert_not_called()
+
+    @patch("base.notifier.Notifier.send_notification")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_all_catalog_content")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.get_icon_hashes_content")
+    @patch("zentral.contrib.monolith.repository_backends.s3.S3Repository.iter_client_resources")
+    def test_sync_repository_task_lock_is_per_repository(
+        self,
+        iter_client_resources,
+        get_icon_hashes_content,
+        get_all_catalog_content,
+        post_event,
+        send_notification
+    ):
+        self._hold_sync_lock(force_repository())
+        repository = force_repository()
+        self._mock_repository_content(
+            iter_client_resources, get_icon_hashes_content, get_all_catalog_content
+        )
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_repository_task(repository.pk)
+        self.assertEqual(result["status"], "SUCCESS")
+        send_notification.assert_called_once_with("monolith.repository", str(repository.pk))

--- a/zentral/contrib/monolith/api_views.py
+++ b/zentral/contrib/monolith/api_views.py
@@ -2,6 +2,7 @@ import logging
 
 from accounts.api_authentication import APITokenAuthentication
 from base.notifier import notifier
+from base.serializers import TaskSerializer
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
@@ -13,6 +14,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
 from rest_framework.views import APIView
 
+from zentral.core.events.base import EventRequest
 from zentral.utils.drf import (
     DefaultDjangoModelPermissions,
     DjangoPermissionRequired,
@@ -36,7 +38,6 @@ from .models import (
     SubManifest,
     SubManifestPkgInfo,
 )
-from .repository_backends import load_repository_backend
 from .serializers import (
     CatalogSerializer,
     ConditionSerializer,
@@ -49,6 +50,7 @@ from .serializers import (
     SubManifestPkgInfoSerializer,
     SubManifestSerializer,
 )
+from .tasks import sync_repository_task
 from .utils import build_configuration_plist, build_configuration_profile
 
 logger = logging.getLogger("zentral.contrib.monolith.api_views")
@@ -89,28 +91,22 @@ class UpdateCacheServer(APIView):
 # repositories
 
 
-class SyncRepository(APIView):
+class SyncRepository(generics.GenericAPIView):
+    authentication_classes = [APITokenAuthentication, SessionAuthentication]
     permission_required = "monolith.sync_repository"
     permission_classes = [DjangoPermissionRequired]
+    serializer_class = TaskSerializer
 
     def post(self, request, *args, **kwargs):
         db_repository = get_object_or_404(Repository, pk=kwargs["pk"])
         post_monolith_sync_catalogs_request(request, db_repository)
-        repository = load_repository_backend(db_repository)
-        error = None
-        status_code = status.HTTP_200_OK
-        try:
-            repository.sync_catalogs(request)
-        except Exception as e:
-            logger.exception("Could not sync repository %s", db_repository.pk)
-            error = str(e)
-            status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-        response = {
-            "status": 0 if error is None else 1,
-        }
-        if error:
-            response["error"] = error
-        return Response(response, status=status_code)
+        task = sync_repository_task.apply_async(
+            (db_repository.pk,),
+            {"serialized_event_request": EventRequest.build_from_request(request).serialize(),
+             "task_user": request.user.id}
+        )
+        serializer = self.serializer_class.from_task(task=task)
+        return Response(serializer.initial_data, status=status.HTTP_201_CREATED)
 
 
 class RepositoryList(ListCreateAPIViewWithAudit):

--- a/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
+++ b/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from base.notifier import notifier
 from zentral.contrib.monolith.models import Repository
 from zentral.contrib.monolith.repository_backends import load_repository_backend
+from zentral.contrib.monolith.tasks import try_lock_repository_sync
 from zentral.core.queues import queues
 
 
@@ -19,6 +20,9 @@ class Command(BaseCommand):
             for db_repository in Repository.objects.all():
                 repository = load_repository_backend(db_repository)
                 self.write(f"Sync {repository.name} repository")
+                if not try_lock_repository_sync(db_repository.pk):
+                    self.stderr.write(f"Could not sync {repository.name}: a sync is already running")
+                    continue
                 try:
                     repository.sync_catalogs()
                 except Exception as e:

--- a/zentral/contrib/monolith/repository_backends/base.py
+++ b/zentral/contrib/monolith/repository_backends/base.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import plistlib
 import uuid
+from collections import Counter, defaultdict
 from datetime import datetime
 
 from django.db import transaction
@@ -16,12 +17,15 @@ logger = logging.getLogger('zentral.contrib.monolith.repository_backends.base')
 
 
 class SyncEventManager:
-    def __init__(self, repository, request=None):
+    def __init__(self, repository, serialized_event_request=None):
         self.repository_pk = repository.pk
-        self.event_request = EventRequest.build_from_request(request) if request else None
+        self.event_request = (
+            EventRequest.deserialize(serialized_event_request) if serialized_event_request else None
+        )
         self.events = []
         self.event_uuid = uuid.uuid4()
         self.event_index = 0
+        self.operations = defaultdict(Counter)
 
     def audit_callback(self, instance, action, prev_value=None):
         event = AuditEvent.build(
@@ -32,6 +36,10 @@ class SyncEventManager:
         event.metadata.add_objects({"monolith_repository": ((self.repository_pk,),)})
         self.events.append(event)
         self.event_index += 1
+        self.operations[instance._meta.model_name][action.value] += 1
+
+    def serialize_operations(self):
+        return {model_name: dict(counter) for model_name, counter in self.operations.items()}
 
     def post_events(self):
         for event in self.events:
@@ -226,9 +234,9 @@ class BaseRepository:
         manifest.bump_version()
         audit_callback(manifest, AuditEvent.Action.UPDATED, prev_value)
 
-    def sync_catalogs(self, event_request=None):
+    def sync_catalogs(self, serialized_event_request=None):
         # initialize sync event manager
-        sync_event_manager = SyncEventManager(self.repository, event_request)
+        sync_event_manager = SyncEventManager(self.repository, serialized_event_request)
         audit_callback = sync_event_manager.audit_callback
 
         found_pkg_info_pks = set([])
@@ -273,6 +281,8 @@ class BaseRepository:
 
         # post events
         transaction.on_commit(lambda: sync_event_manager.post_events())
+
+        return sync_event_manager.serialize_operations()
 
     # to implement in the subclasses
 

--- a/zentral/contrib/monolith/repository_backends/virtual.py
+++ b/zentral/contrib/monolith/repository_backends/virtual.py
@@ -9,9 +9,9 @@ logger = logging.getLogger("zentral.contrib.monolith.repository_backends.virtual
 
 
 class VirtualRepository(BaseRepository):
-    def sync_catalogs(self, audit_callback=None):
+    def sync_catalogs(self, serialized_event_request=None):
         # NOOP
-        return
+        return {}
 
     @cached_property
     def _file_storage(self):

--- a/zentral/contrib/monolith/tasks.py
+++ b/zentral/contrib/monolith/tasks.py
@@ -1,0 +1,41 @@
+import logging
+
+from celery import shared_task
+from django.db import connection, transaction
+
+from base.notifier import notifier
+
+from .models import Repository
+from .repository_backends import load_repository_backend
+
+
+logger = logging.getLogger("zentral.contrib.monolith.tasks")
+
+
+# must not collide with the other advisory lock IDs, see zentral.contrib.mdm.dep
+SYNC_REPOSITORY_LOCK_ID = 24681012
+
+
+def try_lock_repository_sync(repository_pk):
+    # transaction scoped: released on commit, on rollback, and if the connection dies
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_try_advisory_xact_lock(%s, %s)",
+                       [SYNC_REPOSITORY_LOCK_ID, repository_pk])
+        return cursor.fetchone()[0]
+
+
+@shared_task
+def sync_repository_task(repository_pk, serialized_event_request=None, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
+    db_repository = Repository.objects.get(pk=repository_pk)
+    result = {"repository": db_repository.serialize_for_event(keys_only=True)}
+    repository = load_repository_backend(db_repository)
+    with transaction.atomic():
+        if not try_lock_repository_sync(db_repository.pk):
+            logger.warning("Repository %s is already being synced", db_repository.pk)
+            result["status"] = "SKIPPED"
+            return result
+        result["operations"] = repository.sync_catalogs(serialized_event_request)
+    notifier.send_notification("monolith.repository", str(db_repository.pk))
+    result["status"] = "SUCCESS"
+    return result

--- a/zentral/contrib/monolith/templates/monolith/repository_detail.html
+++ b/zentral/contrib/monolith/templates/monolith/repository_detail.html
@@ -17,19 +17,10 @@
         <h3 class="m-0 fs-5 text-secondary">Repository</h3>
         <div class="ms-auto">
             {% if perms.monolith.sync_repository %}
-            <form method="post"
-                  action="{% url 'monolith:sync_repository' object.pk %}"
-                  style="display:inline">
-              {% csrf_token %}
-              <button type="submit"
-                      class="btn btn-link"
-                      value="Sync Monolith repository"
-                      data-bs-toggle="tooltip"
-                      data-bs-placement="bottom"
-                      data-bs-title="Sync Monolith repository">
-                <i class="bi bi-arrow-counterclockwise"></i>
-              </button>
-            </form>
+            <a id="repository-sync-btn" href="{% url 'monolith_api:sync_repository' object.pk %}" class="btn btn-link task"
+                data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Sync Monolith repository">
+              <i class="bi bi-arrow-counterclockwise"></i>
+            </a>
             {% endif %}
             {% if perms.monolith.change_repository  and object.can_be_updated %}
                 {% url 'monolith:update_repository' object.pk as url %}
@@ -193,6 +184,45 @@
 
 {% block extrajs %}
 <script nonce="{{ request.csp_nonce }}">
+  var WAIT_FOR_TASK_TIMEOUT_ID;
+
+  function waitForTask(url) {
+    $.ajax({
+      dataType: "json",
+      url: url,
+      success: function (data) {
+        if (data.unready) {
+          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
+        } else {
+          $("#repository-sync-btn").prop("disabled", false);
+          if (data.status === "SUCCESS") {
+            window.location.reload();
+          }
+        }
+      }
+    });
+  }
+
+  function launchTask($link) {
+      $link.prop("disabled", true);
+      var url = $link.attr("href");
+      $.ajax({
+        dataType: "json",
+        url: url,
+        method: "post",
+        success: function (data) {
+          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
+        }
+      });
+  }
+
+  $(document).ready(function () {
+    $(".task").click(function (event) {
+      event.preventDefault();
+      launchTask($(this));
+    });
+  });
+
   var openEyes = document.querySelectorAll(".bi-eye");
   openEyes.forEach(function(openEye) {
     openEye.addEventListener("click", function(event) {

--- a/zentral/contrib/monolith/urls.py
+++ b/zentral/contrib/monolith/urls.py
@@ -12,7 +12,6 @@ urlpatterns = [
     path('repositories/<int:pk>/', views.RepositoryView.as_view(), name='repository'),
     path('repositories/<int:pk>/update/', views.UpdateRepositoryView.as_view(), name='update_repository'),
     path('repositories/<int:pk>/delete/', views.DeleteRepositoryView.as_view(), name='delete_repository'),
-    path('repositories/<int:pk>/sync/', views.SyncRepositoryView.as_view(), name='sync_repository'),
 
     # pkg infos
     path('pkginfos/', views.PkgInfosView.as_view(), name='pkg_infos'),

--- a/zentral/contrib/monolith/views.py
+++ b/zentral/contrib/monolith/views.py
@@ -1,6 +1,5 @@
 import logging
 from urllib.parse import urlencode
-from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -21,7 +20,6 @@ from zentral.utils.terraform import build_config_response
 from zentral.utils.text import get_version_sort_key, shard as compute_shard, encode_args
 from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
 from .conf import monolith_conf
-from .events import post_monolith_sync_catalogs_request
 from .forms import (AddManifestCatalogForm, EditManifestCatalogForm, DeleteManifestCatalogForm,
                     AddManifestEnrollmentPackageForm,
                     AddManifestSubManifestForm, EditManifestSubManifestForm, DeleteManifestSubManifestForm,
@@ -38,7 +36,7 @@ from .models import (Catalog, CacheServer,
                      Condition, ManifestCatalog, ManifestSubManifest,
                      Repository,
                      SUB_MANIFEST_PKG_INFO_KEY_CHOICES, SubManifest, SubManifestPkgInfo)
-from .repository_backends import load_repository_backend, RepositoryBackend
+from .repository_backends import RepositoryBackend
 from .repository_backends.azure import AzureRepositoryForm
 from .repository_backends.s3 import S3RepositoryForm
 from .terraform import iter_resources
@@ -281,29 +279,6 @@ class DeleteRepositoryView(PermissionRequiredMixin, DeleteView):
 
         transaction.on_commit(post_event_and_notify)
         return super().form_valid(form)
-
-
-class SyncRepositoryView(PermissionRequiredMixin, View):
-    permission_required = "monolith.sync_repository"
-    success_url = reverse_lazy("monolith:repositories")
-
-    def post(self, request, *args, **kwargs):
-        db_repository = get_object_or_404(Repository, pk=kwargs["pk"])
-        post_monolith_sync_catalogs_request(request, db_repository)
-        repository = load_repository_backend(db_repository)
-        try:
-            repository.sync_catalogs(request)
-        except Exception as e:
-            logger.exception("Could not sync repository %s", db_repository.pk)
-            messages.error(request, f"Could not sync repository: {e}")
-        else:
-            messages.info(request, "Repository synced")
-
-            def notify():
-                notifier.send_notification("monolith.repository", str(db_repository.pk))
-
-            transaction.on_commit(notify)
-        return redirect(db_repository)
 
 
 # pkg infos


### PR DESCRIPTION
## Why

The monolith repository sync ran during the request. A repository needing more than the gunicorn worker timeout to sync could not be synced at all: the worker was killed and the transaction rolled back, so the sync never committed.

## What changed

`POST /api/monolith/repositories/<int:pk>/sync/` launches a celery task and returns a serialized task, and accepts a web session on top of an API token. The sync button on the repository page posts to it, so there is a single endpoint and a single permission check for both callers — `SyncRepositoryView` and the `monolith:sync_repository` route are gone, and the template uses the same `launchTask`/`waitForTask` snippet as the other pages that drive a task.

The serialized event request is passed to the task, so the audit events emitted by the sync stay linked to the caller. `task_user` is passed too, so the task shows up on `/tasks/` for the user who asked for it.

`sync_catalogs()` therefore takes a serialized event request instead of an `HttpRequest` (a request cannot cross the celery boundary), and returns the number of objects created or updated per model, reported in the task result:

```json
{
  "repository": {"pk": 1, "name": "Main repository"},
  "operations": {
    "catalog": {"created": 1},
    "manifest": {"updated": 2},
    "pkginfo": {"created": 12, "updated": 3},
    "pkginfoname": {"created": 5}
  },
  "status": "SUCCESS"
}
```

## Only one sync at a time per repository

Both the task and the `sync_monolith_repositories` command take a transaction scoped advisory lock (`pg_try_advisory_xact_lock`, released on commit, on rollback and if the connection dies). The task returns a `SKIPPED` status when it cannot get the lock, the command writes to stderr and moves on to the next repository. Acquisition is non-blocking on both sides, so neither can wait on the other.

This matters more now that a sync can run for minutes: two concurrent syncs of the same repository would either abort on a pkg info unique violation — `_import_pkg_info` and `_import_catalogs` create without a savepoint, so the violation aborts the whole sync — or, when the two runs fetched the catalogs at different times, archive each other's pkg infos without erroring at all.

`SKIPPED` is a field in the task result, not a celery state: celery has no such state, `TaskResultView` only returns the result payload for `SUCCESS`, and a custom state would need `update_state` + `raise Ignore()`.

## Backward incompatibility

The endpoint responds with `201` and a `task_id`/`task_result_url` pair, in place of `200 {"status": 0}` and `500 {"status": 1, "error": "…"}`. Clients that treated the response as "the sync is done" have to poll `task_result_url`. Documented in the changelog and in `docs/apps/monolith.md`.

Syncs launched via the API also refresh the caches now, like the ones launched in the UI already did.

## Tests

Full suite green (7537 tests). The `SKIPPED` path is covered against a real second connection holding the lock rather than a mock, for both the task and the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)