### PR TITLE
Post events when a DEP virtual server syncs with ABM

### DIFF
--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -577,7 +577,7 @@ Note that a device can also become unblocked without an operator: a full state p
 
 ### Automated Device Enrollment devices
 
-Assigning an enrollment profile to a device, refreshing its record from Apple, and synchronizing the virtual server with ABM/ASM are recorded with the `created` and `updated` actions, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved.
+Assigning an enrollment profile to a device — from the web interface as well as the HTTP API — refreshing its record from Apple, and synchronizing the virtual server with ABM/ASM are recorded with the `created` and `updated` actions, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved.
 
 A refresh that Apple answers with an unknown serial number still marks the record as deleted, so it is recorded too. A profile assignment Apple refuses changes nothing and records nothing.
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -847,6 +847,20 @@ Response:
 }
 ```
 
+Poll `task_result_url` for the outcome. Its `result` reports the synchronization type that was requested and the one that actually ran — an expired cursor turns a delta synchronization into a full one — and how many devices were touched:
+
+```json
+{
+  "dep_virtual_server": {"pk": 1, "name": "…"},
+  "requested_sync_type": "delta_sync",
+  "effective_sync_type": "full_sync",
+  "operations": {"created": 2, "updated": 5, "unchanged": 1180,
+                 "marked_deleted": 1, "profiles_assigned": 2}
+}
+```
+
+Apple returns the whole device list on a full synchronization, so most of the devices it reports are usually `unchanged`: only the ones whose attributes really moved are counted as `updated`, and only those are written and recorded in the event pipeline.
+
 ### `/api/mdm/devices/`
 
  * method: `GET`

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -595,7 +595,22 @@ Each synchronization also posts one `dep_virtual_server_synced` event summarizin
 }
 ```
 
-All the events of a single synchronization share the same metadata `id`, with the summary at index 0, so a run can be pulled back together.
+All the events of a single synchronization share the same metadata `id`, with the summary at index 0, so a run can be pulled back together. A synchronization triggered from the web interface or the HTTP API carries the request of the user who triggered it, on the summary as well as on the device events; one Zentral runs on its own carries no request.
+
+A synchronization that fails posts the summary with a `failure` status, the error and, for an error Apple named, its code:
+
+```json
+{
+  "dep_virtual_server": {"pk": 1, "uuid": "…", "name": "…"},
+  "sync_type": "delta",
+  "status": "failure",
+  "error": "DEP cursor expired, error code: EXPIRED_CURSOR",
+  "error_code": "EXPIRED_CURSOR",
+  "duration_seconds": 0.412
+}
+```
+
+It carries no `operations`: a failed synchronization is rolled back, so none of the devices it had already read were written, and no device event is posted for them. Note that an expired cursor is retried as a full synchronization, so a `failure` with the `EXPIRED_CURSOR` code is normally followed by a successful full run.
 
 Disowning a device has its own event, `dep_device_disowned`, rather than an audit event.
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -577,9 +577,25 @@ Note that a device can also become unblocked without an operator: a full state p
 
 ### Automated Device Enrollment devices
 
-Assigning an enrollment profile to a device, and refreshing its record from Apple, are recorded with the `updated` action, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved.
+Assigning an enrollment profile to a device, refreshing its record from Apple, and synchronizing the virtual server with ABM/ASM are recorded with the `created` and `updated` actions, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved.
 
 A refresh that Apple answers with an unknown serial number still marks the record as deleted, so it is recorded too. A profile assignment Apple refuses changes nothing and records nothing.
+
+A synchronization only records the devices that really changed. Apple returns the whole list, but a device whose attributes all match the stored record is left untouched and produces no event. A device Apple stops returning during a full synchronization is recorded with its `last_op_type` becoming `deleted`, and so is a device that gets the virtual server's default enrollment assigned.
+
+Each synchronization also posts one `dep_virtual_server_synced` event summarizing the run — the synchronization type, how many devices were created, updated, left unchanged, marked deleted and assigned a profile, and how long it took:
+
+```json
+{
+  "dep_virtual_server": {"pk": 1, "uuid": "…", "name": "…"},
+  "sync_type": "full",
+  "operations": {"created": 2, "updated": 5, "unchanged": 1180,
+                 "marked_deleted": 1, "profiles_assigned": 2},
+  "duration_seconds": 12.482
+}
+```
+
+All the events of a single synchronization share the same metadata `id`, with the summary at index 0, so a run can be pulled back together.
 
 Disowning a device has its own event, `dep_device_disowned`, rather than an audit event.
 

--- a/tests/mdm/management_commands/test_others.py
+++ b/tests/mdm/management_commands/test_others.py
@@ -199,8 +199,8 @@ class MDMManagementCommandsTest(TestCase):
         dvs1 = force_dep_virtual_server()
         dvs2 = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
-            (("YOLO", True),),
-            (("FOMO", False),),
+            (("YOLO", "created"),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', stdout=out)
@@ -220,7 +220,7 @@ class MDMManagementCommandsTest(TestCase):
         dvs = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
             DEPClientError("yolo", error_code="EXPIRED_CURSOR"),
-            (("FOMO", False),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', stdout=out)
@@ -256,7 +256,7 @@ class MDMManagementCommandsTest(TestCase):
         dvs = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
             ValueError("HAAAAAAAAAAA"),
-            (("FOMO", False),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         err = StringIO()
@@ -276,7 +276,7 @@ class MDMManagementCommandsTest(TestCase):
         force_dep_virtual_server()
         dvs = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
-            (("YOLO", True),),
+            (("YOLO", "created"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', '--server', str(dvs.pk), stdout=out)
@@ -292,8 +292,8 @@ class MDMManagementCommandsTest(TestCase):
         dvs1 = force_dep_virtual_server()
         dvs2 = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
-            (("YOLO", True),),
-            (("FOMO", False),),
+            (("YOLO", "created"),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', '--full-sync', stdout=out)

--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -12,6 +12,7 @@ from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.dep_client import DEPClientError
 from zentral.contrib.mdm.events import DEPDeviceDisownedEvent
+from zentral.core.events.base import AuditEvent
 
 from .utils import force_dep_device, force_dep_enrollment, force_dep_virtual_server
 
@@ -420,6 +421,39 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'virtual_server': dep_device.virtual_server.pk}
         )
         assign_dep_device_profile.assert_called_once_with(dep_device, enrollment)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.serializers.assign_dep_device_profile")
+    def test_update_dep_device_posts_audit_event(self, assign_dep_device_profile, post_event):
+        dep_device = force_dep_device()
+        enrollment = force_dep_enrollment(self.mbu)
+        self.set_permissions("mdm.change_depdevice")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse("mdm_api:dep_device", args=(dep_device.pk,)),
+                                data={"enrollment": enrollment.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depdevice")
+        self.assertIsNone(event.payload["object"]["prev_value"]["enrollment"])
+        self.assertEqual(event.payload["object"]["new_value"]["enrollment"]["pk"], enrollment.pk)
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["machine_serial_number"], dep_device.serial_number)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.serializers.assign_dep_device_profile")
+    def test_update_dep_device_error_posts_no_event(self, assign_dep_device_profile, post_event):
+        assign_dep_device_profile.side_effect = DEPClientError("YOLO")
+        dep_device = force_dep_device()
+        enrollment = force_dep_enrollment(self.mbu)
+        self.set_permissions("mdm.change_depdevice")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse("mdm_api:dep_device", args=(dep_device.pk,)),
+                                data={"enrollment": enrollment.pk})
+        self.assertEqual(response.status_code, 400)
+        post_event.assert_not_called()
 
     @patch("zentral.contrib.mdm.serializers.assign_dep_device_profile")
     def test_update_dep_device_error(self, assign_dep_device_profile):

--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -90,6 +91,21 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(sorted(response.json().keys()), ['task_id', 'task_result_url'])
         result = response.json()
         self.assertEqual(result['task_result_url'], reverse("base_api:task_result", args=(result['task_id'],)))
+
+    @patch("zentral.contrib.mdm.api_views.dep.sync_dep_virtual_server_devices_task.apply_async")
+    def test_user_dep_virtual_server_sync_devices_task_kwargs(self, apply_async):
+        apply_async.return_value.id = uuid.uuid4()
+        dep_server = force_dep_virtual_server()
+        self.login("mdm.view_depvirtualserver")
+        response = self.client.post(reverse("mdm_api:dep_virtual_server_sync_devices", args=(dep_server.pk,)),
+                                    query_params={'full_sync': 'True'})
+        self.assertEqual(response.status_code, 201)
+        args, task_kwargs = apply_async.call_args.args
+        self.assertEqual(args, (dep_server.pk,))
+        # the task kwargs, not the apply_async options: force_full_sync has to reach the task
+        self.assertTrue(task_kwargs["force_full_sync"])
+        self.assertEqual(task_kwargs["task_user"], self.user.pk)
+        self.assertEqual(task_kwargs["serialized_event_request"]["user"]["username"], self.user.username)
 
     def test_user_dep_virtual_server_sync_devices_full(self):
         dep_server = force_dep_virtual_server()

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -45,9 +45,9 @@ class TestDEPEnrollment(TestCase):
         dep_devices = list(sync_dep_virtual_server_devices(server))
         client.fetch_devices.assert_called_once_with()
         self.assertEqual(len(dep_devices), 1)
-        d, d_created = dep_devices[0]
+        d, d_action = dep_devices[0]
         d.refresh_from_db()  # for the datetimes, to get the stored ones, not the parsed ones
-        self.assertTrue(d_created)
+        self.assertEqual(d_action, "created")
         self.assertEqual(d.asset_tag, "")
         self.assertEqual(d.color, "SPACE GRAY")
         self.assertEqual(d.description, "IPHONE X SPACE GRAY 64GB-ZDD")
@@ -101,9 +101,9 @@ class TestDEPEnrollment(TestCase):
         dep_devices = list(sync_dep_virtual_server_devices(server))
         client.sync_devices.assert_called_once_with(sync_cursor)
         self.assertEqual(len(dep_devices), 1)
-        d, d_created = dep_devices[0]
+        d, d_action = dep_devices[0]
         d.refresh_from_db()  # for the datetimes, to get the stored ones, not the parsed ones
-        self.assertTrue(d_created)
+        self.assertEqual(d_action, "created")
         self.assertEqual(d.asset_tag, "")
         self.assertEqual(d.color, "SPACE GRAY")
         self.assertEqual(d.description, "IPHONE X SPACE GRAY 64GB-ZDD")
@@ -155,7 +155,7 @@ class TestDEPEnrollment(TestCase):
         client.fetch_devices.assert_called_once_with()
         client.assign_profile.assert_called_once_with(server.default_enrollment.uuid, [serial_number])
         self.assertEqual(len(dep_devices), 1)
-        device, created = dep_devices[0]
+        device, _ = dep_devices[0]
         self.assertIsNone(device.profile_uuid)
         self.assertIsNone(device.enrollment)
         device.refresh_from_db()
@@ -194,7 +194,7 @@ class TestDEPEnrollment(TestCase):
         client.fetch_devices.assert_called_once_with()
         client.assign_profile.assert_not_called()
         self.assertEqual(len(dep_devices), 1)
-        device, created = dep_devices[0]
+        device, _ = dep_devices[0]
         self.assertIsNone(device.profile_uuid)
         self.assertIsNone(device.enrollment)
         device.refresh_from_db()

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -2,15 +2,16 @@ import uuid
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.utils.crypto import get_random_string
 
+from accounts.models import User
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.dep import define_dep_profile, sync_dep_virtual_server_devices
-from zentral.contrib.mdm.dep_client import CursorIterator
+from zentral.contrib.mdm.dep_client import CursorIterator, DEPClientError
 from zentral.contrib.mdm.models import DEPDevice
 from zentral.contrib.mdm.tasks import define_dep_profile_task
-from zentral.core.events.base import AuditEvent
+from zentral.core.events.base import AuditEvent, EventRequest
 from zentral.utils.time import naive_utcnow
 
 from .utils import force_dep_device, force_dep_enrollment, force_dep_virtual_server
@@ -307,6 +308,69 @@ class TestDEPEnrollment(TestCase):
             DEPDevice.objects.get(virtual_server=server, serial_number=serial_number).last_op_type,
             "deleted",
         )
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_failure_posts_event(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        client = Mock()
+        client.fetch_devices.side_effect = DEPClientError("YOLO", error_code="EXPIRED_CURSOR")
+        from_dep_token.return_value = client
+        with self.assertRaises(DEPClientError):
+            with self.captureOnCommitCallbacks(execute=True):
+                list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        # the failure is not posted on commit: the transaction rolled back
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertEqual(event.event_type, "dep_virtual_server_synced")
+        self.assertEqual(event.payload["status"], "failure")
+        self.assertEqual(event.payload["sync_type"], "full")
+        self.assertEqual(event.payload["error_code"], "EXPIRED_CURSOR")
+        self.assertNotIn("operations", event.payload)
+        self.assertEqual(event.payload["dep_virtual_server"]["pk"], server.pk)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_failure_rolls_back(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        serial_number = get_random_string(10).upper()
+
+        def device_iterator():
+            yield {'device_assigned_date': '2023-01-10T19:09:22Z', 'serial_number': serial_number}
+            raise DEPClientError("YOLO")
+
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator(device_iterator())
+        from_dep_token.return_value = client
+        with self.assertRaises(DEPClientError):
+            with self.captureOnCommitCallbacks(execute=True):
+                list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        self.assertEqual(len(post_event.call_args_list), 1)
+        self.assertEqual(post_event.call_args_list[0].args[0].payload["status"], "failure")
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_event_request(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        serial_number = get_random_string(10).upper()
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator(
+            [{'device_assigned_date': '2023-01-10T19:09:22Z', 'serial_number': serial_number}]
+        )
+        from_dep_token.return_value = client
+        user = User.objects.create_user(get_random_string(12), "godzilla@zentral.io", get_random_string(12))
+        request = RequestFactory().post("/")
+        request.user = user
+        request.session = Mock()
+        request.session.get_expire_at_browser_close.return_value = True
+        serialized_event_request = EventRequest.build_from_request(request).serialize()
+        with self.captureOnCommitCallbacks(execute=True):
+            list(sync_dep_virtual_server_devices(server, force_fetch=True,
+                                                 serialized_event_request=serialized_event_request))
+        self.assertEqual(len(post_event.call_args_list), 2)
+        for call in post_event.call_args_list:
+            metadata = call.args[0].metadata.serialize()
+            self.assertEqual(metadata["request"]["user"]["username"], user.username)
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_define_dep_profile(self, from_dep_token):

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -10,6 +10,7 @@ from zentral.contrib.mdm.dep import define_dep_profile, sync_dep_virtual_server_
 from zentral.contrib.mdm.dep_client import CursorIterator
 from zentral.contrib.mdm.models import DEPDevice
 from zentral.contrib.mdm.tasks import define_dep_profile_task
+from zentral.core.events.base import AuditEvent
 from zentral.utils.time import naive_utcnow
 
 from .utils import force_dep_device, force_dep_enrollment, force_dep_virtual_server
@@ -200,6 +201,112 @@ class TestDEPEnrollment(TestCase):
         self.assertIsNone(device.profile_uuid)
         self.assertIsNone(device.enrollment)
         self.assertEqual(device.profile_status, "empty")
+
+    def _fetch_one_device(self, server, serial_number, from_dep_token, **extra):
+        device = {'color': 'SPACE GRAY',
+                  'description': 'IPHONE X SPACE GRAY 64GB-ZDD',
+                  'device_assigned_by': 'support@zentral.com',
+                  'device_assigned_date': '2023-01-10T19:09:22Z',
+                  'device_family': 'iPhone',
+                  'model': 'iPhone X',
+                  'op_date': '2023-06-17T15:41:06Z',
+                  'op_type': 'modified',
+                  'os': 'iOS',
+                  'serial_number': serial_number}
+        device.update(extra)
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([device])
+        from_dep_token.return_value = client
+        with self.captureOnCommitCallbacks(execute=True):
+            list(sync_dep_virtual_server_devices(server, force_fetch=True))
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_posts_events(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        serial_number = get_random_string(10).upper()
+        self._fetch_one_device(server, serial_number, from_dep_token)
+        self.assertEqual(len(post_event.call_args_list), 2)
+
+        summary = post_event.call_args_list[0].args[0]
+        self.assertEqual(summary.event_type, "dep_virtual_server_synced")
+        self.assertEqual(summary.payload["sync_type"], "full")
+        self.assertEqual(summary.payload["dep_virtual_server"]["pk"], server.pk)
+        self.assertEqual(summary.payload["operations"]["created"], 1)
+        self.assertEqual(summary.payload["operations"]["updated"], 0)
+        self.assertEqual(summary.payload["operations"]["unchanged"], 0)
+        summary_metadata = summary.metadata.serialize()
+        self.assertEqual(summary_metadata["index"], 0)
+        self.assertEqual(summary_metadata["objects"]["mdm_dep_virtual_server"], [str(server.pk)])
+
+        audit = post_event.call_args_list[1].args[0]
+        self.assertIsInstance(audit, AuditEvent)
+        self.assertEqual(audit.payload["action"], "created")
+        self.assertEqual(audit.payload["object"]["model"], "mdm.depdevice")
+        self.assertEqual(audit.payload["object"]["new_value"]["serial_number"], serial_number)
+        audit_metadata = audit.metadata.serialize()
+        self.assertEqual(audit_metadata["machine_serial_number"], serial_number)
+        # one batch: same uuid as the summary, index right after it
+        self.assertEqual(audit_metadata["id"], summary_metadata["id"])
+        self.assertEqual(audit_metadata["index"], 1)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_unchanged_posts_no_audit_event(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        serial_number = get_random_string(10).upper()
+        self._fetch_one_device(server, serial_number, from_dep_token)
+        post_event.reset_mock()
+        # same payload again, nothing moved
+        self._fetch_one_device(server, serial_number, from_dep_token)
+        self.assertEqual(len(post_event.call_args_list), 1)
+        summary = post_event.call_args_list[0].args[0]
+        self.assertEqual(summary.event_type, "dep_virtual_server_synced")
+        self.assertEqual(summary.payload["operations"]["created"], 0)
+        self.assertEqual(summary.payload["operations"]["updated"], 0)
+        self.assertEqual(summary.payload["operations"]["unchanged"], 1)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_change_posts_audit_event(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        serial_number = get_random_string(10).upper()
+        self._fetch_one_device(server, serial_number, from_dep_token)
+        post_event.reset_mock()
+        self._fetch_one_device(server, serial_number, from_dep_token, asset_tag="A42")
+        self.assertEqual(len(post_event.call_args_list), 2)
+        summary = post_event.call_args_list[0].args[0]
+        self.assertEqual(summary.payload["operations"]["updated"], 1)
+        self.assertEqual(summary.payload["operations"]["unchanged"], 0)
+        audit = post_event.call_args_list[1].args[0]
+        self.assertEqual(audit.payload["action"], "updated")
+        self.assertEqual(audit.payload["object"]["prev_value"]["asset_tag"], "")
+        self.assertEqual(audit.payload["object"]["new_value"]["asset_tag"], "A42")
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_missing_device_marked_deleted(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        serial_number = get_random_string(10).upper()
+        self._fetch_one_device(server, serial_number, from_dep_token)
+        post_event.reset_mock()
+        # a full fetch that does not return the device anymore
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([])
+        from_dep_token.return_value = client
+        with self.captureOnCommitCallbacks(execute=True):
+            list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        self.assertEqual(len(post_event.call_args_list), 2)
+        summary = post_event.call_args_list[0].args[0]
+        self.assertEqual(summary.payload["operations"]["marked_deleted"], 1)
+        audit = post_event.call_args_list[1].args[0]
+        self.assertEqual(audit.payload["action"], "updated")
+        self.assertIsNone(audit.payload["object"]["prev_value"]["last_op_type"])
+        self.assertEqual(audit.payload["object"]["new_value"]["last_op_type"], "deleted")
+        self.assertEqual(
+            DEPDevice.objects.get(virtual_server=server, serial_number=serial_number).last_op_type,
+            "deleted",
+        )
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_define_dep_profile(self, from_dep_token):

--- a/tests/mdm/test_dep_enrollment.py
+++ b/tests/mdm/test_dep_enrollment.py
@@ -61,7 +61,10 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(session.status, "STARTED")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "dep", "status": "STARTED"}}
+            {"enrollment_session": {"pk": session.pk, "type": "dep", "status": "STARTED",
+                                    "dep_enrollment": {"pk": enrollment.pk,
+                                                       "name": enrollment.name,
+                                                       "uuid": str(enrollment.uuid)}}}
         )
 
     def test_dep_enrollment_session_no_acme_payload(self):

--- a/tests/mdm/test_ota_enrollment.py
+++ b/tests/mdm/test_ota_enrollment.py
@@ -48,7 +48,9 @@ class TestOTAEnrollment(TestCase):
         self.assertEqual(session.status, "PHASE_2")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "ota", "status": "PHASE_2"}}
+            {"enrollment_session": {"pk": session.pk, "type": "ota", "status": "PHASE_2",
+                                    "ota_enrollment": {"pk": enrollment.pk,
+                                                       "name": enrollment.name}}}
         )
 
     def test_ota_enrollment_session_scep_payload(self):

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -78,6 +78,9 @@ class MDMTasksTestCase(TestCase):
                 "operations": {
                     "created": 1,
                     "updated": 0,
+                    "unchanged": 0,
+                    "marked_deleted": 0,
+                    "profiles_assigned": 0,
                 },
                 "requested_sync_type": "delta_sync",
                 "effective_sync_type": "delta_sync"
@@ -107,7 +110,11 @@ class MDMTasksTestCase(TestCase):
                 },
                 "operations": {
                     "created": 1,
-                    "updated": 1,
+                    # the device from the first sync is returned again unchanged
+                    "updated": 0,
+                    "unchanged": 1,
+                    "marked_deleted": 0,
+                    "profiles_assigned": 0,
                 },
                 "requested_sync_type": "full_sync",
                 "effective_sync_type": "full_sync"
@@ -147,6 +154,9 @@ class MDMTasksTestCase(TestCase):
                 "operations": {
                     "created": 1,
                     "updated": 0,
+                    "unchanged": 0,
+                    "marked_deleted": 0,
+                    "profiles_assigned": 0,
                 },
                 "requested_sync_type": "delta_sync",
                 "effective_sync_type": "full_sync"

--- a/tests/mdm/test_user_enrollment.py
+++ b/tests/mdm/test_user_enrollment.py
@@ -38,7 +38,9 @@ class TestUserEnrollment(TestCase):
         self.assertEqual(session.status, "ACCOUNT_DRIVEN_START")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "user", "status": "ACCOUNT_DRIVEN_START"}}
+            {"enrollment_session": {"pk": session.pk, "type": "user", "status": "ACCOUNT_DRIVEN_START",
+                                    "user_enrollment": {"pk": enrollment.pk,
+                                                        "name": enrollment.name}}}
         )
 
     def test_user_enrollment_session_scep_payload(self):

--- a/zentral/contrib/mdm/api_views/dep.py
+++ b/zentral/contrib/mdm/api_views/dep.py
@@ -5,7 +5,7 @@ from django_filters import rest_framework as filters
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.filters import OrderingFilter
-from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -22,6 +22,7 @@ from zentral.utils.drf import (
     DefaultDjangoModelPermissions,
     DjangoPermissionRequired,
     MaxLimitOffsetPagination,
+    RetrieveUpdateAPIViewWithAudit,
 )
 
 
@@ -62,10 +63,12 @@ class DEPDeviceList(ListAPIView):
     pagination_class = MaxLimitOffsetPagination
 
 
-class DEPDeviceDetail(RetrieveUpdateAPIView):
+class DEPDeviceDetail(RetrieveUpdateAPIViewWithAudit):
     queryset = DEPDevice.objects.all()
     serializer_class = DEPDeviceSerializer
-    permission_classes = [DefaultDjangoModelPermissions]
+
+    def get_audit_machine_serial_number(self):
+        return self.get_object().serial_number
 
 
 class DEPVirtualServerBetaTokensView(RetrieveAPIView):

--- a/zentral/contrib/mdm/api_views/dep.py
+++ b/zentral/contrib/mdm/api_views/dep.py
@@ -18,6 +18,7 @@ from zentral.contrib.mdm.serializers import (
     DEPVirtualServerBetaTokensSerializer,
 )
 from zentral.contrib.mdm.tasks import sync_dep_virtual_server_devices_task
+from zentral.core.events.base import EventRequest
 from zentral.utils.drf import (
     DefaultDjangoModelPermissions,
     DjangoPermissionRequired,
@@ -39,7 +40,10 @@ class DEPVirtualServerSyncDevicesView(GenericAPIView):
         if isinstance(qp, str):
             full_sync = qp.lower() in ('', 'yes', 'y', 't', 'true')
         task = sync_dep_virtual_server_devices_task.apply_async(
-            (server.pk,), force_full_sync=full_sync
+            (server.pk,),
+            {"force_full_sync": full_sync,
+             "serialized_event_request": EventRequest.build_from_request(request).serialize(),
+             "task_user": request.user.id}
         )
         serializer = self.serializer_class.from_task(task=task)
         return Response(

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -2,23 +2,25 @@ import base64
 import datetime
 import json
 import logging
+import time
 import uuid
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from dateutil import parser
 from django.db import connection, transaction
 from django.urls import reverse
 from django.utils import timezone
 
 from zentral.conf import settings
+from zentral.core.events.base import AuditEvent
 from zentral.utils.certificates import split_certificate_chain
-from zentral.utils.time import naive_utcnow
+from zentral.utils.time import naive_utcnow, parse_naive_datetime
 
 from .crypto import decrypt_cms_payload_with_pem_privkey
 from .dep_client import DEPClient, DEPClientError
+from .events import build_dep_virtual_server_synced_event
 from .models import DEPDevice, DEPEnrollment
 
 logger = logging.getLogger("zentral.contrib.mdm.dep")
@@ -186,8 +188,9 @@ def dep_device_update_dict(device, known_enrollments=None):
         except KeyError:
             pass
         else:
-            val = parser.parse(val)
-            update_d[attr] = val
+            # naive, like every datetime read back from the database, so that the values can be
+            # compared with the stored ones without having to normalize either side
+            update_d[attr] = parse_naive_datetime(val)
 
     return update_d
 
@@ -206,6 +209,25 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, lock_
         yield from _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch)
 
 
+def _dep_device_changed(dep_device, defaults):
+    """Would applying defaults move anything?
+
+    A sync re-reads every device Apple returns, but only a few of them have really changed.
+    Skipping the untouched ones keeps the sync from writing the whole table and, more importantly,
+    from emitting an audit event per device on every full fetch.
+    """
+    for attr, new_value in defaults.items():
+        if attr == "enrollment":
+            # compare the ids, reading the relation would query once per device
+            old_value = dep_device.enrollment_id
+            new_value = new_value.pk if new_value else None
+        else:
+            old_value = getattr(dep_device, attr)
+        if old_value != new_value:
+            return True
+    return False
+
+
 def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
     dep_token = dep_virtual_server.token
     client = DEPClient.from_dep_token(dep_token)
@@ -221,6 +243,17 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
     found_serial_numbers = []
     unassigned_serial_numbers = []
 
+    started_at = time.monotonic()
+    events = []
+    event_uuid = uuid.uuid4()
+    counters = {"created": 0, "updated": 0, "unchanged": 0, "marked_deleted": 0, "profiles_assigned": 0}
+
+    def add_event(dep_device, action, prev_value=None):
+        # index 0 is kept for the summary event, which is only complete once the sync is over
+        events.append(AuditEvent.build(dep_device, action, prev_value=prev_value,
+                                       event_uuid=event_uuid, event_index=len(events) + 1,
+                                       machine_serial_number=dep_device.serial_number))
+
     for device in devices:
         serial_number = device["serial_number"]
         found_serial_numbers.append(serial_number)
@@ -234,18 +267,17 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
         ):
             unassigned_serial_numbers.append(serial_number)
 
+        try:
+            dep_device = DEPDevice.objects.get(virtual_server=dep_virtual_server, serial_number=serial_number)
+        except DEPDevice.DoesNotExist:
+            dep_device = None
+
         # sync
         if not fetch:
             op_type = device["op_type"]
             if op_type != "deleted":
                 defaults["disowned_at"] = None
-            op_date = parser.parse(device["op_date"])
-            if timezone.is_aware(op_date):
-                op_date = timezone.make_naive(op_date)
-            try:
-                dep_device = DEPDevice.objects.get(virtual_server=dep_virtual_server, serial_number=serial_number)
-            except DEPDevice.DoesNotExist:
-                dep_device = None
+            op_date = parse_naive_datetime(device["op_date"])
             if dep_device and dep_device.last_op_date and dep_device.last_op_date > op_date:
                 # already applied a newer operation. skip stalled one.
                 continue
@@ -257,19 +289,40 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
 
         defaults.update(dep_device_update_dict(device, known_enrollments))
 
-        yield DEPDevice.objects.update_or_create(
-            virtual_server=dep_virtual_server,
-            serial_number=serial_number,
-            defaults=defaults
-        )
+        if dep_device is None:
+            dep_device = DEPDevice.objects.create(virtual_server=dep_virtual_server,
+                                                  serial_number=serial_number,
+                                                  **defaults)
+            add_event(dep_device, AuditEvent.Action.CREATED)
+            counters["created"] += 1
+            created = True
+        else:
+            created = False
+            if _dep_device_changed(dep_device, defaults):
+                prev_value = dep_device.serialize_for_event()
+                for attr, value in defaults.items():
+                    setattr(dep_device, attr, value)
+                dep_device.save()
+                add_event(dep_device, AuditEvent.Action.UPDATED, prev_value=prev_value)
+                counters["updated"] += 1
+            else:
+                counters["unchanged"] += 1
+
+        yield dep_device, created
     dep_token.sync_cursor = devices.cursor
     dep_token.last_synced_at = timezone.now()
     dep_token.save()
     if fetch:
         # mark all other existing token devices as deleted
-        (DEPDevice.objects.filter(virtual_server=dep_virtual_server)
-                          .exclude(serial_number__in=found_serial_numbers)
-                          .update(last_op_type=DEPDevice.OP_TYPE_DELETED))
+        deleted_qs = (DEPDevice.objects.filter(virtual_server=dep_virtual_server)
+                                       .exclude(serial_number__in=found_serial_numbers)
+                                       .exclude(last_op_type=DEPDevice.OP_TYPE_DELETED))
+        for dep_device in deleted_qs:
+            prev_value = dep_device.serialize_for_event()
+            dep_device.last_op_type = DEPDevice.OP_TYPE_DELETED
+            add_event(dep_device, AuditEvent.Action.UPDATED, prev_value=prev_value)
+            counters["marked_deleted"] += 1
+        deleted_qs.update(last_op_type=DEPDevice.OP_TYPE_DELETED)
     if unassigned_serial_numbers:
         default_enrollment = dep_virtual_server.default_enrollment
         # assign the default profile
@@ -284,12 +337,33 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
         if success_devices:
             # To avoid some performance issues, only update the devices in the database.
             # The next sync will fix the differences.
-            (DEPDevice.objects.filter(virtual_server=dep_virtual_server,
-                                      serial_number__in=success_devices)
-                              .update(profile_uuid=default_enrollment.uuid,
-                                      profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
-                                      profile_assign_time=naive_utcnow(),
-                                      enrollment=default_enrollment))
+            profile_assign_time = naive_utcnow()
+            assigned_qs = DEPDevice.objects.filter(virtual_server=dep_virtual_server,
+                                                   serial_number__in=success_devices)
+            for dep_device in assigned_qs:
+                prev_value = dep_device.serialize_for_event()
+                dep_device.profile_uuid = default_enrollment.uuid
+                dep_device.profile_status = DEPDevice.PROFILE_STATUS_ASSIGNED
+                dep_device.profile_assign_time = profile_assign_time
+                dep_device.enrollment = default_enrollment
+                add_event(dep_device, AuditEvent.Action.UPDATED, prev_value=prev_value)
+                counters["profiles_assigned"] += 1
+            assigned_qs.update(profile_uuid=default_enrollment.uuid,
+                               profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
+                               profile_assign_time=profile_assign_time,
+                               enrollment=default_enrollment)
+
+    payload = {"dep_virtual_server": dep_virtual_server.serialize_for_event(keys_only=True),
+               "sync_type": "full" if fetch else "delta",
+               "operations": counters,
+               "duration_seconds": round(time.monotonic() - started_at, 3)}
+    events.insert(0, build_dep_virtual_server_synced_event(dep_virtual_server, payload, event_uuid, 0))
+
+    def post_events():
+        for event in events:
+            event.post()
+
+    transaction.on_commit(post_events)
 
 
 def assign_dep_device_profile(dep_device, dep_profile):

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -206,7 +206,26 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, lock_
                            [PG_ADVISORY_LOCK_ID, dep_virtual_server.pk])
             logger.info("Advisory lock %s for DEP virtual server %s acquired",
                         PG_ADVISORY_LOCK_ID, dep_virtual_server.pk)
-        yield from _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch)
+        return (yield from _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch))
+
+
+class SyncCounters(object):
+    """Mirrors CursorIterator: drive a sync and keep what the generator returned.
+
+    The counters are only complete once the sync is over, and a caller that just wants the
+    totals should not have to tell an unchanged device from an updated one itself.
+    """
+    def __init__(self, object_iter):
+        self.object_iter = object_iter
+        self.counters = None
+
+    def __iter__(self):
+        self.counters = yield from self.object_iter
+
+    def run(self):
+        for _ in self:
+            pass
+        return self.counters
 
 
 def _dep_device_changed(dep_device, defaults):
@@ -294,21 +313,19 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
                                                   serial_number=serial_number,
                                                   **defaults)
             add_event(dep_device, AuditEvent.Action.CREATED)
-            counters["created"] += 1
-            created = True
+            action = "created"
+        elif _dep_device_changed(dep_device, defaults):
+            prev_value = dep_device.serialize_for_event()
+            for attr, value in defaults.items():
+                setattr(dep_device, attr, value)
+            dep_device.save()
+            add_event(dep_device, AuditEvent.Action.UPDATED, prev_value=prev_value)
+            action = "updated"
         else:
-            created = False
-            if _dep_device_changed(dep_device, defaults):
-                prev_value = dep_device.serialize_for_event()
-                for attr, value in defaults.items():
-                    setattr(dep_device, attr, value)
-                dep_device.save()
-                add_event(dep_device, AuditEvent.Action.UPDATED, prev_value=prev_value)
-                counters["updated"] += 1
-            else:
-                counters["unchanged"] += 1
+            action = "unchanged"
+        counters[action] += 1
 
-        yield dep_device, created
+        yield dep_device, action
     dep_token.sync_cursor = devices.cursor
     dep_token.last_synced_at = timezone.now()
     dep_token.save()
@@ -364,6 +381,7 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
             event.post()
 
     transaction.on_commit(post_events)
+    return counters
 
 
 def assign_dep_device_profile(dep_device, dep_profile):

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from zentral.conf import settings
-from zentral.core.events.base import AuditEvent
+from zentral.core.events.base import AuditEvent, EventRequest
 from zentral.utils.certificates import split_certificate_chain
 from zentral.utils.time import naive_utcnow, parse_naive_datetime
 
@@ -195,7 +195,8 @@ def dep_device_update_dict(device, known_enrollments=None):
     return update_d
 
 
-def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, lock_timeout=600):
+def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, lock_timeout=600,
+                                    serialized_event_request=None):
     PG_ADVISORY_LOCK_ID = 12345678
     with transaction.atomic():
         with connection.cursor() as cursor:
@@ -206,7 +207,8 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, lock_
                            [PG_ADVISORY_LOCK_ID, dep_virtual_server.pk])
             logger.info("Advisory lock %s for DEP virtual server %s acquired",
                         PG_ADVISORY_LOCK_ID, dep_virtual_server.pk)
-        return (yield from _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch))
+        return (yield from _sync_dep_virtual_server_devices(
+            dep_virtual_server, force_fetch, serialized_event_request))
 
 
 class SyncCounters(object):
@@ -247,22 +249,41 @@ def _dep_device_changed(dep_device, defaults):
     return False
 
 
-def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
+def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, serialized_event_request=None):
+    started_at = time.monotonic()
+    event_request = EventRequest.deserialize(serialized_event_request) if serialized_event_request else None
+    # read inside the advisory lock: a sync that just finished may have moved the cursor
     dep_token = dep_virtual_server.token
+    fetch = force_fetch or not dep_token.sync_cursor
+    try:
+        return (yield from _iter_dep_virtual_server_sync(
+            dep_virtual_server, dep_token, fetch, started_at, event_request))
+    except Exception as e:
+        # the surrounding transaction is rolling back, so nothing was written and the device
+        # events never happened: report the failure alone, and not through transaction.on_commit
+        payload = {"dep_virtual_server": dep_virtual_server.serialize_for_event(keys_only=True),
+                   "sync_type": "full" if fetch else "delta",
+                   "status": "failure",
+                   "error": str(e),
+                   "duration_seconds": round(time.monotonic() - started_at, 3)}
+        error_code = getattr(e, "error_code", None)
+        if error_code:
+            payload["error_code"] = error_code
+        build_dep_virtual_server_synced_event(
+            dep_virtual_server, payload, uuid.uuid4(), 0, event_request
+        ).post()
+        raise
+
+
+def _iter_dep_virtual_server_sync(dep_virtual_server, dep_token, fetch, started_at, event_request):
     client = DEPClient.from_dep_token(dep_token)
-    if force_fetch or not dep_token.sync_cursor:
-        fetch = True
-        devices = client.fetch_devices()
-    else:
-        fetch = False
-        devices = client.sync_devices(dep_token.sync_cursor)
+    devices = client.fetch_devices() if fetch else client.sync_devices(dep_token.sync_cursor)
 
     known_enrollments = {e.uuid: e for e in dep_virtual_server.depenrollment_set.all()}
 
     found_serial_numbers = []
     unassigned_serial_numbers = []
 
-    started_at = time.monotonic()
     events = []
     event_uuid = uuid.uuid4()
     counters = {"created": 0, "updated": 0, "unchanged": 0, "marked_deleted": 0, "profiles_assigned": 0}
@@ -271,6 +292,7 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
         # index 0 is kept for the summary event, which is only complete once the sync is over
         events.append(AuditEvent.build(dep_device, action, prev_value=prev_value,
                                        event_uuid=event_uuid, event_index=len(events) + 1,
+                                       event_request=event_request,
                                        machine_serial_number=dep_device.serial_number))
 
     for device in devices:
@@ -372,9 +394,11 @@ def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
 
     payload = {"dep_virtual_server": dep_virtual_server.serialize_for_event(keys_only=True),
                "sync_type": "full" if fetch else "delta",
+               "status": "success",
                "operations": counters,
                "duration_seconds": round(time.monotonic() - started_at, 3)}
-    events.insert(0, build_dep_virtual_server_synced_event(dep_virtual_server, payload, event_uuid, 0))
+    events.insert(0, build_dep_virtual_server_synced_event(
+        dep_virtual_server, payload, event_uuid, 0, event_request))
 
     def post_events():
         for event in events:

--- a/zentral/contrib/mdm/events/management.py
+++ b/zentral/contrib/mdm/events/management.py
@@ -117,7 +117,8 @@ class DEPVirtualServerSyncedEvent(BaseEvent):
 register_event_type(DEPVirtualServerSyncedEvent)
 
 
-def build_dep_virtual_server_synced_event(dep_virtual_server, payload, event_uuid, event_index):
-    event_metadata = EventMetadata(uuid=event_uuid, index=event_index)
+def build_dep_virtual_server_synced_event(dep_virtual_server, payload, event_uuid, event_index,
+                                          event_request=None):
+    event_metadata = EventMetadata(uuid=event_uuid, index=event_index, request=event_request)
     event_metadata.add_objects({"mdm_dep_virtual_server": ((dep_virtual_server.pk,),)})
     return DEPVirtualServerSyncedEvent(event_metadata, payload)

--- a/zentral/contrib/mdm/events/management.py
+++ b/zentral/contrib/mdm/events/management.py
@@ -91,7 +91,7 @@ def post_device_lock_pin_viewed_event(request, enrolled_device):
 
 class DEPDeviceDisownedEvent(BaseEvent):
     event_type = "dep_device_disowned"
-    tags = ["mdm"]
+    tags = ["mdm", "dep"]
 
 
 register_event_type(DEPDeviceDisownedEvent)

--- a/zentral/contrib/mdm/events/management.py
+++ b/zentral/contrib/mdm/events/management.py
@@ -104,3 +104,20 @@ def post_dep_device_disowned_event(request, dep_device, payload):
     )
     event = DEPDeviceDisownedEvent(event_metadata, payload)
     event.post()
+
+
+# DEP virtual server
+
+
+class DEPVirtualServerSyncedEvent(BaseEvent):
+    event_type = "dep_virtual_server_synced"
+    tags = ["mdm", "dep"]
+
+
+register_event_type(DEPVirtualServerSyncedEvent)
+
+
+def build_dep_virtual_server_synced_event(dep_virtual_server, payload, event_uuid, event_index):
+    event_metadata = EventMetadata(uuid=event_uuid, index=event_index)
+    event_metadata.add_objects({"mdm_dep_virtual_server": ((dep_virtual_server.pk,),)})
+    return DEPVirtualServerSyncedEvent(event_metadata, payload)

--- a/zentral/contrib/mdm/management/commands/sync_dep_devices.py
+++ b/zentral/contrib/mdm/management/commands/sync_dep_devices.py
@@ -33,15 +33,13 @@ class Command(BaseCommand):
         for server in depvs_qs:
             self.write(f"Sync server {server.pk} {server}")
             try:
-                for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=full_sync):
-                    operation = "Created" if created else "Updated"
-                    self.write(f"{operation} {dep_device}")
+                for dep_device, action in sync_dep_virtual_server_devices(server, force_fetch=full_sync):
+                    self.write(f"{action.title()} {dep_device}")
             except DEPClientError as e:
                 if e.error_code == "EXPIRED_CURSOR":
                     self.write("Expired cursor → full sync")
-                    for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=True):
-                        operation = "Created" if created else "Updated"
-                        self.write(f"{operation} {dep_device}")
+                    for dep_device, action in sync_dep_virtual_server_devices(server, force_fetch=True):
+                        self.write(f"{action.title()} {dep_device}")
                 else:
                     self.stderr.write(f"DEP client error: {e}")
             except Exception as e:

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -1524,6 +1524,9 @@ class EnrollmentSession(models.Model):
         d = {"pk": self.pk,
              "type": enrollment_session_type,
              "status": self.status}
+        # the enrollments are referenced by their keys only: these events are posted on every
+        # enrollment attempt, and the full serialization carries the enrollment secret metadata
+        d.update(extra_dict)
         return {"enrollment_session": d}
 
     # status update methods
@@ -1770,7 +1773,8 @@ class OTAEnrollmentSession(EnrollmentSession):
             raise ValueError("Wrong enrollment sessions status")
 
     def serialize_for_event(self):
-        return super().serialize_for_event("ota", {"ota_enrollment": self.ota_enrollment.serialize_for_event()})
+        return super().serialize_for_event("ota", {"ota_enrollment": self.ota_enrollment.serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.ota_enrollment.blueprint
@@ -2288,7 +2292,8 @@ class DEPEnrollmentSession(EnrollmentSession):
             raise ValueError("Wrong enrollment sessions status")
 
     def serialize_for_event(self):
-        return super().serialize_for_event("dep", {"dep_enrollment": self.dep_enrollment.serialize_for_event()})
+        return super().serialize_for_event("dep", {"dep_enrollment": self.dep_enrollment.serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.dep_enrollment.blueprint
@@ -2430,7 +2435,8 @@ class UserEnrollmentSession(EnrollmentSession):
             raise ValueError("Wrong enrollment sessions status")
 
     def serialize_for_event(self):
-        return super().serialize_for_event("user", {"user_enrollment": self.user_enrollment.serialize_for_event()})
+        return super().serialize_for_event("user", {"user_enrollment": self.user_enrollment.serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.user_enrollment.blueprint
@@ -2553,7 +2559,8 @@ class ReEnrollmentSession(EnrollmentSession):
         return self.first_enrolled_at
 
     def serialize_for_event(self):
-        return super().serialize_for_event("re", self.get_enrollment().serialize_for_event())
+        return super().serialize_for_event("re", {"enrollment": self.get_enrollment().serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.get_enrollment().blueprint

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -14,7 +14,9 @@ logger = logging.getLogger("zentral.contrib.mdm.tasks")
 
 
 @shared_task
-def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=False):
+def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=False,
+                                         serialized_event_request=None, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     server = DEPVirtualServer.objects.get(pk=dep_virtual_server_pk)
     result = {"dep_virtual_server": {"pk": server.pk,
                                      "name": server.name},
@@ -22,7 +24,9 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
               "effective_sync_type": "full_sync" if force_full_sync else "delta_sync"}
 
     def run(force_fetch):
-        return SyncCounters(sync_dep_virtual_server_devices(server, force_fetch=force_fetch)).run()
+        return SyncCounters(sync_dep_virtual_server_devices(
+            server, force_fetch=force_fetch, serialized_event_request=serialized_event_request
+        )).run()
 
     try:
         result["operations"] = run(force_full_sync)

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -3,7 +3,7 @@ import logging
 from celery import shared_task
 
 from .apps_books import bulk_assign_location_asset
-from .dep import DEPClientError, define_dep_profile, sync_dep_virtual_server_devices
+from .dep import DEPClientError, SyncCounters, define_dep_profile, sync_dep_virtual_server_devices
 from .models import DEPEnrollment, DEPVirtualServer, LocationAsset
 from .software_updates import sync_software_updates
 
@@ -18,26 +18,19 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
     server = DEPVirtualServer.objects.get(pk=dep_virtual_server_pk)
     result = {"dep_virtual_server": {"pk": server.pk,
                                      "name": server.name},
-              "operations": {"created": 0,
-                             "updated": 0},
               "requested_sync_type": "full_sync" if force_full_sync else "delta_sync",
               "effective_sync_type": "full_sync" if force_full_sync else "delta_sync"}
 
-    def update_counters(created):
-        if created:
-            result["operations"]["created"] += 1
-        else:
-            result["operations"]["updated"] += 1
+    def run(force_fetch):
+        return SyncCounters(sync_dep_virtual_server_devices(server, force_fetch=force_fetch)).run()
 
     try:
-        for _, created in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync):
-            update_counters(created)
+        result["operations"] = run(force_full_sync)
     except DEPClientError as e:
         if e.error_code == "EXPIRED_CURSOR":
-            # full sync
+            # full sync, from scratch: whatever the delta sync had counted is not part of it
             result["effective_sync_type"] = "full_sync"
-            for _, created in sync_dep_virtual_server_devices(server, force_fetch=True):
-                update_counters(created)
+            result["operations"] = run(True)
         else:
             raise
 

--- a/zentral/utils/drf.py
+++ b/zentral/utils/drf.py
@@ -74,11 +74,11 @@ class ListCreateAPIViewWithAudit(generics.ListCreateAPIView):
         transaction.on_commit(on_commit_callback)
 
 
-class RetrieveUpdateDestroyAPIViewWithAudit(generics.RetrieveUpdateDestroyAPIView):
+class UpdateAPIViewWithAuditMixin:
     permission_classes = [DefaultDjangoModelPermissions]
     # Zentral only does full updates — PATCH is a 405 everywhere, so the serializers' update()
     # methods can rely on every declared field being present in validated_data
-    http_method_names = ["delete", "get", "head", "options", "put"]
+    http_method_names = ["get", "head", "options", "put"]
 
     def get_audit_machine_serial_number(self):
         return None
@@ -102,6 +102,14 @@ class RetrieveUpdateDestroyAPIViewWithAudit(generics.RetrieveUpdateDestroyAPIVie
             self.on_commit_callback_extra(instance)
 
         transaction.on_commit(on_commit_callback)
+
+
+class RetrieveUpdateAPIViewWithAudit(UpdateAPIViewWithAuditMixin, generics.RetrieveUpdateAPIView):
+    pass
+
+
+class RetrieveUpdateDestroyAPIViewWithAudit(UpdateAPIViewWithAuditMixin, generics.RetrieveUpdateDestroyAPIView):
+    http_method_names = UpdateAPIViewWithAuditMixin.http_method_names + ["delete"]
 
     def perform_destroy(self, instance):
         prev_pk = instance.pk


### PR DESCRIPTION
The synchronization with Apple Business Manager was the one DEP workflow that left no trace in the event pipeline. A device assigned to us in ABM, unassigned, deleted, or whose profile was removed on the Apple side all landed in the database silently. The only record was the Celery task result, which `django-celery-results` expires within a day, so there was nothing to search in the event store and nothing on a device's timeline.

## What the synchronization posts now

Every device it really changes produces the same `zentral_audit` event the assign and refresh views already emit — same shape, tagged with the machine serial number — so the whole history of a DEP device is one event type. Each run also posts a `dep_virtual_server_synced` summary:

```json
{
  "dep_virtual_server": {"pk": 1, "uuid": "…", "name": "…"},
  "sync_type": "full",
  "status": "success",
  "operations": {"created": 2, "updated": 5, "unchanged": 1180,
                 "marked_deleted": 1, "profiles_assigned": 2},
  "duration_seconds": 12.482
}
```

All the events of one run share the metadata `id`, with the summary at index 0, so a run can be pulled back together. A run that fails posts the summary with a `failure` status, the error and Apple's error code, and no counters — the transaction is rolling back, so none of the devices it had read were written.

**Only the devices that moved are recorded, and now also written.** Apple returns the whole list on a full fetch; without that, a synchronization would rewrite the table and post an event per device every time. That comparison needs the parsed values and the stored ones to be comparable, so `dep_device_update_dict()` builds naive datetimes with `parse_naive_datetime()` instead of aware ones with `dateutil`.

## Task result and event no longer disagree

The task counted every device it had not created as updated, so a full fetch of a fleet that had not moved reported thousands of updates. The synchronization now yields the action it took for each device and returns its counters through the generator, the way `CursorIterator` already carries the cursor back; the task returns those counters instead of counting again.

⚠️ **API change.** The result of `/api/mdm/dep/virtual_servers/<pk>/sync_devices/` gains `unchanged`, `marked_deleted` and `profiles_assigned`, and `updated` drops to the devices that really changed. A client reading `operations.updated` as the number of devices Apple returned has to read `created + updated + unchanged`.

## Attribution, and a bug it exposed

A synchronization triggered from the web interface was indistinguishable from one Zentral ran on its own: the events carried no request, and no `UserTask` was created, so the task list had nothing to show in its user column. The API view now passes the serialized event request and the task user, the way the monolith repository sync already does.

Passing them exposed a bug in the same call: `force_full_sync` was given to `apply_async` as an option instead of a task kwarg, so it never reached the task. **The `full_sync` query parameter has never done anything** — neither from the API nor from the Synchronize button. The task kwargs are now passed as the dict `apply_async` expects.

## Three smaller gaps

- Assigning an enrollment profile over the HTTP API changed the device without recording anything, while the same action from the web interface posted an audit event. `RetrieveUpdateAPIViewWithAudit` is split out of the existing retrieve/update/destroy view — a DEP device is never deleted — and `DEPDeviceDetail` uses it.
- `EnrollmentSession.serialize_for_event()` took an `extra_dict` and dropped it, so the `*_enrollment_request` events never said which enrollment was used. It is applied again, with the enrollments referenced by their keys only: these events fire on every enrollment attempt, and the full serialization pulls in the enrollment secret metadata. The re-enrollment session passed its enrollment unwrapped, which would have overwritten the session `pk`, so it now nests it under an `enrollment` key.
- `DEPDeviceDisownedEvent` was the only DEP event without the `dep` tag, so a `tag=dep` search missed disowned devices.

## Tests

Full suite green. New coverage for the created/unchanged/changed/marked-deleted paths, the failure event and its rollback, the request reaching both event kinds, the task kwargs, and the API audit event. One existing assertion in `test_tasks.py` changed from `{"created": 1, "updated": 1}` to `{"created": 1, "updated": 0, "unchanged": 1}` — it was encoding the counting bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
