### PR TITLE
mdm: show an error page when DEP web enroll lacks the device info header

### DIFF
--- a/tests/mdm/test_dep_enrollment_public_views.py
+++ b/tests/mdm/test_dep_enrollment_public_views.py
@@ -1,17 +1,25 @@
 import base64
 import datetime
 import plistlib
-from unittest.mock import Mock, patch
 import uuid
+from unittest.mock import Mock, patch
+
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
+
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.crypto import verify_signed_payload
 from zentral.contrib.mdm.events import DEPEnrollmentRequestEvent
-from zentral.contrib.mdm.public_views.dep import dep_web_enroll_callback, DEP_ENROLLMENT_SESSION_KEY
-from .utils import (force_dep_enrollment, force_dep_enrollment_custom_view, force_dep_enrollment_session,
-                    force_realm_user, force_software_update)
+from zentral.contrib.mdm.public_views.dep import DEP_ENROLLMENT_SESSION_KEY, dep_web_enroll_callback
+
+from .utils import (
+    force_dep_enrollment,
+    force_dep_enrollment_custom_view,
+    force_dep_enrollment_session,
+    force_realm_user,
+    force_software_update,
+)
 
 
 @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -347,7 +355,13 @@ class MDMDEPEnrollmentPublicViewsTestCase(TestCase):
         enrollment = session.dep_enrollment
         response = self.client.get(reverse("mdm_public:dep_web_enroll", args=(enrollment.enrollment_secret.secret,)))
         self.assertEqual(response.status_code, 400)
-        self.assertAbort(post_event, "Missing x-apple-aspen-deviceinfo header")
+        self.assertTemplateUsed(response, "mdm/dep_missing_device_info.html")
+        self.assertContains(response, "Missing Device Information", status_code=400)
+        self.assertContains(response, "Restart the enrollment, or contact your IT support.", status_code=400)
+        last_event = post_event.call_args.args[0]
+        self.assertIsInstance(last_event, DEPEnrollmentRequestEvent)
+        self.assertEqual(last_event.payload["status"], "failure")
+        self.assertEqual(last_event.payload["reason"], "Missing x-apple-aspen-deviceinfo header")
 
     def test_dep_web_enroll_no_realm(self, vicsp, post_event):
         vicsp.side_effect = lambda d: d

--- a/zentral/contrib/mdm/public_views/dep.py
+++ b/zentral/contrib/mdm/public_views/dep.py
@@ -1,21 +1,23 @@
 import base64
 import logging
 import plistlib
+
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.template import Context, Engine
 from django.urls import reverse
 from django.views.generic import View
+
 from zentral.contrib.inventory.exceptions import EnrollmentSecretVerificationFailed
 from zentral.contrib.inventory.utils import verify_enrollment_secret
 from zentral.contrib.mdm.crypto import verify_iphone_ca_signed_payload
 from zentral.contrib.mdm.events import DEPEnrollmentRequestEvent
-from zentral.contrib.mdm.models import DEPEnrollmentSession, DEPEnrollment, EnrolledDevice
+from zentral.contrib.mdm.models import DEPEnrollment, DEPEnrollmentSession, EnrolledDevice
 from zentral.contrib.mdm.payloads import build_configuration_profile_response, build_mdm_configuration_profile
 from zentral.contrib.mdm.software_updates import best_available_software_update_for_device_id_and_build
 from zentral.utils.os_version import make_comparable_os_version
-from .base import PostEventMixin
 
+from .base import PostEventMixin
 
 logger = logging.getLogger('zentral.contrib.mdm.public_views.dep')
 
@@ -218,12 +220,14 @@ class DEPWebEnrollView(DEPEnrollMixin, View):
     # https://developer.apple.com/documentation/devicemanagement/device_assignment/authenticating_through_web_views
 
     def get_payload_data(self):
-        try:
-            return base64.b64decode(self.request.META["HTTP_X_APPLE_ASPEN_DEVICEINFO"])
-        except KeyError:
-            self.abort("Missing x-apple-aspen-deviceinfo header")
+        return base64.b64decode(self.request.META["HTTP_X_APPLE_ASPEN_DEVICEINFO"])
 
     def get(self, request, *args, **kwargs):
+        if "HTTP_X_APPLE_ASPEN_DEVICEINFO" not in request.META:
+            reason = "Missing x-apple-aspen-deviceinfo header"
+            logger.error(reason)
+            self.post_event("failure", reason=reason)
+            return render(request, "mdm/dep_missing_device_info.html", status=400)
         self.get_payload()
         err_response = self.verify()
         if err_response:

--- a/zentral/contrib/mdm/templates/mdm/dep_missing_device_info.html
+++ b/zentral/contrib/mdm/templates/mdm/dep_missing_device_info.html
@@ -1,0 +1,6 @@
+{% extends 'base_error.html' %}
+
+{% block content %}
+<h1 class="h3 text-center">Missing Device Information</h1>
+<p class="text-center text-body-secondary">Restart the enrollment, or contact your IT support.</p>
+{% endblock %}


### PR DESCRIPTION
The Setup Assistant web view occasionally issues the initial navigation to the DEP web enrollment URL without the `x-apple-aspen-deviceinfo` header.

Instead of letting the request fail with a `SuspiciousOperation`, the view renders `mdm/dep_missing_device_info.html`, a short template extending `base_error.html`, with a title naming the fault so a screenshot is enough for the support team to identify it. The response is still a `400`, and the event is still posted as a `failure`.
