### PR TITLE
Wait for the celery tasks in the bundle, and report their outcome

### DIFF
--- a/server/static_src/js/main.js
+++ b/server/static_src/js/main.js
@@ -78,3 +78,107 @@ $(document).ready(function () {
         }
     }
 });
+
+
+// tasks
+//
+// A link with the task class posts to its href to launch a celery task, then polls
+// the task result until it is ready. The messages are built with the task label. A
+// task result with a file sends the browser to the download URL, without one the
+// page is reloaded to display what the task changed. An export link carries the
+// format in data-format, and its enclosing form is posted with it.
+
+const TASK_POLLING_DELAY = 1000
+const TASK_RELOAD_DELAY = 1000
+
+function csrfToken() {
+    const cookie = document.cookie.split("; ").find(c => c.startsWith("csrftoken="))
+    return cookie ? decodeURIComponent(cookie.slice("csrftoken=".length)) : ""
+}
+
+function getJSON(url, options) {
+    return fetch(url, options).then(response => {
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`)
+        }
+        return response.json()
+    })
+}
+
+function addMessage(message, tag) {
+    const alert = document.createElement("div")
+    alert.className = `alert alert-${tag === "error" ? "danger" : tag} alert-dismissible fade show`
+    alert.setAttribute("role", "alert")
+    alert.textContent = message
+    const closeButton = document.createElement("button")
+    closeButton.type = "button"
+    closeButton.className = "btn-close"
+    closeButton.setAttribute("data-bs-dismiss", "alert")
+    closeButton.setAttribute("aria-label", "Close")
+    alert.appendChild(closeButton)
+    document.getElementById("messages").appendChild(alert)
+    return alert
+}
+
+function taskDone(link, startedMessage, message, tag) {
+    if (startedMessage) {
+        startedMessage.remove()
+    }
+    link.classList.remove("disabled")
+    addMessage(message, tag)
+}
+
+function waitForTask(url, link, startedMessage) {
+    const label = link.dataset.taskLabel
+    getJSON(url).then(data => {
+        if (data.unready) {
+            window.setTimeout(waitForTask, TASK_POLLING_DELAY, url, link, startedMessage)
+        } else if (data.status !== "SUCCESS") {
+            taskDone(link, startedMessage, `${label} failed.`, "error")
+        } else if ((data.result || {}).status === "SKIPPED") {
+            taskDone(link, startedMessage, `${label} skipped, already running.`, "warning")
+        } else if (data.download_url) {
+            taskDone(link, startedMessage, `${label} done.`, "success")
+            window.location = data.download_url
+        } else {
+            if (startedMessage) {
+                startedMessage.remove()
+            }
+            addMessage(`${label} done.`, "success")
+            // the link stays disabled, the message is displayed for a moment before the reload
+            window.setTimeout(() => window.location.reload(), TASK_RELOAD_DELAY)
+        }
+    }).catch(() => taskDone(link, startedMessage, `${label} status unknown.`, "error"))
+}
+
+function launchTask(link) {
+    const label = link.dataset.taskLabel
+    const options = {method: "POST", headers: {"X-CSRFToken": csrfToken()}}
+    const exportFormat = link.dataset.format
+    if (exportFormat) {
+        const postData = {"export_format": exportFormat}
+        const form = link.closest("form")
+        if (form) {
+            new FormData(form).forEach((value, name) => {
+                if (value) {
+                    postData[name] = value
+                }
+            })
+        }
+        options.headers["Content-Type"] = "application/json"
+        options.body = JSON.stringify(postData)
+    }
+    link.classList.add("disabled")
+    getJSON(link.href, options).then(data => {
+        const startedMessage = addMessage(`${label} started.`, "info")
+        window.setTimeout(waitForTask, 300, data.task_result_url, link, startedMessage)
+    }).catch(() => taskDone(link, null, `${label} could not be launched.`, "error"))
+}
+
+document.addEventListener("click", event => {
+    const link = event.target.closest(".task")
+    if (link) {
+        event.preventDefault()
+        launchTask(link)
+    }
+})

--- a/server/static_src/scss/styles.scss
+++ b/server/static_src/scss/styles.scss
@@ -80,6 +80,22 @@ pre, ol, ul, dl {
     margin-bottom: 0px;
 }
 
+// Messages
+// they stick to the top of the scrolled content, because the button launching a task
+// can be far down the page, a DEP virtual server sync for example
+#messages {
+    position: sticky;
+    top: 0;
+    z-index: $zindex-sticky;
+}
+
+// only when there is something to display, an empty container would hide the top of
+// the scrolled content behind its padding
+#messages:has(.alert) {
+    padding-top: map-get($spacers, 3);
+    background-color: var(--bs-body-bg);
+}
+
 // Forms
 .errorlist {
     color: $ztl-red;

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -64,12 +64,14 @@
         </div>
         {% endif %}
         <main class="container-fluid overflow-auto">
+        <div id="messages">
         {% for message in messages %}
         <div class="alert alert-{% if message.tags == 'error' %}danger{% else %}{{ message.tags }}{% endif %} alert-dismissible fade show" role="alert">
           {{ message }}
           <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         {% endfor %}
+        </div>
         {% block content %}
         {% endblock %}
         </main>

--- a/zentral/contrib/google_workspace/templates/google_workspace/connection_detail.html
+++ b/zentral/contrib/google_workspace/templates/google_workspace/connection_detail.html
@@ -85,8 +85,9 @@
         {% button 'CREATE' url "Create new group tag mapping" %}
     {% endif %}
     {% if perms.google_workspace.change_grouptagmapping and connection_authorized %}
-        <a id="grouptagmappings-sync-btn" href="{% url 'google_workspace_api:sync_tags' object.id %}"
-            class="btn btn-link task" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Synchronize">
+        <a href="{% url 'google_workspace_api:sync_tags' object.id %}"
+            class="btn btn-link task" data-task-label="Group tag mappings sync"
+            data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Synchronize">
                 <i class="bi bi-arrow-repeat"></i>
         </a>
     {% endif %}
@@ -137,48 +138,3 @@
 {% endif %}
 
 {% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else {
-          $("#grouptagmappings-sync-btn").prop("disabled", false);
-          if (data.status === "SUCCESS") {
-            window.location.reload();
-          }
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-      $link.prop("disabled", true);
-      var url = $link.attr("href");
-      $.ajax({
-        dataType: "json",
-        url: url,
-        method: "post",
-        success: function (data) {
-            
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-      });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-</script>
-{% endblock %}
-

--- a/zentral/contrib/inventory/templates/inventory/android_apps.html
+++ b/zentral/contrib/inventory/templates/inventory/android_apps.html
@@ -30,8 +30,10 @@
             <i class="bi bi-download"></i>
         </button>
         <ul class="dropdown-menu" aria-labelledby="downloadTargets">
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:android_apps_export' %}" data-format="csv">CSV</a></li>
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:android_apps_export' %}" data-format="xlsx">XLSX</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:android_apps_export' %}"
+                   data-format="csv" data-task-label="Android apps export (CSV)">CSV</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:android_apps_export' %}"
+                   data-format="xlsx" data-task-label="Android apps export (XLSX)">XLSX</a></li>
         </ul>
     </form>
 </div>
@@ -80,53 +82,4 @@
         {% empty_results empty_results_url %}
     {% endif %}
 
-{% endblock %}
-
-    {% block extrajs %}
-    <script nonce="{{ request.csp_nonce }}">
-    var WAIT_FOR_TASK_TIMEOUT_ID;
-
-    function waitForTask(url) {
-        $.ajax({
-        dataType: "json",
-        url: url,
-        success: function (data) {
-            console.log(data);
-            if (data.unready) {
-            WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-            } else if (data.status === "SUCCESS") {
-            window.location = data.download_url;
-            }
-        }
-        });
-    }
-
-    function launchTask($link) {
-        var url = $link.attr("href");
-        var postData = {"export_format": $link.data("format")};
-        var formData = $link.parents("form").serializeArray();
-        $.map(formData, function(n, i) {
-        if (n['value']) {
-            postData[n['name']] = n['value'];
-        }
-        });
-        $.ajax({
-        dataType: "json",
-        contentType: "application/json",
-        url: url,
-        data: JSON.stringify(postData),
-        method: "post",
-        success: function (data) {
-            WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-        });
-    }
-
-    $(document).ready(function () {
-        $(".task").click(function (event) {
-        event.preventDefault();
-        launchTask($(this));
-        });
-    });
-    </script>
 {% endblock %}

--- a/zentral/contrib/inventory/templates/inventory/deb_packages.html
+++ b/zentral/contrib/inventory/templates/inventory/deb_packages.html
@@ -30,8 +30,10 @@
             <i class="bi bi-download"></i>
         </button>
         <ul class="dropdown-menu" aria-labelledby="downloadTargets">
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:deb_packages_export' %}" data-format="csv">CSV</a></li>
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:deb_packages_export' %}" data-format="xlsx">XLSX</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:deb_packages_export' %}"
+                   data-format="csv" data-task-label="Debian packages export (CSV)">CSV</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:deb_packages_export' %}"
+                   data-format="xlsx" data-task-label="Debian packages export (XLSX)">XLSX</a></li>
         </ul>
     </form>
 </div>
@@ -80,53 +82,4 @@
         {% empty_results empty_results_url %}
     {% endif %}
 
-{% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        console.log(data);
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-          window.location = data.download_url;
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-    var url = $link.attr("href");
-    var postData = {"export_format": $link.data("format")};
-    var formData = $link.parents("form").serializeArray();
-    $.map(formData, function(n, i) {
-      if (n['value']) {
-        postData[n['name']] = n['value'];
-      }
-    });
-    $.ajax({
-      dataType: "json",
-      contentType: "application/json",
-      url: url,
-      data: JSON.stringify(postData),
-      method: "post",
-      success: function (data) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-      }
-    });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-</script>
 {% endblock %}

--- a/zentral/contrib/inventory/templates/inventory/ios_apps.html
+++ b/zentral/contrib/inventory/templates/inventory/ios_apps.html
@@ -30,8 +30,10 @@
             <i class="bi bi-download"></i>
         </button>
         <ul class="dropdown-menu" aria-labelledby="downloadTargets">
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:ios_apps_export' %}" data-format="csv">CSV</a></li>
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:ios_apps_export' %}" data-format="xlsx">XLSX</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:ios_apps_export' %}"
+                   data-format="csv" data-task-label="iOS apps export (CSV)">CSV</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:ios_apps_export' %}"
+                   data-format="xlsx" data-task-label="iOS apps export (XLSX)">XLSX</a></li>
         </ul>
     </form>
 </div>
@@ -81,53 +83,4 @@
         {% empty_results empty_results_url %}
     {% endif %}
 
-{% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        console.log(data);
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-          window.location = data.download_url;
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-    var url = $link.attr("href");
-    var postData = {"export_format": $link.data("format")};
-    var formData = $link.parents("form").serializeArray();
-    $.map(formData, function(n, i) {
-      if (n['value']) {
-        postData[n['name']] = n['value'];
-      }
-    });
-    $.ajax({
-      dataType: "json",
-      contentType: "application/json",
-      url: url,
-      data: JSON.stringify(postData),
-      method: "post",
-      success: function (data) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-      }
-    });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-</script>
 {% endblock %}

--- a/zentral/contrib/inventory/templates/inventory/machine_list.html
+++ b/zentral/contrib/inventory/templates/inventory/machine_list.html
@@ -237,7 +237,8 @@
             </button>
             <ul class="dropdown-menu">
                 {% for format, link in export_links %}
-                <li><a href="{{ link }}" class="task dropdown-item">{{ format|upper }}</a></li>
+                <li><a href="{{ link }}" class="task dropdown-item"
+                       data-task-label="Machines export ({{ format|upper }})">{{ format|upper }}</a></li>
                 {% endfor %}
             </ul>
         </div>
@@ -452,35 +453,6 @@
     });
   }
 
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        console.log(data);
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-          window.location = data.download_url;
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-      var url = $link.attr("href");
-      $.ajax({
-        dataType: "json",
-        url: url,
-        method: "post",
-        success: function (data) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-      });
-  }
-
   $(document).ready(function () {
     // remove filter links
     $(".filter-title").hover(
@@ -504,11 +476,6 @@
     $(".reorder-filter").click(function (event) {
       event.preventDefault();
       sortFilterList($(this));
-    });
-
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
     });
   });
 </script>

--- a/zentral/contrib/inventory/templates/inventory/macos_apps.html
+++ b/zentral/contrib/inventory/templates/inventory/macos_apps.html
@@ -30,8 +30,10 @@
             <i class="bi bi-download"></i>
         </button>
         <ul class="dropdown-menu" aria-labelledby="downloadTargets">
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:macos_apps_export' %}" data-format="csv">CSV</a></li>
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:macos_apps_export' %}" data-format="xlsx">XLSX</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:macos_apps_export' %}"
+                   data-format="csv" data-task-label="macOS apps export (CSV)">CSV</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:macos_apps_export' %}"
+                   data-format="xlsx" data-task-label="macOS apps export (XLSX)">XLSX</a></li>
         </ul>
     </form>
 </div>
@@ -85,53 +87,4 @@
         {% empty_results empty_results_url %}
     {% endif %}
 
-{% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        console.log(data);
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-          window.location = data.download_url;
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-    var url = $link.attr("href");
-    var postData = {"export_format": $link.data("format")};
-    var formData = $link.parents("form").serializeArray();
-    $.map(formData, function(n, i) {
-      if (n['value']) {
-        postData[n['name']] = n['value'];
-      }
-    });
-    $.ajax({
-      dataType: "json",
-      contentType: "application/json",
-      url: url,
-      data: JSON.stringify(postData),
-      method: "post",
-      success: function (data) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-      }
-    });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-</script>
 {% endblock %}

--- a/zentral/contrib/inventory/templates/inventory/programs.html
+++ b/zentral/contrib/inventory/templates/inventory/programs.html
@@ -30,8 +30,10 @@
             <i class="bi bi-download"></i>
         </button>
         <ul class="dropdown-menu" aria-labelledby="downloadTargets">
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:programs_export' %}" data-format="csv">CSV</a></li>
-            <li><a class="dropdown-item task" href="{% url 'inventory_api:programs_export' %}" data-format="xlsx">XLSX</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:programs_export' %}"
+                   data-format="csv" data-task-label="Programs export (CSV)">CSV</a></li>
+            <li><a class="dropdown-item task" href="{% url 'inventory_api:programs_export' %}"
+                   data-format="xlsx" data-task-label="Programs export (XLSX)">XLSX</a></li>
         </ul>
     </form>
 </div>
@@ -85,53 +87,4 @@
         {% empty_results empty_results_url %}
     {% endif %}
 
-{% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        console.log(data);
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-          window.location = data.download_url;
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-    var url = $link.attr("href");
-    var postData = {"export_format": $link.data("format")};
-    var formData = $link.parents("form").serializeArray();
-    $.map(formData, function(n, i) {
-      if (n['value']) {
-        postData[n['name']] = n['value'];
-      }
-    });
-    $.ajax({
-      dataType: "json",
-      contentType: "application/json",
-      url: url,
-      data: JSON.stringify(postData),
-      method: "post",
-      success: function (data) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-      }
-    });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-</script>
 {% endblock %}

--- a/zentral/contrib/mdm/templates/mdm/depvirtualserver_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/depvirtualserver_detail.html
@@ -130,7 +130,8 @@
         <h3>Device{{ devices_count|pluralize }} ({{ devices_count }})</h3>
         <div class="ms-auto">
             {% if perms.mdm.change_depvirtualserver %}
-            <a id="devices-sync-btn" href="{% url 'mdm_api:dep_virtual_server_sync_devices' object.id %}" class="btn btn-link task"
+            <a href="{% url 'mdm_api:dep_virtual_server_sync_devices' object.id %}" class="btn btn-link task"
+                data-task-label="Devices sync"
                 data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Synchronize">
                 <i class="bi bi-arrow-repeat"></i>
             </a>
@@ -243,38 +244,6 @@
 
 {% block extrajs %}
 <script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else {
-          $("#devices-sync-btn").prop("disabled", false);
-          if (data.status === "SUCCESS") {
-            window.location.reload();
-          }
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-      $link.prop("disabled", true);
-      var url = $link.attr("href");
-      $.ajax({
-        dataType: "json",
-        url: url,
-        method: "post",
-        success: function (data) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-      });
-  }
-
   function renderBetaTokensError(message) {
     var container = document.getElementById("beta-tokens-container");
     container.replaceChildren();
@@ -349,13 +318,6 @@
     if (betaTokensBtn) {
       betaTokensBtn.addEventListener("click", fetchBetaTokens);
     }
-  });
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
   });
 </script>
 {% endblock %}

--- a/zentral/contrib/monolith/templates/monolith/repository_detail.html
+++ b/zentral/contrib/monolith/templates/monolith/repository_detail.html
@@ -17,7 +17,8 @@
         <h3 class="m-0 fs-5 text-secondary">Repository</h3>
         <div class="ms-auto">
             {% if perms.monolith.sync_repository %}
-            <a id="repository-sync-btn" href="{% url 'monolith_api:sync_repository' object.pk %}" class="btn btn-link task"
+            <a href="{% url 'monolith_api:sync_repository' object.pk %}" class="btn btn-link task"
+                data-task-label="Repository sync"
                 data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Sync Monolith repository">
               <i class="bi bi-arrow-counterclockwise"></i>
             </a>
@@ -184,45 +185,6 @@
 
 {% block extrajs %}
 <script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else {
-          $("#repository-sync-btn").prop("disabled", false);
-          if (data.status === "SUCCESS") {
-            window.location.reload();
-          }
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-      $link.prop("disabled", true);
-      var url = $link.attr("href");
-      $.ajax({
-        dataType: "json",
-        url: url,
-        method: "post",
-        success: function (data) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-      });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-
   var openEyes = document.querySelectorAll(".bi-eye");
   openEyes.forEach(function(openEye) {
     openEye.addEventListener("click", function(event) {

--- a/zentral/contrib/osquery/templates/osquery/distributedqueryresult_list.html
+++ b/zentral/contrib/osquery/templates/osquery/distributedqueryresult_list.html
@@ -26,7 +26,8 @@
         </button>
         <ul class="dropdown-menu">
             {% for format, link in export_links %}
-            <li><a class="dropdown-item task" href="{{ link }}">{{ format|upper }}</a></li>
+            <li><a class="dropdown-item task" href="{{ link }}"
+                   data-task-label="Results export ({{ format|upper }})">{{ format|upper }}</a></li>
             {% endfor %}
         </ul>
         </div>
@@ -115,53 +116,4 @@
 
   </div>
 </div>
-{% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-  var WAIT_FOR_TASK_TIMEOUT_ID;
-
-  function waitForTask(url) {
-    $.ajax({
-      dataType: "json",
-      url: url,
-      success: function (data) {
-        console.log(data);
-        if (data.unready) {
-          WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-          window.location = data.download_url;
-        }
-      }
-    });
-  }
-
-  function launchTask($link) {
-    var url = $link.attr("href");
-    var postData = {"export_format": $link.data("format")};
-    var formData = $link.parents("form").serializeArray();
-    $.map(formData, function(n, i) {
-      if (n['value']) {
-        postData[n['name']] = n['value'];
-      }
-    });
-    $.ajax({
-      dataType: "json",
-      contentType: "application/json",
-      url: url,
-      data: JSON.stringify(postData),
-      method: "post",
-      success: function (data) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-      }
-    });
-  }
-
-  $(document).ready(function () {
-    $(".task").click(function (event) {
-      event.preventDefault();
-      launchTask($(this));
-    });
-  });
-</script>
 {% endblock %}

--- a/zentral/contrib/santa/templates/santa/targets.html
+++ b/zentral/contrib/santa/templates/santa/targets.html
@@ -33,7 +33,8 @@
             </button>
             <ul class="dropdown-menu" aria-labelledby="downloadTargets">
                 {% for format, link in export_links %}
-                    <li><a class="dropdown-item task" href="{{ link }}">{{ format|upper }}</a></li>
+                    <li><a class="dropdown-item task" href="{{ link }}"
+                           data-task-label="Targets export ({{ format|upper }})">{{ format|upper }}</a></li>
                 {% endfor %}
             </ul>
         </div>
@@ -129,46 +130,5 @@
       <h5>Use the filters to run a target search</h5>
     </div>
 {% endif %}
-
-{% endblock %}
-
-{% block extrajs %}
-<script nonce="{{ request.csp_nonce }}">
-var WAIT_FOR_TASK_TIMEOUT_ID;
-
-function waitForTask(url) {
-    $.ajax({
-    dataType: "json",
-    url: url,
-    success: function (data) {
-        console.log(data);
-        if (data.unready) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 1000, url);
-        } else if (data.status === "SUCCESS") {
-        window.location = data.download_url;
-        }
-    }
-    });
-}
-
-function launchTask($link) {
-    var url = $link.attr("href");
-    $.ajax({
-        dataType: "json",
-        url: url,
-        method: "post",
-        success: function (data) {
-        WAIT_FOR_TASK_TIMEOUT_ID = window.setTimeout(waitForTask, 300, data.task_result_url);
-        }
-    });
-}
-
-$(document).ready(function () {
-    $(".task").click(function (event) {
-    event.preventDefault();
-    launchTask($(this));
-    });
-});
-</script>
 
 {% endblock %}


### PR DESCRIPTION
Follow-up to 7fad830b, which moved the monolith repository sync to a celery task.

Supersedes #1582, closed by the branch rename.

## Problem

Eleven pages launch a celery task and poll the task result, and each one carries its own copy of the same `waitForTask`/`launchTask` pair, in an inline script. None of them reports anything. The monolith repository sync posts to the API and reloads the page when the task is done, so a sync that fails, or that is skipped because the repository is already being synced, looks exactly like a sync that did nothing. The exports are worse: a failed export leaves the dropdown as if it had never been clicked.

## Changes

**1. The task waiting code moves to `server/static_src/js/main.js`**, the bundle already loaded on every page, and is driven by the markup instead of being copied:

* a link with the `task` class posts to its `href` and polls `task_result_url`;
* `data-task-label` builds the messages: *`<label>` started.* while it runs, replaced by *done.*, *failed.*, or *skipped, already running.* when the task result is ready;
* a task result with a file sends the browser to the `download_url`, without one the page is reloaded to display what the task changed, a second after the success message;
* an export link keeps its format in `data-format`, and its enclosing form is serialized and posted with it.

It is plain javascript, no jquery: `fetch`, with the CSRF token read from the cookie since the header used to be set by the `$.ajaxSetup` call in `base.html`, a `FormData` instead of `serializeArray`, and a click listener on the document, which also picks up a task link added to a page after it loads.

`base.html` wraps the django messages in a `#messages` container, so the same alerts can be added to the page from javascript.

The monolith repository page is converted with it: its inline script is gone, replaced by `data-task-label="Repository sync"` on the link.

**2. The ten other pages follow**, one commit each, or grouped when they are the same page in five copies:

| commit | pages | flavour |
| --- | --- | --- |
| osquery | distributed query results | export, format in the query string |
| santa | targets | export, search and format in the query string |
| inventory | machine list | export, search and format in the query string |
| inventory | macOS, iOS, android apps, programs, debian packages | export, format and form in the body |
| mdm | DEP virtual server devices sync | sync, then reload |
| google_workspace | connection group tag mappings sync | sync, then reload |

Nothing changes on the wire: the pages that posted a body still post the same one, the pages that posted none still post none. Where an inline script held more than the task code — the machine list filters and charts, the DEP virtual server beta enrollment tokens — only the task functions and their click binding were removed.

**Around 500 lines of duplicated javascript deleted.** Every task page now reports what happened.

## Notes for the reviewer

* Every `.task` link is bound, so a link without a label is not silently inert: it says *undefined started.* The label is required.
* The monolith sync button is disabled with the bootstrap `disabled` class instead of the `disabled` property, which has no effect on a link. A second click used to start a second task that could only be skipped. The DEP virtual server and google workspace buttons had the same bug.
* `SKIPPED` is only returned by the monolith sync task today. Reading it in the shared code makes it the convention for the tasks that decline to run.
* `tests.monolith` (559), `tests.osquery` (563), `tests.santa`, `tests.inventory` (1225 together), `tests.mdm` and `tests.google_workspace` (2711 together) pass. The bundle was built and exercised in a browser against stubbed responses: launch failure, poll failure, done then reload, skipped, download, a click on the icon inside a link, a link added after load, and a link without a label. The POST bodies, headers and URLs are the ones the pages sent before.