### PR TITLE
osquery: bound the events one status log upload can produce

### DIFF
--- a/tests/osquery/test_events.py
+++ b/tests/osquery/test_events.py
@@ -1,7 +1,10 @@
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit
-from zentral.contrib.osquery.events import _filter_status_logs, OsqueryRequestEvent
+from zentral.contrib.osquery.events import (_filter_status_logs, _iter_grouped_status_logs,
+                                            OsqueryRequestEvent,
+                                            STATUS_LOG_TRUNCATION_FILENAME,
+                                            STATUS_LOG_TRUNCATION_SEVERITY)
 from zentral.contrib.osquery.models import Configuration, EnrolledMachine, Enrollment
 
 
@@ -60,3 +63,87 @@ class OsqueryEventsTestCase(TestCase):
             {"message": "No severity… Should not happen!"},
             {"severity": 1, "message": "Warning included"},
         ])
+
+    # _iter_grouped_status_logs
+
+    @staticmethod
+    def build_status_log(message, severity=1, filename="mdfind.mm", line=42, unix_time="1480605737"):
+        return {"severity": severity, "filename": filename, "line": line,
+                "message": message, "unixTime": unix_time}
+
+    def test_grouped_status_logs_distinct_records_kept(self):
+        records = [self.build_status_log("one"), self.build_status_log("two")]
+        grouped = list(_iter_grouped_status_logs(records))
+        self.assertEqual([r["message"] for r in grouped], ["one", "two"])
+        self.assertEqual([r["count"] for r in grouped], [1, 1])
+
+    def test_grouped_status_logs_identical_records_collapsed(self):
+        records = [self.build_status_log("same") for _ in range(2000)]
+        grouped = list(_iter_grouped_status_logs(records))
+        self.assertEqual(len(grouped), 1)
+        self.assertEqual(grouped[0]["count"], 2000)
+        self.assertEqual(grouped[0]["message"], "same")
+
+    def test_grouped_status_logs_first_occurrence_kept(self):
+        records = [self.build_status_log("same", unix_time="1480605737"),
+                   self.build_status_log("same", unix_time="1480605999")]
+        grouped = list(_iter_grouped_status_logs(records))
+        self.assertEqual(grouped[0]["unixTime"], "1480605737")
+
+    def test_grouped_status_logs_differ_on_every_key(self):
+        records = [self.build_status_log("m"),
+                   self.build_status_log("m", severity=2),
+                   self.build_status_log("m", filename="other.cpp"),
+                   self.build_status_log("m", line=43)]
+        self.assertEqual(len(list(_iter_grouped_status_logs(records))), 4)
+
+    def test_grouped_status_logs_order_preserved(self):
+        records = [self.build_status_log("a"), self.build_status_log("b"),
+                   self.build_status_log("a"), self.build_status_log("c")]
+        grouped = list(_iter_grouped_status_logs(records))
+        self.assertEqual([r["message"] for r in grouped], ["a", "b", "c"])
+        self.assertEqual([r["count"] for r in grouped], [2, 1, 1])
+
+    def test_grouped_status_logs_capped(self):
+        records = [self.build_status_log(f"m{i}") for i in range(5)]
+        grouped = list(_iter_grouped_status_logs(records, max_events=3))
+        self.assertEqual(len(grouped), 4)
+        self.assertEqual([r["message"] for r in grouped[:3]], ["m0", "m1", "m2"])
+
+    def test_grouped_status_logs_truncation_record(self):
+        records = [self.build_status_log(f"m{i}") for i in range(4)]
+        records.extend(self.build_status_log("m3") for _ in range(9))
+        truncation = list(_iter_grouped_status_logs(records, max_events=2))[-1]
+        self.assertEqual(truncation["severity"], STATUS_LOG_TRUNCATION_SEVERITY)
+        self.assertEqual(truncation["filename"], STATUS_LOG_TRUNCATION_FILENAME)
+        self.assertEqual(truncation["count"], 1)
+        # m2 once, m3 ten times
+        self.assertEqual(truncation["message"], "Status log truncated, 11 record(s) dropped")
+
+    def test_grouped_status_logs_known_group_still_counted_after_cap(self):
+        records = [self.build_status_log("kept"), self.build_status_log("dropped")]
+        records.extend(self.build_status_log("kept") for _ in range(5))
+        grouped = list(_iter_grouped_status_logs(records, max_events=1))
+        self.assertEqual(grouped[0]["message"], "kept")
+        self.assertEqual(grouped[0]["count"], 6)
+        self.assertEqual(grouped[-1]["message"], "Status log truncated, 1 record(s) dropped")
+
+    def test_grouped_status_logs_group_count_bounded(self):
+        records = [self.build_status_log(f"m{i}") for i in range(50)]
+        grouped = list(_iter_grouped_status_logs(records, max_events=10))
+        # 10 groups + the truncation record, whatever the input size
+        self.assertEqual(len(grouped), 11)
+
+    def test_grouped_status_logs_no_truncation_record_when_under_cap(self):
+        records = [self.build_status_log(f"m{i}") for i in range(3)]
+        grouped = list(_iter_grouped_status_logs(records, max_events=3))
+        self.assertEqual(len(grouped), 3)
+        self.assertNotIn(STATUS_LOG_TRUNCATION_FILENAME, [r["filename"] for r in grouped])
+
+    def test_grouped_status_logs_truncation_record_has_unix_time(self):
+        records = [self.build_status_log(f"m{i}", unix_time=str(1480605737 + i)) for i in range(3)]
+        truncation = list(_iter_grouped_status_logs(records, max_events=1))[-1]
+        self.assertEqual(truncation["unixTime"], "1480605739")
+
+    def test_grouped_status_logs_empty(self):
+        self.assertEqual(list(_iter_grouped_status_logs([])), [])

--- a/zentral/contrib/osquery/events/__init__.py
+++ b/zentral/contrib/osquery/events/__init__.py
@@ -223,6 +223,15 @@ def _post_events(msn, user_agent, ip, event_cls, records):
     )
 
 
+# osquery batches its status log, so one upload can carry tens of thousands of
+# records, and each record would otherwise become an event. Identical records are
+# collapsed into one carrying a count, and at most STATUS_LOG_MAX_EVENTS distinct
+# records are kept, so the work one request can create is bounded.
+STATUS_LOG_MAX_EVENTS = 100
+STATUS_LOG_TRUNCATION_SEVERITY = 2
+STATUS_LOG_TRUNCATION_FILENAME = "zentral"
+
+
 def _filter_status_logs(logs, min_severity):
     for log in logs:
         try:
@@ -235,12 +244,40 @@ def _filter_status_logs(logs, min_severity):
                 yield log
 
 
+def _iter_grouped_status_logs(records, max_events=STATUS_LOG_MAX_EVENTS):
+    groups = {}
+    dropped_records = unix_time = 0
+    for record in records:
+        key = (record.get("severity"), record.get("filename"),
+               record.get("line"), record.get("message"))
+        group = groups.get(key)
+        if group is not None:
+            group["count"] += 1
+        elif len(groups) < max_events:
+            record["count"] = 1
+            groups[key] = record
+        else:
+            dropped_records += 1
+            unix_time = record.get("unixTime", 0)
+    yield from groups.values()
+    if dropped_records:
+        # a cap that hides what it removed makes the events lie about scope
+        yield {"unixTime": unix_time,
+               "severity": STATUS_LOG_TRUNCATION_SEVERITY,
+               "filename": STATUS_LOG_TRUNCATION_FILENAME,
+               "line": 0,
+               "message": f"Status log truncated, {dropped_records} record(s) dropped",
+               "count": 1}
+
+
 def post_status_logs(msn, user_agent, ip, logs, min_severity=1):
     # See https://github.com/osquery/osquery/blob/fe9e6249c12fa87ea31f298b7e831d97c760013b/osquery/core/plugins/logger.h#L40  # NOQA
     # 0 = INFO, by default min = 1 = WARNING
     OsqueryStatusEvent.post_machine_request_payloads(
         msn, user_agent, ip,
-        _iter_cleaned_up_records(_filter_status_logs(logs, min_severity)),
+        _iter_grouped_status_logs(
+            _iter_cleaned_up_records(_filter_status_logs(logs, min_severity))
+        ),
         _get_record_created_at
     )
 


### PR DESCRIPTION
## Problem

osquery buffers its status log locally and flushes the buffer in a single `log_type=status` request. Every record in that request becomes one event:

```
public_views.py   records = self.data.pop("data", [])      # unbounded
  post_status_logs(...)
    _filter_status_logs   drops severity < min_severity
    _iter_cleaned_up_records
      post_machine_request_payloads
        for event in ...: event.post()                     # one post per record
```

So the number of events a single client can create in one request is however many lines it happened to buffer. A table that fails per row emits one status line per attempt, which means a single query can turn into millions of writes fanned out across the queues and every configured event store.

Nothing on the path bounds this. The effective ceiling is `DATA_UPLOAD_MAX_MEMORY_SIZE` (10 MiB by default): at roughly 400 bytes for a status record carrying `unixTime`, `hostIdentifier`, `calendarTime`, `decorations`, `severity`, `filename`, `line`, `message` and `version`, that permits on the order of 26,000 events from one request. That is an accidental limit — it exists to bound request memory, not event volume, and raising it for an unrelated reason makes this worse.

The existing `min_severity=1` does not help: it only removes INFO, and floods of this shape are usually WARNING or above.

## Change

Both parts live in `post_status_logs`, which is already a composed generator chain, so nothing is restructured.

**Group identical records.** Records repeat heavily, because the same failure logs the same line every time. Collapse on `(severity, filename, line, message)` into one event carrying a `count`. Payloads now always carry `count`, so `sum(count)` is the number of lines the client actually sent, and no information is lost when the repeats are byte-identical. The first occurrence's `unixTime` is kept, so the event timestamp is when the condition started.

**Bound the tracking.** Once `STATUS_LOG_MAX_EVENTS` (100) distinct records are held, new distinct records are counted and discarded rather than accumulated. This bounds both the events produced and the memory the grouping costs, regardless of how much a client sends — a client emitting a million *distinct* messages costs the same as one emitting a hundred.

Records matching a group already held still increment its count after the bound is reached, so the counts that are kept remain exact.

When anything is dropped, a final record names how many:

```
Status log truncated, 11 record(s) dropped
```

marked with `filename = "zentral"` so it is distinguishable from anything osquery produced. A cap that silently discarded records would make the events understate the scope of whatever caused the flood, which is precisely when the data matters.

Note this reports dropped *records*, not dropped distinct messages — counting the latter would require remembering every discarded key, which is the unbounded memory the change exists to avoid.

## Compatibility

`OsqueryStatusEvent` is produced but never consumed anywhere in the codebase, so nothing internal depends on the payload shape. `count` is additive.

Two behaviour changes worth calling out for anyone with probes or dashboards on `osquery_status`:

- repeated identical lines now arrive as **one** event with `count > 1` rather than N events, so anything counting events should sum `count` instead
- above the bound, a synthetic record appears with `filename = "zentral"`

`STATUS_LOG_MAX_EVENTS` is a module constant rather than a `Configuration` field. At 100 a host legitimately emitting more than 100 distinct messages between flushes will produce a truncation record on ordinary uploads, not only pathological ones — that is visible rather than silent, so it will be obvious quickly if the value is too tight. Making the severity floor and the bound configurable per configuration is the natural follow-up; this PR keeps to bounding the unbounded case.

## Tests

12 new tests in `tests/osquery/test_events.py` covering: distinct records kept, identical records collapsed, first-occurrence timestamp retained, each key participating in the grouping, order preservation, the bound, the truncation record's contents and timestamp, counts staying exact for held groups after the bound is reached, the group count being bounded whatever the input size, no truncation record below the bound, and empty input.

Full `tests.osquery` suite passes (563 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
