### PR TITLE
mdm: paginate the remaining API list endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Repository syncs now run in the background. Repositories that need more than the
 
 ### Backward incompatibilities
 
+#### 🧨 MDM API endpoint pagination
+
+The API endpoints for the ACME issuer, SCEP issuer, FileVault configuration, recovery password configuration, software update enforcement, OTA enrollment, blueprint, blueprint artifact, location, location asset and push certificate lists are paginated now. Remember to upgrade the Terraform Provider.
+
+
 #### 🧨 Monolith repository sync API endpoint
 
 `/api/monolith/repositories/<int:pk>/sync/` launches a background task instead of syncing the repository during the request. It responds with `201` and a `task_id`/`task_result_url` pair, in place of the `200 {"status": 0}` and `500 {"status": 1, "error": "…"}` responses it used to return. Poll `task_result_url` to know the outcome of the sync.

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -1423,9 +1423,9 @@ Fetches the list of Apps / Books locations.
 Example:
 
 ```bash
-curl -XPOST \
-  -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_FQDN/api/mdm/locations/
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/mdm/locations/ \
+  | python3 -m json.tool
 ```
 
 Result:
@@ -1470,9 +1470,9 @@ Fetches the list of Apps / Books location assets.
 Example:
 
 ```bash
-curl -XPOST \
-  -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_FQDN/api/mdm/location_assets/?location_id=749
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/mdm/location_assets/?location_id=749" \
+  | python3 -m json.tool
 ```
 
 Result:

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -1414,6 +1414,9 @@ Response: HTTP 204 No Content
  * available filters:
      * `name`
      * `organization_name`
+ * pagination:
+    * `limit` (max `500`, `50` by default)
+    * `offset`
 
 Fetches the list of Apps / Books locations.
 
@@ -1428,21 +1431,26 @@ curl -XPOST \
 Result:
 
 ```json
-[
-  {
-    "id": 388,
-    "server_token_expiration_date": "2050-01-01T00:00:00",
-    "organization_name": "Organization name",
-    "name": "Location name",
-    "country_code": "DE",
-    "library_uid": "1dc05825-af1d-422a-9b26-72a2f8c2aae5",
-    "platform": "enterprisestore",
-    "website_url": "https://business.apple.com",
-    "mdm_info_id": "f42d9d70-d304-4ac1-83db-b045fa4bc623",
-    "created_at": "2024-03-28T17:58:15.948083",
-    "updated_at": "2024-03-28T17:58:15.948088"
-  }
-]
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 388,
+            "server_token_expiration_date": "2050-01-01T00:00:00",
+            "organization_name": "Organization name",
+            "name": "Location name",
+            "country_code": "DE",
+            "library_uid": "1dc05825-af1d-422a-9b26-72a2f8c2aae5",
+            "platform": "enterprisestore",
+            "website_url": "https://business.apple.com",
+            "mdm_info_id": "f42d9d70-d304-4ac1-83db-b045fa4bc623",
+            "created_at": "2024-03-28T17:58:15.948083",
+            "updated_at": "2024-03-28T17:58:15.948088"
+        }
+    ]
+}
 ```
 
 ### `/api/mdm/location_assets/`
@@ -1453,6 +1461,9 @@ Result:
      * `adam_id`
      * `pricing_param`
      * `location_id`
+ * pagination:
+    * `limit` (max `500`, `50` by default)
+    * `offset`
 
 Fetches the list of Apps / Books location assets.
 
@@ -1467,19 +1478,24 @@ curl -XPOST \
 Result:
 
 ```json
-[
-  {
-    "id": 414,
-    "assigned_count": 0,
-    "available_count": 0,
-    "retired_count": 0,
-    "total_count": 0,
-    "created_at": "2024-03-28T19:15:58.212233",
-    "updated_at": "2024-03-28T19:15:58.212237",
-    "location": 749,
-    "asset": 489
-  }
-]
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 414,
+            "assigned_count": 0,
+            "available_count": 0,
+            "retired_count": 0,
+            "total_count": 0,
+            "created_at": "2024-03-28T19:15:58.212233",
+            "updated_at": "2024-03-28T19:15:58.212237",
+            "location": 749,
+            "asset": 489
+        }
+    ]
+}
 ```
 
 ### `/api/mdm/software_updates/sync/`

--- a/tests/mdm/test_api_acme_issuers_views.py
+++ b/tests/mdm/test_api_acme_issuers_views.py
@@ -66,26 +66,31 @@ class MDMACMEIssuerAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         backend_kwargs = acme_issuer.get_microsoft_ca_kwargs()
         self.assertEqual(
             response.json(),
-            [{'attest': True,
-              'backend': 'MICROSOFT_CA',
-              'created_at': acme_issuer.created_at.isoformat(),
-              'description': '',
-              'directory_url': acme_issuer.directory_url,
-              'extended_key_usage': [],
-              'hardware_bound': True,
-              'id': str(acme_issuer.pk),
-              'key_size': 384,
-              'key_type': 'ECSECPrimeRandom',
-              'name': acme_issuer.name,
-              'microsoft_ca_kwargs': {
-                  'url': backend_kwargs['url'],
-                  'username': backend_kwargs['username'],
-                  'password': backend_kwargs['password'],
-              },
-              'provisioning_uid': None,
-              'updated_at': acme_issuer.updated_at.isoformat(),
-              'usage_flags': 1,
-              'version': 1}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'attest': True,
+                  'backend': 'MICROSOFT_CA',
+                  'created_at': acme_issuer.created_at.isoformat(),
+                  'description': '',
+                  'directory_url': acme_issuer.directory_url,
+                  'extended_key_usage': [],
+                  'hardware_bound': True,
+                  'id': str(acme_issuer.pk),
+                  'key_size': 384,
+                  'key_type': 'ECSECPrimeRandom',
+                  'name': acme_issuer.name,
+                  'microsoft_ca_kwargs': {
+                      'url': backend_kwargs['url'],
+                      'username': backend_kwargs['username'],
+                      'password': backend_kwargs['password'],
+                  },
+                  'provisioning_uid': None,
+                  'updated_at': acme_issuer.updated_at.isoformat(),
+                  'usage_flags': 1,
+                  'version': 1}
+             ]}
         )
 
     def test_list_acme_issuers_name_filter(self):
@@ -97,27 +102,32 @@ class MDMACMEIssuerAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         backend_kwargs = acme_issuer.get_ident_kwargs()
         self.assertEqual(
             response.json(),
-            [{'attest': True,
-              'backend': 'IDENT',
-              'created_at': acme_issuer.created_at.isoformat(),
-              'description': '',
-              'directory_url': acme_issuer.directory_url,
-              'extended_key_usage': [],
-              'hardware_bound': True,
-              'id': str(acme_issuer.pk),
-              'key_size': 384,
-              'key_type': 'ECSECPrimeRandom',
-              'ident_kwargs': {
-                  'url': backend_kwargs['url'],
-                  'bearer_token': backend_kwargs['bearer_token'],
-                  'request_timeout': backend_kwargs['request_timeout'],
-                  'max_retries': backend_kwargs['max_retries'],
-              },
-              'name': acme_issuer.name,
-              'provisioning_uid': None,
-              'updated_at': acme_issuer.updated_at.isoformat(),
-              'usage_flags': 1,
-              'version': 1}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'attest': True,
+                  'backend': 'IDENT',
+                  'created_at': acme_issuer.created_at.isoformat(),
+                  'description': '',
+                  'directory_url': acme_issuer.directory_url,
+                  'extended_key_usage': [],
+                  'hardware_bound': True,
+                  'id': str(acme_issuer.pk),
+                  'key_size': 384,
+                  'key_type': 'ECSECPrimeRandom',
+                  'ident_kwargs': {
+                      'url': backend_kwargs['url'],
+                      'bearer_token': backend_kwargs['bearer_token'],
+                      'request_timeout': backend_kwargs['request_timeout'],
+                      'max_retries': backend_kwargs['max_retries'],
+                  },
+                  'name': acme_issuer.name,
+                  'provisioning_uid': None,
+                  'updated_at': acme_issuer.updated_at.isoformat(),
+                  'usage_flags': 1,
+                  'version': 1}
+             ]}
         )
 
     # get ACME issuer

--- a/tests/mdm/test_api_apps_books_views.py
+++ b/tests/mdm/test_api_apps_books_views.py
@@ -69,17 +69,22 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'country_code': 'DE',
-              'created_at': location.created_at.isoformat(),
-              'id': location.pk,
-              'library_uid': str(location.library_uid),
-              'mdm_info_id': str(location.mdm_info_id),
-              'name': location.name,
-              'organization_name': location.organization_name,
-              'platform': 'enterprisestore',
-              'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
-              'updated_at': location.updated_at.isoformat(),
-              'website_url': 'https://business.apple.com'}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'country_code': 'DE',
+                  'created_at': location.created_at.isoformat(),
+                  'id': location.pk,
+                  'library_uid': str(location.library_uid),
+                  'mdm_info_id': str(location.mdm_info_id),
+                  'name': location.name,
+                  'organization_name': location.organization_name,
+                  'platform': 'enterprisestore',
+                  'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
+                  'updated_at': location.updated_at.isoformat(),
+                  'website_url': 'https://business.apple.com'}
+             ]}
         )
 
     def test_location_by_mdm_info_id(self):
@@ -90,24 +95,29 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'country_code': 'DE',
-              'created_at': location.created_at.isoformat(),
-              'id': location.pk,
-              'library_uid': str(location.library_uid),
-              'mdm_info_id': str(location.mdm_info_id),
-              'name': location.name,
-              'organization_name': location.organization_name,
-              'platform': 'enterprisestore',
-              'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
-              'updated_at': location.updated_at.isoformat(),
-              'website_url': 'https://business.apple.com'}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'country_code': 'DE',
+                  'created_at': location.created_at.isoformat(),
+                  'id': location.pk,
+                  'library_uid': str(location.library_uid),
+                  'mdm_info_id': str(location.mdm_info_id),
+                  'name': location.name,
+                  'organization_name': location.organization_name,
+                  'platform': 'enterprisestore',
+                  'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
+                  'updated_at': location.updated_at.isoformat(),
+                  'website_url': 'https://business.apple.com'}
+             ]}
         )
 
     def test_location_by_mdm_info_id_no_results(self):
         self.set_permissions("mdm.view_location")
         response = self.get(reverse("mdm_api:locations") + "?mdm_info_id=734898e6-dbcf-4bba-ab60-5ede4633a033")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_location_by_name(self):
         self.set_permissions("mdm.view_location")
@@ -117,24 +127,29 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'country_code': 'DE',
-              'created_at': location.created_at.isoformat(),
-              'id': location.pk,
-              'library_uid': str(location.library_uid),
-              'mdm_info_id': str(location.mdm_info_id),
-              'name': location.name,
-              'organization_name': location.organization_name,
-              'platform': 'enterprisestore',
-              'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
-              'updated_at': location.updated_at.isoformat(),
-              'website_url': 'https://business.apple.com'}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'country_code': 'DE',
+                  'created_at': location.created_at.isoformat(),
+                  'id': location.pk,
+                  'library_uid': str(location.library_uid),
+                  'mdm_info_id': str(location.mdm_info_id),
+                  'name': location.name,
+                  'organization_name': location.organization_name,
+                  'platform': 'enterprisestore',
+                  'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
+                  'updated_at': location.updated_at.isoformat(),
+                  'website_url': 'https://business.apple.com'}
+             ]}
         )
 
     def test_location_by_name_no_results(self):
         self.set_permissions("mdm.view_location")
         response = self.get(reverse("mdm_api:locations") + "?name=yolo")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_location_by_organization_name(self):
         self.set_permissions("mdm.view_location")
@@ -144,24 +159,29 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'country_code': 'DE',
-              'created_at': location.created_at.isoformat(),
-              'id': location.pk,
-              'library_uid': str(location.library_uid),
-              'mdm_info_id': str(location.mdm_info_id),
-              'name': location.name,
-              'organization_name': location.organization_name,
-              'platform': 'enterprisestore',
-              'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
-              'updated_at': location.updated_at.isoformat(),
-              'website_url': 'https://business.apple.com'}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'country_code': 'DE',
+                  'created_at': location.created_at.isoformat(),
+                  'id': location.pk,
+                  'library_uid': str(location.library_uid),
+                  'mdm_info_id': str(location.mdm_info_id),
+                  'name': location.name,
+                  'organization_name': location.organization_name,
+                  'platform': 'enterprisestore',
+                  'server_token_expiration_date': location.server_token_expiration_date.isoformat(),
+                  'updated_at': location.updated_at.isoformat(),
+                  'website_url': 'https://business.apple.com'}
+             ]}
         )
 
     def test_location_by_organization_name_no_results(self):
         self.set_permissions("mdm.view_location")
         response = self.get(reverse("mdm_api:locations") + "?organization_name=yolo")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     # location
 
@@ -227,17 +247,22 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'adam_id': la.asset.adam_id,
-              'asset': la.asset.pk,
-              'assigned_count': 0,
-              'available_count': 0,
-              'created_at': la.created_at.isoformat(),
-              'id': la.pk,
-              'location': la.location.pk,
-              'pricing_param': la.asset.pricing_param,
-              'retired_count': 0,
-              'total_count': 0,
-              'updated_at': la.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'adam_id': la.asset.adam_id,
+                  'asset': la.asset.pk,
+                  'assigned_count': 0,
+                  'available_count': 0,
+                  'created_at': la.created_at.isoformat(),
+                  'id': la.pk,
+                  'location': la.location.pk,
+                  'pricing_param': la.asset.pricing_param,
+                  'retired_count': 0,
+                  'total_count': 0,
+                  'updated_at': la.updated_at.isoformat()}
+             ]}
         )
 
     def test_location_assets_by_adam_id(self):
@@ -247,17 +272,22 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'adam_id': la.asset.adam_id,
-              'asset': la.asset.pk,
-              'assigned_count': 0,
-              'available_count': 0,
-              'created_at': la.created_at.isoformat(),
-              'id': la.pk,
-              'location': la.location.pk,
-              'pricing_param': la.asset.pricing_param,
-              'retired_count': 0,
-              'total_count': 0,
-              'updated_at': la.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'adam_id': la.asset.adam_id,
+                  'asset': la.asset.pk,
+                  'assigned_count': 0,
+                  'available_count': 0,
+                  'created_at': la.created_at.isoformat(),
+                  'id': la.pk,
+                  'location': la.location.pk,
+                  'pricing_param': la.asset.pricing_param,
+                  'retired_count': 0,
+                  'total_count': 0,
+                  'updated_at': la.updated_at.isoformat()}
+             ]}
         )
 
     def test_location_assets_by_adam_id_no_results(self):
@@ -265,7 +295,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         force_location_asset()
         response = self.get(reverse("mdm_api:location_assets") + "?adam_id=yolo")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_location_assets_by_pricing_param(self):
         self.set_permissions("mdm.view_locationasset")
@@ -274,17 +304,22 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'adam_id': la.asset.adam_id,
-              'asset': la.asset.pk,
-              'assigned_count': 0,
-              'available_count': 0,
-              'created_at': la.created_at.isoformat(),
-              'id': la.pk,
-              'location': la.location.pk,
-              'pricing_param': la.asset.pricing_param,
-              'retired_count': 0,
-              'total_count': 0,
-              'updated_at': la.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'adam_id': la.asset.adam_id,
+                  'asset': la.asset.pk,
+                  'assigned_count': 0,
+                  'available_count': 0,
+                  'created_at': la.created_at.isoformat(),
+                  'id': la.pk,
+                  'location': la.location.pk,
+                  'pricing_param': la.asset.pricing_param,
+                  'retired_count': 0,
+                  'total_count': 0,
+                  'updated_at': la.updated_at.isoformat()}
+             ]}
         )
 
     def test_location_assets_by_pricing_param_no_results(self):
@@ -292,7 +327,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         force_location_asset()
         response = self.get(reverse("mdm_api:location_assets") + "?pricing_param=yolo")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_location_assets_by_location_id(self):
         self.set_permissions("mdm.view_locationasset")
@@ -302,17 +337,22 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'adam_id': la.asset.adam_id,
-              'asset': la.asset.pk,
-              'assigned_count': 0,
-              'available_count': 0,
-              'created_at': la.created_at.isoformat(),
-              'id': la.pk,
-              'location': la.location.pk,
-              'pricing_param': la.asset.pricing_param,
-              'retired_count': 0,
-              'total_count': 0,
-              'updated_at': la.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'adam_id': la.asset.adam_id,
+                  'asset': la.asset.pk,
+                  'assigned_count': 0,
+                  'available_count': 0,
+                  'created_at': la.created_at.isoformat(),
+                  'id': la.pk,
+                  'location': la.location.pk,
+                  'pricing_param': la.asset.pricing_param,
+                  'retired_count': 0,
+                  'total_count': 0,
+                  'updated_at': la.updated_at.isoformat()}
+             ]}
         )
 
     def test_location_assets_by_location_id_no_results(self):
@@ -321,7 +361,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         location = force_location()
         response = self.get(reverse("mdm_api:location_assets") + f"?location_id={location.pk}")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_location_assets_all_filters(self):
         self.set_permissions("mdm.view_locationasset")
@@ -335,15 +375,20 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'adam_id': la.asset.adam_id,
-              'asset': la.asset.pk,
-              'assigned_count': 0,
-              'available_count': 0,
-              'created_at': la.created_at.isoformat(),
-              'id': la.pk,
-              'location': la.location.pk,
-              'pricing_param': la.asset.pricing_param,
-              'retired_count': 0,
-              'total_count': 0,
-              'updated_at': la.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'adam_id': la.asset.adam_id,
+                  'asset': la.asset.pk,
+                  'assigned_count': 0,
+                  'available_count': 0,
+                  'created_at': la.created_at.isoformat(),
+                  'id': la.pk,
+                  'location': la.location.pk,
+                  'pricing_param': la.asset.pricing_param,
+                  'retired_count': 0,
+                  'total_count': 0,
+                  'updated_at': la.updated_at.isoformat()}
+             ]}
         )

--- a/tests/mdm/test_api_blueprint_artifacts_views.py
+++ b/tests/mdm/test_api_blueprint_artifacts_views.py
@@ -62,27 +62,32 @@ class MDMBlueprintArtifactsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': blueprint_artifact.pk,
-              'blueprint': blueprint_artifact.blueprint.pk,
-              'artifact': str(artifact.pk),
-              'default_shard': 100,
-              'excluded_tags': [],
-              'ios': False,
-              'ios_max_version': '',
-              'ios_min_version': '',
-              'ipados': False,
-              'ipados_max_version': '',
-              'ipados_min_version': '',
-              'macos': True,
-              'macos_max_version': '',
-              'macos_min_version': '',
-              'shard_modulo': 100,
-              'tag_shards': [],
-              'tvos': False,
-              'tvos_max_version': '',
-              'tvos_min_version': '',
-              'created_at': blueprint_artifact.created_at.isoformat(),
-              'updated_at': blueprint_artifact.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': blueprint_artifact.pk,
+                  'blueprint': blueprint_artifact.blueprint.pk,
+                  'artifact': str(artifact.pk),
+                  'default_shard': 100,
+                  'excluded_tags': [],
+                  'ios': False,
+                  'ios_max_version': '',
+                  'ios_min_version': '',
+                  'ipados': False,
+                  'ipados_max_version': '',
+                  'ipados_min_version': '',
+                  'macos': True,
+                  'macos_max_version': '',
+                  'macos_min_version': '',
+                  'shard_modulo': 100,
+                  'tag_shards': [],
+                  'tvos': False,
+                  'tvos_max_version': '',
+                  'tvos_min_version': '',
+                  'created_at': blueprint_artifact.created_at.isoformat(),
+                  'updated_at': blueprint_artifact.updated_at.isoformat()}
+             ]}
         )
 
     # get blueprint artifact

--- a/tests/mdm/test_api_blueprints_views.py
+++ b/tests/mdm/test_api_blueprints_views.py
@@ -64,19 +64,24 @@ class MDMBlueprintsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': blueprint.pk,
-              'name': blueprint.name,
-              'inventory_interval': 86400,
-              'collect_apps': 0,
-              'collect_certificates': 0,
-              'collect_profiles': 0,
-              'default_location': None,
-              'filevault_config': None,
-              'legacy_profiles_via_ddm': True,
-              'recovery_password_config': None,
-              'software_update_enforcements': [],
-              'created_at': blueprint.created_at.isoformat(),
-              'updated_at': blueprint.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': blueprint.pk,
+                  'name': blueprint.name,
+                  'inventory_interval': 86400,
+                  'collect_apps': 0,
+                  'collect_certificates': 0,
+                  'collect_profiles': 0,
+                  'default_location': None,
+                  'filevault_config': None,
+                  'legacy_profiles_via_ddm': True,
+                  'recovery_password_config': None,
+                  'software_update_enforcements': [],
+                  'created_at': blueprint.created_at.isoformat(),
+                  'updated_at': blueprint.updated_at.isoformat()}
+             ]}
         )
 
     def test_list_blueprints_name_filter(self):
@@ -92,19 +97,24 @@ class MDMBlueprintsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': blueprint.pk,
-              'name': blueprint.name,
-              'inventory_interval': 86400,
-              'collect_apps': 0,
-              'collect_certificates': 0,
-              'collect_profiles': 0,
-              'default_location': None,
-              'filevault_config': filevault_config.pk,
-              'legacy_profiles_via_ddm': True,
-              'recovery_password_config': recovery_password_config.pk,
-              'software_update_enforcements': [sue.pk],
-              'created_at': blueprint.created_at.isoformat(),
-              'updated_at': blueprint.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': blueprint.pk,
+                  'name': blueprint.name,
+                  'inventory_interval': 86400,
+                  'collect_apps': 0,
+                  'collect_certificates': 0,
+                  'collect_profiles': 0,
+                  'default_location': None,
+                  'filevault_config': filevault_config.pk,
+                  'legacy_profiles_via_ddm': True,
+                  'recovery_password_config': recovery_password_config.pk,
+                  'software_update_enforcements': [sue.pk],
+                  'created_at': blueprint.created_at.isoformat(),
+                  'updated_at': blueprint.updated_at.isoformat()}
+             ]}
         )
 
     # get blueprint

--- a/tests/mdm/test_api_filevault_configs_views.py
+++ b/tests/mdm/test_api_filevault_configs_views.py
@@ -61,17 +61,22 @@ class MDMFileVaultConfigsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': fv_config.pk,
-              'name': fv_config.name,
-              'escrow_location_display_name': fv_config.escrow_location_display_name,
-              'at_login_only': False,
-              'bypass_attempts': -1,
-              'show_recovery_key': False,
-              'destroy_key_on_standby': False,
-              'prk_rotation_interval_days': 0,
-              'prk_reveal_rotation_delay': 0,
-              'created_at': fv_config.created_at.isoformat(),
-              'updated_at': fv_config.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': fv_config.pk,
+                  'name': fv_config.name,
+                  'escrow_location_display_name': fv_config.escrow_location_display_name,
+                  'at_login_only': False,
+                  'bypass_attempts': -1,
+                  'show_recovery_key': False,
+                  'destroy_key_on_standby': False,
+                  'prk_rotation_interval_days': 0,
+                  'prk_reveal_rotation_delay': 0,
+                  'created_at': fv_config.created_at.isoformat(),
+                  'updated_at': fv_config.updated_at.isoformat()}
+             ]}
         )
 
     def test_list_filevault_configs_name_filter(self):
@@ -82,17 +87,22 @@ class MDMFileVaultConfigsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': fv_config.pk,
-              'name': fv_config.name,
-              'escrow_location_display_name': fv_config.escrow_location_display_name,
-              'at_login_only': False,
-              'bypass_attempts': -1,
-              'show_recovery_key': False,
-              'destroy_key_on_standby': False,
-              'prk_rotation_interval_days': 0,
-              'prk_reveal_rotation_delay': 0,
-              'created_at': fv_config.created_at.isoformat(),
-              'updated_at': fv_config.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': fv_config.pk,
+                  'name': fv_config.name,
+                  'escrow_location_display_name': fv_config.escrow_location_display_name,
+                  'at_login_only': False,
+                  'bypass_attempts': -1,
+                  'show_recovery_key': False,
+                  'destroy_key_on_standby': False,
+                  'prk_rotation_interval_days': 0,
+                  'prk_reveal_rotation_delay': 0,
+                  'created_at': fv_config.created_at.isoformat(),
+                  'updated_at': fv_config.updated_at.isoformat()}
+             ]}
         )
 
     # get FileVault config

--- a/tests/mdm/test_api_ota_enrollments_views.py
+++ b/tests/mdm/test_api_ota_enrollments_views.py
@@ -66,26 +66,31 @@ class MDMOTAEnrollmentsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'blueprint': None,
-              'created_at': oe.created_at.isoformat(),
-              'display_name': oe.display_name,
-              'enrollment_secret': {
-                  'id': oe.enrollment_secret.pk,
-                  'meta_business_unit': oe.enrollment_secret.meta_business_unit.pk,
-                  'quota': None,
-                  'request_count': 0,
-                  'secret': oe.enrollment_secret.secret,
-                  'serial_numbers': None,
-                  'tags': [],
-                  'udids': None
-              },
-              'id': oe.pk,
-              'name': oe.name,
-              'push_certificate': oe.push_certificate.pk,
-              'realm': str(realm.pk),
-              'acme_issuer': str(oe.acme_issuer.pk),
-              'scep_issuer': str(oe.scep_issuer.pk),
-              'updated_at': oe.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'blueprint': None,
+                  'created_at': oe.created_at.isoformat(),
+                  'display_name': oe.display_name,
+                  'enrollment_secret': {
+                      'id': oe.enrollment_secret.pk,
+                      'meta_business_unit': oe.enrollment_secret.meta_business_unit.pk,
+                      'quota': None,
+                      'request_count': 0,
+                      'secret': oe.enrollment_secret.secret,
+                      'serial_numbers': None,
+                      'tags': [],
+                      'udids': None
+                  },
+                  'id': oe.pk,
+                  'name': oe.name,
+                  'push_certificate': oe.push_certificate.pk,
+                  'realm': str(realm.pk),
+                  'acme_issuer': str(oe.acme_issuer.pk),
+                  'scep_issuer': str(oe.scep_issuer.pk),
+                  'updated_at': oe.updated_at.isoformat()}
+             ]}
         )
 
     def test_list_ota_enrollments_name_filter(self):
@@ -96,26 +101,31 @@ class MDMOTAEnrollmentsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'blueprint': None,
-              'created_at': oe.created_at.isoformat(),
-              'display_name': oe.display_name,
-              'enrollment_secret': {
-                  'id': oe.enrollment_secret.pk,
-                  'meta_business_unit': oe.enrollment_secret.meta_business_unit.pk,
-                  'quota': None,
-                  'request_count': 0,
-                  'secret': oe.enrollment_secret.secret,
-                  'serial_numbers': None,
-                  'tags': [],
-                  'udids': None
-              },
-              'id': oe.pk,
-              'name': oe.name,
-              'push_certificate': oe.push_certificate.pk,
-              'realm': None,
-              'acme_issuer': str(oe.acme_issuer.pk),
-              'scep_issuer': str(oe.scep_issuer.pk),
-              'updated_at': oe.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'blueprint': None,
+                  'created_at': oe.created_at.isoformat(),
+                  'display_name': oe.display_name,
+                  'enrollment_secret': {
+                      'id': oe.enrollment_secret.pk,
+                      'meta_business_unit': oe.enrollment_secret.meta_business_unit.pk,
+                      'quota': None,
+                      'request_count': 0,
+                      'secret': oe.enrollment_secret.secret,
+                      'serial_numbers': None,
+                      'tags': [],
+                      'udids': None
+                  },
+                  'id': oe.pk,
+                  'name': oe.name,
+                  'push_certificate': oe.push_certificate.pk,
+                  'realm': None,
+                  'acme_issuer': str(oe.acme_issuer.pk),
+                  'scep_issuer': str(oe.scep_issuer.pk),
+                  'updated_at': oe.updated_at.isoformat()}
+             ]}
         )
 
     # get OTA enrollment

--- a/tests/mdm/test_api_push_certificates_views.py
+++ b/tests/mdm/test_api_push_certificates_views.py
@@ -58,15 +58,20 @@ class MDMPushCertificateAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': push_certificate.pk,
-              'provisioning_uid': "YoLoFoMo",
-              'name': push_certificate.name,
-              'topic': push_certificate.topic,
-              'not_before': push_certificate.not_before.isoformat().split("+")[0],
-              'not_after': push_certificate.not_after.isoformat().split("+")[0],
-              'certificate': push_certificate.certificate.decode("ascii"),
-              'created_at': push_certificate.created_at.isoformat(),
-              'updated_at': push_certificate.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': push_certificate.pk,
+                  'provisioning_uid': "YoLoFoMo",
+                  'name': push_certificate.name,
+                  'topic': push_certificate.topic,
+                  'not_before': push_certificate.not_before.isoformat().split("+")[0],
+                  'not_after': push_certificate.not_after.isoformat().split("+")[0],
+                  'certificate': push_certificate.certificate.decode("ascii"),
+                  'created_at': push_certificate.created_at.isoformat(),
+                  'updated_at': push_certificate.updated_at.isoformat()}
+             ]}
         )
 
     def test_list_push_certificates_name_filter(self):
@@ -77,15 +82,20 @@ class MDMPushCertificateAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': push_certificate.pk,
-              'provisioning_uid': None,
-              'name': push_certificate.name,
-              'topic': push_certificate.topic,
-              'not_before': push_certificate.not_before.isoformat().split("+")[0],
-              'not_after': push_certificate.not_after.isoformat().split("+")[0],
-              'certificate': '1',
-              'created_at': push_certificate.created_at.isoformat(),
-              'updated_at': push_certificate.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': push_certificate.pk,
+                  'provisioning_uid': None,
+                  'name': push_certificate.name,
+                  'topic': push_certificate.topic,
+                  'not_before': push_certificate.not_before.isoformat().split("+")[0],
+                  'not_after': push_certificate.not_after.isoformat().split("+")[0],
+                  'certificate': '1',
+                  'created_at': push_certificate.created_at.isoformat(),
+                  'updated_at': push_certificate.updated_at.isoformat()}
+             ]}
         )
 
     # get push_certificate

--- a/tests/mdm/test_api_recovery_password_configs_views.py
+++ b/tests/mdm/test_api_recovery_password_configs_views.py
@@ -61,15 +61,20 @@ class MDMRecoveryPasswordConfigsAPIViewsTestCase(TestCase, LoginCase, RequestCas
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': rp_config.pk,
-              'name': rp_config.name,
-              'dynamic_password': rp_config.dynamic_password,
-              'static_password': rp_config.static_password,
-              'rotation_interval_days': 0,
-              'reveal_rotation_delay': 0,
-              'rotate_firmware_password': False,
-              'created_at': rp_config.created_at.isoformat(),
-              'updated_at': rp_config.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': rp_config.pk,
+                  'name': rp_config.name,
+                  'dynamic_password': rp_config.dynamic_password,
+                  'static_password': rp_config.static_password,
+                  'rotation_interval_days': 0,
+                  'reveal_rotation_delay': 0,
+                  'rotate_firmware_password': False,
+                  'created_at': rp_config.created_at.isoformat(),
+                  'updated_at': rp_config.updated_at.isoformat()}
+             ]}
         )
 
     def test_list_recovery_password_configs_name_filter(self):
@@ -81,15 +86,20 @@ class MDMRecoveryPasswordConfigsAPIViewsTestCase(TestCase, LoginCase, RequestCas
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': rp_config.pk,
-              'name': rp_config.name,
-              'dynamic_password': rp_config.dynamic_password,
-              'static_password': static_password,
-              'rotation_interval_days': 0,
-              'reveal_rotation_delay': 0,
-              'rotate_firmware_password': False,
-              'created_at': rp_config.created_at.isoformat(),
-              'updated_at': rp_config.updated_at.isoformat()}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': rp_config.pk,
+                  'name': rp_config.name,
+                  'dynamic_password': rp_config.dynamic_password,
+                  'static_password': static_password,
+                  'rotation_interval_days': 0,
+                  'reveal_rotation_delay': 0,
+                  'rotate_firmware_password': False,
+                  'created_at': rp_config.created_at.isoformat(),
+                  'updated_at': rp_config.updated_at.isoformat()}
+             ]}
         )
 
     # get recovery password config

--- a/tests/mdm/test_api_scep_issuers_views.py
+++ b/tests/mdm/test_api_scep_issuers_views.py
@@ -65,18 +65,23 @@ class MDMSCEPIssuerAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'backend': 'STATIC_CHALLENGE',
-              'created_at': scep_issuer.created_at.isoformat(),
-              'id': str(scep_issuer.pk),
-              'key_usage': 0,
-              'key_size': 2048,
-              'name': scep_issuer.name,
-              'description': '',
-              'provisioning_uid': None,
-              'static_challenge_kwargs': {'challenge': scep_issuer.get_static_challenge_kwargs()['challenge']},
-              'updated_at': scep_issuer.updated_at.isoformat(),
-              'url': scep_issuer.url,
-              'version': 1}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'backend': 'STATIC_CHALLENGE',
+                  'created_at': scep_issuer.created_at.isoformat(),
+                  'id': str(scep_issuer.pk),
+                  'key_usage': 0,
+                  'key_size': 2048,
+                  'name': scep_issuer.name,
+                  'description': '',
+                  'provisioning_uid': None,
+                  'static_challenge_kwargs': {'challenge': scep_issuer.get_static_challenge_kwargs()['challenge']},
+                  'updated_at': scep_issuer.updated_at.isoformat(),
+                  'url': scep_issuer.url,
+                  'version': 1}
+             ]}
         )
 
     def test_list_scep_issuers_name_filter(self):
@@ -88,23 +93,28 @@ class MDMSCEPIssuerAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         backend_kwargs = scep_issuer.get_ident_kwargs()
         self.assertEqual(
             response.json(),
-            [{'backend': 'IDENT',
-              'created_at': scep_issuer.created_at.isoformat(),
-              'id': str(scep_issuer.pk),
-              'key_usage': 0,
-              'key_size': 2048,
-              'name': scep_issuer.name,
-              'description': '',
-              'provisioning_uid': None,
-              'ident_kwargs': {
-                  'url': backend_kwargs['url'],
-                  'bearer_token': backend_kwargs['bearer_token'],
-                  'request_timeout': backend_kwargs['request_timeout'],
-                  'max_retries': backend_kwargs['max_retries'],
-              },
-              'updated_at': scep_issuer.updated_at.isoformat(),
-              'url': scep_issuer.url,
-              'version': 1}]
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'backend': 'IDENT',
+                  'created_at': scep_issuer.created_at.isoformat(),
+                  'id': str(scep_issuer.pk),
+                  'key_usage': 0,
+                  'key_size': 2048,
+                  'name': scep_issuer.name,
+                  'description': '',
+                  'provisioning_uid': None,
+                  'ident_kwargs': {
+                      'url': backend_kwargs['url'],
+                      'bearer_token': backend_kwargs['bearer_token'],
+                      'request_timeout': backend_kwargs['request_timeout'],
+                      'max_retries': backend_kwargs['max_retries'],
+                  },
+                  'updated_at': scep_issuer.updated_at.isoformat(),
+                  'url': scep_issuer.url,
+                  'version': 1}
+             ]}
         )
 
     # get SCEP issuer

--- a/tests/mdm/test_api_software_update_enforcements_views.py
+++ b/tests/mdm/test_api_software_update_enforcements_views.py
@@ -63,19 +63,24 @@ class MDMSoftwareUpdateEnforcementsAPIViewsTestCase(TestCase, LoginCase, Request
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': sue.pk,
-              'name': sue.name,
-              'details_url': '',
-              'platforms': ['macOS'],
-              'tags': [],
-              'max_os_version': '17.1.2',
-              'delay_days': 14,
-              'local_time': '09:30:00',
-              'os_version': '',
-              'build_version': '',
-              'local_datetime': None,
-              'created_at': sue.created_at.isoformat(),
-              'updated_at': sue.updated_at.isoformat()}],
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': sue.pk,
+                  'name': sue.name,
+                  'details_url': '',
+                  'platforms': ['macOS'],
+                  'tags': [],
+                  'max_os_version': '17.1.2',
+                  'delay_days': 14,
+                  'local_time': '09:30:00',
+                  'os_version': '',
+                  'build_version': '',
+                  'local_datetime': None,
+                  'created_at': sue.created_at.isoformat(),
+                  'updated_at': sue.updated_at.isoformat()}
+             ]},
         )
 
     def test_list_software_update_enforcements_name_filter(self):
@@ -86,19 +91,24 @@ class MDMSoftwareUpdateEnforcementsAPIViewsTestCase(TestCase, LoginCase, Request
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{'id': sue.pk,
-              'name': sue.name,
-              'details_url': '',
-              'platforms': ['macOS'],
-              'tags': [],
-              'max_os_version': '17.1.2',
-              'delay_days': 14,
-              'local_time': '09:30:00',
-              'os_version': '',
-              'build_version': '',
-              'local_datetime': None,
-              'created_at': sue.created_at.isoformat(),
-              'updated_at': sue.updated_at.isoformat()}],
+            {'count': 1,
+             'next': None,
+             'previous': None,
+             'results': [
+                 {'id': sue.pk,
+                  'name': sue.name,
+                  'details_url': '',
+                  'platforms': ['macOS'],
+                  'tags': [],
+                  'max_os_version': '17.1.2',
+                  'delay_days': 14,
+                  'local_time': '09:30:00',
+                  'os_version': '',
+                  'build_version': '',
+                  'local_datetime': None,
+                  'created_at': sue.created_at.isoformat(),
+                  'updated_at': sue.updated_at.isoformat()}
+             ]},
         )
 
     # get software update enforcement

--- a/zentral/contrib/mdm/api_views/apps_books.py
+++ b/zentral/contrib/mdm/api_views/apps_books.py
@@ -2,7 +2,7 @@ from django_filters import rest_framework as filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from zentral.contrib.mdm.models import Location, LocationAsset
 from zentral.contrib.mdm.serializers import LocationAssetSerializer, LocationSerializer
-from zentral.utils.drf import DefaultDjangoModelPermissions
+from zentral.utils.drf import DefaultDjangoModelPermissions, MaxLimitOffsetPagination
 
 
 class LocationList(ListAPIView):
@@ -11,6 +11,7 @@ class LocationList(ListAPIView):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name', 'organization_name', 'mdm_info_id')
+    pagination_class = MaxLimitOffsetPagination
 
 
 class LocationDetail(RetrieveAPIView):
@@ -26,8 +27,9 @@ class LocationAssetFilter(filters.FilterSet):
 
 
 class LocationAssetList(ListAPIView):
-    queryset = LocationAsset.objects.select_related("asset", "location").all()
+    queryset = LocationAsset.objects.select_related("asset", "location").order_by("pk")
     serializer_class = LocationAssetSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = LocationAssetFilter
+    pagination_class = MaxLimitOffsetPagination

--- a/zentral/contrib/mdm/api_views/blueprints.py
+++ b/zentral/contrib/mdm/api_views/blueprints.py
@@ -1,6 +1,8 @@
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit,
+                               MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from zentral.contrib.mdm.artifacts import update_blueprint_serialized_artifacts
 from zentral.contrib.mdm.models import Blueprint, BlueprintArtifact
 from zentral.contrib.mdm.serializers import BlueprintSerializer, BlueprintArtifactSerializer
@@ -15,6 +17,7 @@ class BlueprintList(ListCreateAPIViewWithAudit):
     ).all()
     serializer_class = BlueprintSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class BlueprintDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -42,8 +45,9 @@ class BlueprintArtifactList(ListCreateAPIViewWithAudit):
                                  .prefetch_related("excluded_tags",
                                                    "item_tags__tag__meta_business_unit",
                                                    "item_tags__tag__taxonomy")
-                                 .all())
+                                 .order_by("pk"))
     serializer_class = BlueprintArtifactSerializer
+    pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
     def dispatch(self, request, *args, **kwargs):

--- a/zentral/contrib/mdm/api_views/cert_issuers.py
+++ b/zentral/contrib/mdm/api_views/cert_issuers.py
@@ -1,13 +1,16 @@
 from rest_framework.exceptions import ValidationError
 from zentral.contrib.mdm.models import ACMEIssuer, SCEPIssuer
 from zentral.contrib.mdm.serializers import ACMEIssuerSerializer, SCEPIssuerSerializer
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit,
+                               MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 
 
 class ACMEIssuerList(ListCreateAPIViewWithAudit):
-    queryset = ACMEIssuer.objects.all()
+    queryset = ACMEIssuer.objects.order_by("name")
     serializer_class = ACMEIssuerSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ACMEIssuerDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -26,9 +29,10 @@ class ACMEIssuerDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class SCEPIssuerList(ListCreateAPIViewWithAudit):
-    queryset = SCEPIssuer.objects.all()
+    queryset = SCEPIssuer.objects.order_by("name")
     serializer_class = SCEPIssuerSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class SCEPIssuerDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/mdm/api_views/filevault_configs.py
+++ b/zentral/contrib/mdm/api_views/filevault_configs.py
@@ -1,5 +1,7 @@
 from rest_framework.exceptions import ValidationError
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit,
+                               MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from zentral.contrib.mdm.models import FileVaultConfig
 from zentral.contrib.mdm.serializers import FileVaultConfigSerializer
 
@@ -11,6 +13,7 @@ class FileVaultConfigList(ListCreateAPIViewWithAudit):
     queryset = FileVaultConfig.objects.all()
     serializer_class = FileVaultConfigSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class FileVaultConfigDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/mdm/api_views/ota_enrollments.py
+++ b/zentral/contrib/mdm/api_views/ota_enrollments.py
@@ -1,5 +1,7 @@
 from rest_framework.exceptions import ValidationError
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit,
+                               MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from zentral.contrib.mdm.models import OTAEnrollment
 from zentral.contrib.mdm.serializers import OTAEnrollmentSerializer
 
@@ -12,6 +14,7 @@ class OTAEnrollmentList(ListCreateAPIViewWithAudit):
     queryset = OTAEnrollment.objects.all()
     serializer_class = OTAEnrollmentSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class OTAEnrollmentDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/mdm/api_views/push_certificates.py
+++ b/zentral/contrib/mdm/api_views/push_certificates.py
@@ -2,7 +2,7 @@ from django_filters import rest_framework as filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from zentral.contrib.mdm.models import PushCertificate
 from zentral.contrib.mdm.serializers import PushCertificateSerializer
-from zentral.utils.drf import DefaultDjangoModelPermissions
+from zentral.utils.drf import DefaultDjangoModelPermissions, MaxLimitOffsetPagination
 
 
 class PushCertificateList(ListAPIView):
@@ -11,6 +11,7 @@ class PushCertificateList(ListAPIView):
     serializer_class = PushCertificateSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class PushCertificateDetail(RetrieveAPIView):

--- a/zentral/contrib/mdm/api_views/recovery_password_configs.py
+++ b/zentral/contrib/mdm/api_views/recovery_password_configs.py
@@ -1,5 +1,7 @@
 from rest_framework.exceptions import ValidationError
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit,
+                               MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from zentral.contrib.mdm.models import RecoveryPasswordConfig
 from zentral.contrib.mdm.serializers import RecoveryPasswordConfigSerializer
 
@@ -11,6 +13,7 @@ class RecoveryPasswordConfigList(ListCreateAPIViewWithAudit):
     queryset = RecoveryPasswordConfig.objects.all()
     serializer_class = RecoveryPasswordConfigSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class RecoveryPasswordConfigDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/mdm/api_views/software_update_enforcements.py
+++ b/zentral/contrib/mdm/api_views/software_update_enforcements.py
@@ -1,5 +1,7 @@
 from rest_framework.exceptions import ValidationError
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit,
+                               MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from zentral.contrib.mdm.models import SoftwareUpdateEnforcement
 from zentral.contrib.mdm.serializers import SoftwareUpdateEnforcementSerializer
 
@@ -9,9 +11,10 @@ class SoftwareUpdateEnforcementList(ListCreateAPIViewWithAudit):
     List all SoftwareUpdateEnforcement, search SoftwareUpdateEnforcement by name,
     or create a new SoftwareUpdateEnforcement.
     """
-    queryset = SoftwareUpdateEnforcement.objects.all()
+    queryset = SoftwareUpdateEnforcement.objects.order_by("name")
     serializer_class = SoftwareUpdateEnforcementSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class SoftwareUpdateEnforcementDetail(RetrieveUpdateDestroyAPIViewWithAudit):


### PR DESCRIPTION
Eleven MDM list endpoints returned their full queryset in a single response. They now use `MaxLimitOffsetPagination` like the rest of the MDM API:

`acme_issuers/`, `scep_issuers/`, `filevault_configs/`, `recovery_password_configs/`, `software_update_enforcements/`, `ota_enrollments/`, `blueprints/`, `blueprint_artifacts/`, `locations/`, `location_assets/`, `push_certificates/`

`location_assets/` is the one that grows without bound; the others are configuration tables, but they were the last MDM list views without a `pagination_class`.

### Ordering

The ACME issuer, SCEP issuer, software update enforcement, blueprint artifact and location asset models have no `Meta.ordering`. Offset pagination over an unordered queryset can drop or repeat rows between pages, so those list querysets are ordered explicitly — by `name` where it is unique, by `pk` otherwise.

### Backward incompatibility

Those responses change from a bare list to the `{count, next, previous, results}` envelope. Added to the changelog, and the Terraform Provider will need a release built against an updated [goztl](https://github.com/zentralopensource/goztl).

### Tests

Full `tests.mdm` run: 2605 tests, OK. `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)