### PR TITLE
Stop the TOTP tests failing on a time step boundary

### DIFF
--- a/tests/server_accounts/views/test_users_views.py
+++ b/tests/server_accounts/views/test_users_views.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import re
+import time
 from unittest.mock import patch
 
 import pyotp
@@ -18,6 +19,15 @@ from tests.zentral_test_utils.assertions.event_assertions import EventAssertions
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.conf import ConfigDict, settings
 from zentral.core.events.base import AuditEvent
+
+
+def verification_code(secret):
+    totp = pyotp.totp.TOTP(secret)
+    # the views verify without a valid window, so a code generated at the end of its
+    # time step is refused if the step rolls over before the response is rendered
+    if totp.interval - time.time() % totp.interval < 2:
+        time.sleep(2)
+    return totp.now()
 
 
 class AccountUsersViewsTestCase(TestCase, LoginCase, EventAssertions):
@@ -184,7 +194,7 @@ class AccountUsersViewsTestCase(TestCase, LoginCase, EventAssertions):
         self.assertTemplateUsed(response, "accounts/verify_totp.html")
         self.assertFalse(response.context["request"].user.is_authenticated)
         response = self.client.post(reverse("accounts:verify_totp"),
-                                    {"verification_code": pyotp.totp.TOTP(user_totp.secret).now()},
+                                    {"verification_code": verification_code(user_totp.secret)},
                                     follow=True)
         self.assertTemplateUsed(response, "base/index.html")
         self.assertTrue(response.context["request"].user.is_authenticated)
@@ -1125,7 +1135,7 @@ class AccountUsersViewsTestCase(TestCase, LoginCase, EventAssertions):
         response = self.client.post(reverse("accounts:add_totp"),
                                     {"name": name,
                                      "secret": form.initial_secret,
-                                     "verification_code": pyotp.totp.TOTP(form.initial_secret).now()},
+                                     "verification_code": verification_code(form.initial_secret)},
                                     follow=True)
         self.assertTemplateUsed(response, "accounts/user_verification_devices.html")
         self.assertContains(response, name)


### PR DESCRIPTION
## Problem

`test_add_totp_ok` and `test_login_totp_ok` fail intermittently in CI, for example in [this run](https://github.com/zentralopensource/zentral/actions/runs/31210486923/job/92972969181):

```
FAIL: test_add_totp_ok (tests.server_accounts.views.test_users_views.AccountUsersViewsTestCase.test_add_totp_ok)
AssertionError: False is not true : Template 'accounts/user_verification_devices.html' was not a template
used to render the response. Actual template(s) used: accounts/add_totp.html, ...
```

The form was re-rendered because the code was refused. Both tests generate a code with `TOTP(secret).now()` and post it, and both views verify with `pyotp`'s default `valid_window=0`: `AddTOTPForm.clean` in `server/accounts/forms.py`, and `UserTOTP.verify` in `server/accounts/models.py`. A code generated in the last moments of its 30 second time step has expired by the time the view verifies it.

## Change

A helper waits for the next time step when the current one is about to end, so the code is always verified inside the step it was generated in. It costs a 2 second wait in the few percent of runs that land near a boundary.

Only the tests change. Whether the views should accept the adjacent codes, as most TOTP implementations do, is a separate question.