### PR TITLE
Add a read-only compliance-check-id to serializers

### DIFF
--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -1339,6 +1339,7 @@ Response:
     {
         "id": 1,
         "compliance_check_enabled": false,
+        "compliance_check_id": null,
         "name": "GetApps",
         "sql": "SELECT * FROM apps;",
         "platforms": [],
@@ -1392,6 +1393,7 @@ Response:
 {
 	"id": 1,
 	"compliance_check_enabled": false,
+	"compliance_check_id": null,
 	"name": "GetApps",
 	"sql": "SELECT * FROM apps;",
 	"platforms": [],
@@ -1435,6 +1437,7 @@ Response:
 {
 	"id": 1,
 	"compliance_check_enabled": false,
+	"compliance_check_id": null,
 	"name": "GetApps",
 	"sql": "SELECT * FROM apps;",
 	"platforms": [],
@@ -1481,6 +1484,7 @@ Response:
 {
 	"id": 1,
 	"compliance_check_enabled": false,
+	"compliance_check_id": null,
 	"name": "GetUsers",
 	"sql": "SELECT * FROM users;",
 	"platforms": [],

--- a/tests/inventory/test_compliance_checks_api.py
+++ b/tests/inventory/test_compliance_checks_api.py
@@ -117,6 +117,7 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
             response = self.post(reverse('inventory_api:jmespath_checks'), data)
         self.assertEqual(response.status_code, 201)
         jpcc = JMESPathCheck.objects.get(compliance_check__name=name)
+        self.assertEqual(response.json()["compliance_check_id"], jpcc.compliance_check.pk)
         self.assertEqual(jpcc.compliance_check.description, description)
         self.assertEqual(jpcc.compliance_check.version, 1)
         self.assertEqual(jpcc.source_name, source_name)
@@ -213,6 +214,7 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
              "name": jpcc.compliance_check.name,
              "description": jpcc.compliance_check.description,
              "version": jpcc.compliance_check.version,
+             "compliance_check_id": jpcc.compliance_check.pk,
              "source_name": jpcc.source_name,
              "platforms": jpcc.platforms,
              "jmespath_expression": jpcc.jmespath_expression,
@@ -345,6 +347,7 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
               "name": jpcc.compliance_check.name,
               "description": jpcc.compliance_check.description,
               "version": jpcc.compliance_check.version,
+              "compliance_check_id": jpcc.compliance_check.pk,
               "source_name": jpcc.source_name,
               "platforms": jpcc.platforms,
               "jmespath_expression": jpcc.jmespath_expression,
@@ -366,6 +369,7 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
               "name": jpcc.compliance_check.name,
               "description": jpcc.compliance_check.description,
               "version": jpcc.compliance_check.version,
+              "compliance_check_id": jpcc.compliance_check.pk,
               "source_name": jpcc.source_name,
               "platforms": jpcc.platforms,
               "jmespath_expression": jpcc.jmespath_expression,

--- a/tests/munki/test_api_views.py
+++ b/tests/munki/test_api_views.py
@@ -818,6 +818,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             [{'id': sc.pk,
+              'compliance_check_id': sc.compliance_check.pk,
               'description': sc.compliance_check.description,
               'expected_result': sc.expected_result,
               'arch_amd64': True,
@@ -845,6 +846,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             sorted(response.json(), key=lambda d: d["id"]),
             [{'id': sc.pk,
+              'compliance_check_id': sc.compliance_check.pk,
               'description': sc.compliance_check.description,
               'expected_result': sc.expected_result,
               'arch_amd64': True,
@@ -860,6 +862,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
               'updated_at': sc.updated_at.isoformat(),
               'version': 1},
              {'id': sc2.pk,
+              'compliance_check_id': sc2.compliance_check.pk,
               'description': sc2.compliance_check.description,
               'expected_result': sc2.expected_result,
               'arch_amd64': True,
@@ -1012,6 +1015,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             {'id': script_check.pk,
+             'compliance_check_id': script_check.compliance_check.pk,
              'description': "",
              'expected_result': "yolo",
              'arch_amd64': True,
@@ -1081,6 +1085,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             {'id': sc.pk,
+             'compliance_check_id': sc.compliance_check.pk,
              'description': sc.compliance_check.description,
              'expected_result': sc.expected_result,
              'arch_amd64': True,
@@ -1165,6 +1170,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             {'id': script_check.pk,
+             'compliance_check_id': script_check.compliance_check.pk,
              'description': "yolo",
              'expected_result': "true",
              'arch_amd64': False,

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -2472,6 +2472,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                            "name": query.name,
                            "version": 1,
                            "compliance_check_enabled": False,
+                           "compliance_check_id": None,
                            "sql": query.sql,
                            "tag": None,
                            "minimum_osquery_version": None,
@@ -2503,6 +2504,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                            "name": query.name,
                            "version": 1,
                            "compliance_check_enabled": False,
+                           "compliance_check_id": None,
                            "sql": query.sql,
                            "tag": None,
                            "minimum_osquery_version": None,
@@ -2527,6 +2529,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                            "name": query.name,
                            "version": 1,
                            "compliance_check_enabled": False,
+                           "compliance_check_id": None,
                            "sql": query.sql,
                            "tag": None,
                            "minimum_osquery_version": None,
@@ -2574,6 +2577,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "name": query.name,
                           "version": 1,
                           "compliance_check_enabled": False,
+                          "compliance_check_id": None,
                           "sql": "select * from osquery_info;",
                           "tag": None,
                           "minimum_osquery_version": None,
@@ -2606,6 +2610,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "name": query.name,
                           "version": 1,
                           "compliance_check_enabled": False,
+                          "compliance_check_id": None,
                           "sql": "select * from osquery_info;",
                           "tag": None,
                           "minimum_osquery_version": None,
@@ -2640,6 +2645,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "name": query.name,
                           "version": 1,
                           "compliance_check_enabled": True,
+                          "compliance_check_id": query.compliance_check.pk,
                           "sql": "select 'OK' ztl_status;",
                           "tag": None,
                           "minimum_osquery_version": None,
@@ -2668,6 +2674,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "name": query.name,
                           "version": 1,
                           "compliance_check_enabled": False,
+                          "compliance_check_id": None,
                           "sql": "select 'OK' ztl_status;",
                           "tag": tag.pk,
                           "minimum_osquery_version": None,
@@ -2866,6 +2873,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "name": query.name,
                           "version": 1,
                           "compliance_check_enabled": False,
+                          "compliance_check_id": None,
                           "sql": query.sql,
                           "tag": None,
                           "minimum_osquery_version": None,
@@ -2890,6 +2898,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("osquery_api:query", args=(query.pk,)))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["compliance_check_enabled"], True)
+        self.assertEqual(response.json()["compliance_check_id"], query.compliance_check.pk)
         self.assertIs(isinstance(query.compliance_check, ComplianceCheck), True)
 
     def test_get_query_unauthorized(self):
@@ -2946,6 +2955,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             {'compliance_check_enabled': False,
+             'compliance_check_id': None,
              'created_at': query.created_at.isoformat(),
              'description': '',
              'id': query.pk,
@@ -3002,6 +3012,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             {'compliance_check_enabled': False,
+             'compliance_check_id': None,
              'created_at': query.created_at.isoformat(),
              'description': '',
              'id': query.pk,
@@ -3052,6 +3063,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(
             response.json(),
             {'compliance_check_enabled': False,
+             'compliance_check_id': None,
              'created_at': query.created_at.isoformat(),
              'description': '',
              'id': query.pk,
@@ -3119,8 +3131,22 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         query.refresh_from_db()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["compliance_check_enabled"], True)
+        self.assertEqual(response.json()["compliance_check_id"], query.compliance_check.pk)
         self.assertIs(isinstance(query.compliance_check, ComplianceCheck), True)
         self.assertEqual(query.sql, "ztl_status;")
+
+    def test_update_query_disable_compliance_check(self):
+        query = self.force_query(compliance_check=True)
+        compliance_check_pk = query.compliance_check.pk
+        data = {"name": query.name, "sql": query.sql, "compliance_check_enabled": False}
+        self.set_permissions("osquery.change_query")
+        response = self.put(reverse("osquery_api:query", args=(query.pk,)), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["compliance_check_enabled"], False)
+        self.assertIsNone(response.json()["compliance_check_id"])
+        query.refresh_from_db()
+        self.assertIsNone(query.compliance_check)
+        self.assertEqual(ComplianceCheck.objects.filter(pk=compliance_check_pk).count(), 0)
 
     def test_update_query_increment_version(self):
         query = self.force_query()

--- a/zentral/contrib/inventory/serializers.py
+++ b/zentral/contrib/inventory/serializers.py
@@ -107,10 +107,11 @@ class JMESPathCheckSerializer(serializers.ModelSerializer):
         allow_blank=True, required=False, default=""
     )
     version = serializers.IntegerField(source="compliance_check.version", read_only=True)
+    compliance_check_id = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = JMESPathCheck
-        fields = ("name", "description", "version",
+        fields = ("name", "description", "version", "compliance_check_id",
                   "id", "source_name", "platforms", "tags",
                   "jmespath_expression", "created_at", "updated_at")
 

--- a/zentral/contrib/munki/serializers.py
+++ b/zentral/contrib/munki/serializers.py
@@ -70,10 +70,11 @@ class ScriptCheckSerializer(serializers.ModelSerializer):
         allow_blank=True, required=False, default=""
     )
     version = serializers.IntegerField(source="compliance_check.version", read_only=True)
+    compliance_check_id = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = ScriptCheck
-        fields = ("name", "description", "version",
+        fields = ("name", "description", "version", "compliance_check_id",
                   "id", "tags", "excluded_tags",
                   "arch_amd64", "arch_arm64",
                   "min_os_version", "max_os_version",

--- a/zentral/contrib/osquery/compliance_checks.py
+++ b/zentral/contrib/osquery/compliance_checks.py
@@ -62,6 +62,9 @@ def sync_query_compliance_check(query, on):
                 query.compliance_check.save()
     elif query.compliance_check:
         query.compliance_check.delete()
+        # delete() only NULLs the FK column (SET_NULL); refresh the in-memory instance so the caller's
+        # serialization doesn't report the deleted check as still set
+        query.compliance_check = None
         deleted = True
     return created, updated, deleted
 

--- a/zentral/contrib/osquery/serializers.py
+++ b/zentral/contrib/osquery/serializers.py
@@ -199,6 +199,7 @@ class QuerySchedulingSerializer(serializers.ModelSerializer):
 
 class QuerySerializer(serializers.ModelSerializer):
     compliance_check_enabled = serializers.BooleanField(default=False)
+    compliance_check_id = serializers.IntegerField(read_only=True, allow_null=True)
     scheduling = QuerySchedulingSerializer(source="packquery", required=False, allow_null=True)
 
     class Meta:


### PR DESCRIPTION
Adds `compliance_check_id` to the osquery `QuerySerializer`, the inventory `JMESPathCheckSerializer` and the munki `ScriptCheckSerializer`, so API clients can correlate these objects with their compliance check statuses without a second lookup.

Read-only, and declared the same way as the turbo `ScriptSerializer` / `MSCPCheckSerializer` already do it.

## One fix this needed

The osquery query is the only one of the three whose compliance check FK is nullable — the other two are non-null `OneToOneField`s, so their id is always there.

Disabling a query's compliance check deletes it, and since the FK is `on_delete=SET_NULL`, the delete only NULLs the column. The in-memory instance the DRF response is serialized from kept pointing at the deleted check, so the PUT that disabled it would have echoed back a stale `compliance_check_id`. `sync_query_compliance_check` now clears the attribute, as the turbo one already does.

That also fixes an existing bug on the same path: the response to the request that disabled a check reported `compliance_check_enabled: true`, because that field reads the same stale attribute. `test_update_query_disable_compliance_check` covers both.

## Notes for the reviewer

- The four osquery query response examples in the docs gained the field. The request payload example is untouched — it is read-only.
- Munki script checks and inventory JMESPath checks have no REST API section in the docs, only Terraform resources, so there was nothing to update for them.
- `tests.osquery tests.inventory tests.munki` pass (1432 tests), `ruff check` is clean, and `mkdocs build --strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)