### PR TITLE
Wait for the tasks and report their outcome in the bundle

### DIFF
--- a/server/static_src/js/main.js
+++ b/server/static_src/js/main.js
@@ -78,3 +78,106 @@ $(document).ready(function () {
         }
     }
 });
+
+
+// tasks
+//
+// A link with the task class posts to its href to launch a celery task, then polls
+// the task result until it is ready. The messages are built with the task label. A
+// task result with a file sends the browser to the download URL, without one the
+// page is reloaded to display what the task changed. An export link carries the
+// format in data-format, and its enclosing form is posted with it.
+
+var TASK_POLLING_DELAY = 1000;
+var TASK_RELOAD_DELAY = 1000;
+
+function addMessage(message, tag) {
+    var alert = document.createElement("div");
+    alert.className = "alert alert-" + (tag === "error" ? "danger" : tag) + " alert-dismissible fade show";
+    alert.setAttribute("role", "alert");
+    alert.textContent = message;
+    var closeButton = document.createElement("button");
+    closeButton.type = "button";
+    closeButton.className = "btn-close";
+    closeButton.setAttribute("data-bs-dismiss", "alert");
+    closeButton.setAttribute("aria-label", "Close");
+    alert.appendChild(closeButton);
+    document.getElementById("messages").appendChild(alert);
+    return alert;
+}
+
+function taskDone($link, startedMessage, message, tag) {
+    if (startedMessage) {
+        startedMessage.remove();
+    }
+    $link.removeClass("disabled");
+    addMessage(message, tag);
+}
+
+function waitForTask(url, $link, startedMessage) {
+    var label = $link.data("task-label");
+    $.ajax({
+        dataType: "json",
+        url: url,
+        success: function (data) {
+            if (data.unready) {
+                window.setTimeout(waitForTask, TASK_POLLING_DELAY, url, $link, startedMessage);
+            } else if (data.status !== "SUCCESS") {
+                taskDone($link, startedMessage, label + " failed.", "error");
+            } else if ((data.result || {}).status === "SKIPPED") {
+                taskDone($link, startedMessage, label + " skipped, already running.", "warning");
+            } else if (data.download_url) {
+                taskDone($link, startedMessage, label + " done.", "success");
+                window.location = data.download_url;
+            } else {
+                if (startedMessage) {
+                    startedMessage.remove();
+                }
+                addMessage(label + " done.", "success");
+                // the link stays disabled, the message is displayed for a moment before the reload
+                window.setTimeout(function () { window.location.reload(); }, TASK_RELOAD_DELAY);
+            }
+        },
+        error: function () {
+            taskDone($link, startedMessage, label + " status unknown.", "error");
+        }
+    });
+}
+
+function launchTask($link) {
+    var label = $link.data("task-label");
+    var options = {
+        dataType: "json",
+        url: $link.attr("href"),
+        method: "post",
+        success: function (data) {
+            var startedMessage = addMessage(label + " started.", "info");
+            window.setTimeout(waitForTask, 300, data.task_result_url, $link, startedMessage);
+        },
+        error: function () {
+            taskDone($link, null, label + " could not be launched.", "error");
+        }
+    };
+    var exportFormat = $link.data("format");
+    if (exportFormat) {
+        var postData = {"export_format": exportFormat};
+        $.each($link.parents("form").serializeArray(), function (index, field) {
+            if (field.value) {
+                postData[field.name] = field.value;
+            }
+        });
+        options.contentType = "application/json";
+        options.data = JSON.stringify(postData);
+    }
+    $link.addClass("disabled");
+    $.ajax(options);
+}
+
+$(document).ready(function () {
+    // the pages that still wait for their tasks themselves bind the task class too,
+    // the label is what tells them apart. To be dropped once they all use this code.
+    $(".task[data-task-label]").click(function (event) {
+        event.preventDefault();
+        launchTask($(this));
+    });
+});

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -64,12 +64,14 @@
         </div>
         {% endif %}
         <main class="container-fluid overflow-auto">
+        <div id="messages">
         {% for message in messages %}
         <div class="alert alert-{% if message.tags == 'error' %}danger{% else %}{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">
           {{ message }}
           <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         {% endfor %}
+        </div>
         {% block content %}
         {% endblock %}
         </main>

--- a/zentral/contrib/monolith/templates/monolith/repository_detail.html
+++ b/zentral/contrib/monolith/templates/monolith/repository_detail.html
@@ -17,7 +17,8 @@
         <h3 class="m-0 fs-5 text-secondary">Repository</h3>
         <div class="ms-auto">
             {% if perms.monolith.sync_repository %}
-            <a id="repository-sync-btn" href="{% url 'monolith_api:sync_repository' object.pk %}" class="btn btn-link task"
+            <a href="{% url 'monolith_api:sync_repository' object.pk %}" class="btn btn-link task"
+                data-task-label="Repository sync"
                 data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Sync Monolith repository">
               <i class="bi bi-arrow-counterclockwise"></i>
             </a>
@@ -184,45 +185,6 @@
 
 {% block extrajs %}
 <script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else {
-          $("#repository-sync-btn").prop("disabled", false);
-          if (data.status === "SUCCESS") {
-            window.location.reload();
-          }
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-      $link.prop("disabled", true);
-      var url = $link.attr("href");
-      $.ajax({
-        dataType: "json",
-        url: url,
-        method: "post",
-        success: function (data) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-      });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-
   var openEyes = document.querySelectorAll(".bi-eye");
   openEyes.forEach(function(openEye) {
     openEye.addEventListener("click", function(event) {


### PR DESCRIPTION
Follow-up to 7fad830b, which moved the monolith repository sync to a celery task.

## Problem

Eleven pages launch a celery task and poll the task result, and each one carries its own copy of the same `waitForTask`/`launchTask` pair, in an inline script. None of them reports anything: the monolith repository sync posts to the API and reloads the page when the task is done, so a sync that fails, or that is skipped because the repository is already being synced, looks exactly like a sync that did nothing. The exports are worse, a failed export does nothing at all.

## Changes

The task waiting code moves to `server/static_src/js/main.js`, the bundle already loaded on every page, and is driven by the markup instead of being copied:

* a link with the `task` class posts to its `href` and polls `task_result_url`;
* `data-task-label` builds the messages: *`<label>` started.* while it runs, replaced by *done.*, *failed.*, or *skipped, already running.* when the task result is ready;
* a task result with a file sends the browser to the `download_url`, without one the page is reloaded to display what the task changed, a second after the success message;
* an export link keeps its format in `data-format`, and its enclosing form is serialized and posted with it, as the inventory export pages do today.

`base.html` wraps the django messages in a `#messages` container, so the same alerts can be added to the page from javascript.

The monolith repository page is the first one to use it: its inline script is gone, replaced by `data-task-label=\"Repository sync\"` on the link.

## Notes for the reviewer

* The other ten pages still wait for their tasks themselves. They bind the `task` class too, and both handlers would fire, launching the task twice, so the shared code only binds the links carrying a label. The `[data-task-label]` part of the selector can go away once every page is converted.
* The sync button is disabled with the bootstrap `disabled` class instead of the `disabled` property, which has no effect on a link. A second click used to start a second task that could only be skipped.
* `SKIPPED` is only returned by the monolith sync task today. Reading it in the shared code makes it the convention for the tasks that decline to run.
* `tests.monolith` passes (559 tests). The bundle was built and exercised in a browser against stubbed responses, for the started, done, skipped, failed, and download outcomes, and the export POST body was checked to be the one the inventory pages send today.