### PR TITLE
mdm: drop the DEP token expiry flags from the event payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Repository syncs now run in the background. Repositories that need more than the
 The API endpoints for the ACME issuer, SCEP issuer, FileVault configuration, recovery password configuration, software update enforcement, OTA enrollment, blueprint, blueprint artifact, location, location asset and push certificate lists are paginated now. Remember to upgrade the Terraform Provider.
 
 
+#### 🧨 MDM DEP token audit event payload
+
+The DEP token audit events do not carry the `has_expired` and `expires_soon` booleans anymore. They were computed when the event was serialized, and never refreshed afterwards, so a stored event kept reporting the state of the token at the time it was written. Use the `access_token_expiry` timestamp, which is still in the payload, and compare it with the event `created_at`. Probes keyed on the two removed fields need to be updated.
+
+
 #### 🧨 Monolith repository sync API endpoint
 
 `/api/monolith/repositories/<int:pk>/sync/` launches a background task instead of syncing the repository during the request. It responds with `201` and a `task_id`/`task_result_url` pair, in place of the `200 {"status": 0}` and `500 {"status": 1, "error": "…"}` responses it used to return. Poll `task_result_url` to know the outcome of the sync.

--- a/tests/mdm/models/test_credential_models.py
+++ b/tests/mdm/models/test_credential_models.py
@@ -1,11 +1,13 @@
 import hashlib
 import json
+from datetime import timedelta
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 from tests.mdm.utils import force_dep_virtual_server, force_push_certificate
 from tests.zentral_test_utils.assertions.serialization_assertions import SerializeForEventAssertions
 from zentral.contrib.mdm.crypto import certificate_sha256_fingerprint
 from zentral.contrib.mdm.models import PushCertificate
+from zentral.utils.time import naive_utcnow
 
 
 class TestMDMCredentialModelSerialization(TestCase, SerializeForEventAssertions):
@@ -83,12 +85,21 @@ class TestMDMCredentialModelSerialization(TestCase, SerializeForEventAssertions)
         d = dep_token.serialize_for_event()
         self.assertEqual(
             set(d),
-            {"pk", "certificate_sha256", "access_token_expiry", "has_expired", "expires_soon",
-             "last_synced_at", "created_at", "updated_at"},
+            {"pk", "certificate_sha256", "access_token_expiry", "last_synced_at", "created_at", "updated_at"},
         )
-        self.assertIsInstance(d["has_expired"], bool)
-        self.assertIsInstance(d["expires_soon"], bool)
         self.assert_serialize_for_event_is_json_native(dep_token)
+
+    def test_dep_token_serialize_for_event_has_no_point_in_time_expiry_flags(self):
+        # a stored event must not carry a value that was only true when it was serialized
+        dep_token = force_dep_virtual_server().token
+        dep_token.access_token_expiry = naive_utcnow() - timedelta(days=1)
+        dep_token.save()
+        self.assertTrue(dep_token.has_expired())
+        self.assertTrue(dep_token.expires_soon())
+        d = dep_token.serialize_for_event()
+        self.assertNotIn("has_expired", d)
+        self.assertNotIn("expires_soon", d)
+        self.assertEqual(d["access_token_expiry"], dep_token.access_token_expiry.isoformat())
 
     def test_dep_token_serialize_for_event_keys_only(self):
         dep_token = force_dep_virtual_server().token

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -1961,12 +1961,12 @@ class DEPToken(models.Model):
         # Only the metadata an auditor can act on. The three secrets are left out, and so are
         # consumer_key and access_token: they are the public halves of the OAuth credential,
         # but there is one token per virtual server, so naming them tells an auditor nothing.
-        # sync_cursor is operational state.
+        # sync_cursor is operational state. The expiry is reported as a timestamp and not as
+        # has_expired/expires_soon booleans: those are only true at serialization time, and a
+        # stored event would keep asserting them long after they stopped being accurate.
         d.update({
             "certificate_sha256": certificate_sha256_fingerprint(self.certificate),
             "access_token_expiry": self.access_token_expiry.isoformat() if self.access_token_expiry else None,
-            "has_expired": bool(self.has_expired()),
-            "expires_soon": bool(self.expires_soon()),
             "last_synced_at": self.last_synced_at.isoformat() if self.last_synced_at else None,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),


### PR DESCRIPTION
## What

`DEPToken.serialize_for_event` emitted two `timezone.now()`-derived booleans next to the raw timestamp:

```python
"access_token_expiry": self.access_token_expiry.isoformat() if self.access_token_expiry else None,
"has_expired": bool(self.has_expired()),
"expires_soon": bool(self.expires_soon()),
```

`has_expired` and `expires_soon` are gone. `access_token_expiry` stays.

## Why

An event payload must not carry a value that is only true at serialization time. Neither boolean is recomputed once the event is written — the token is only re-serialized when it is next saved or synced — so an event emitted the day before an expiry goes into the event store saying `has_expired: false` and keeps saying it forever. A probe or a dashboard reading that field off a stored event reads the state of the token at write time, not now.

The timestamp does not have that problem: consumers compare `access_token_expiry` against the event's own `created_at` and get an answer that stays correct for as long as the event is kept.

This matches `APIToken.serialize_for_event` in `server/accounts/models.py`, which has `is_active()` / `is_expired()` helpers but whose payload carries only the raw `expiry`.

## Scope

The `has_expired()` / `expires_soon()` **methods are untouched** — only the event payload changes. They are still used by:

- `mdm/depvirtualserver_detail.html` and `mdm/depvirtualserver_list.html` (expiry badges)
- `zentral/contrib/mdm/dep_client.py:66`

Rendering them in a template is fine: the template is evaluated on each request, so the value is never stale.

## Breaking change

Anyone with a probe keyed on `has_expired` or `expires_soon` in a DEP token audit event needs to update it. A 🧨 entry is in the CHANGELOG under 2026.5 → *Backward incompatibilities*, pointing at `access_token_expiry` and `created_at` as the replacement.

## Notes for the reviewer

- The regression test backdates `access_token_expiry` by a day so both methods return true, then asserts the payload carries neither key. The pinned key set alone would not catch a conditional re-add.
- That test uses `naive_utcnow()` from `zentral.utils.time`, not `datetime.utcnow()` — this project runs `USE_TZ = False`, so `timezone.now()` inside `has_expired()` is naive UTC and a tz-aware value raises on comparison. Same helper `tests/mdm/test_setup_dep_enrollment.py:255` uses.
- `Location.server_token_expires_soon` (`models.py:763`) is the same point-in-time shape for VPP server tokens, but it is only read by `location_list.html` / `location_detail.html` and never reaches an event payload, so it is left alone here.

## Tests

```
tests.mdm.models.test_credential_models                       14 tests, OK
tests.mdm.test_setup_credential_audit,
tests.mdm.test_setup_dep_virtual_server, tests.mdm.test_dep,
tests.mdm.test_dep_beta_tokens, tests.mdm.test_api_dep_views,
tests.mdm.test_setup_dep_enrollment, tests.mdm.test_enrollment_audit   128 tests, OK
```

`ruff check` on both changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

