### PR TITLE
santa: fix the false sync incidents

### DIFF
--- a/tests/santa/test_configuration.py
+++ b/tests/santa/test_configuration.py
@@ -1,9 +1,28 @@
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.santa.models import Configuration
+from zentral.core.incidents.models import Severity
 
 
 class SantaConfigurationTestCase(TestCase):
+    # get_sync_incident_severity
+
+    def test_get_sync_incident_severity(self):
+        config = Configuration.objects.create(name=get_random_string(256),
+                                              sync_incident_severity=Severity.MAJOR.value)
+        self.assertEqual(config.get_sync_incident_severity(), Severity.MAJOR)
+
+    def test_get_unknown_sync_incident_severity_none(self):
+        config = Configuration.objects.create(name=get_random_string(256))
+        Configuration.objects.filter(pk=config.pk).update(sync_incident_severity=42)
+        config.refresh_from_db()
+        with self.assertLogs("zentral.contrib.santa.models", level="ERROR") as cm:
+            self.assertEqual(config.get_sync_incident_severity(), Severity.NONE)
+        self.assertEqual(
+            cm.output,
+            [f"ERROR:zentral.contrib.santa.models:Configuration {config.pk}: unknown sync incident severity 42"]
+        )
+
     def test_local_configuration_url_keys(self):
         config = Configuration.objects.create(name=get_random_string(256))
         local_config = config.get_local_config()

--- a/tests/santa/test_rule_engine.py
+++ b/tests/santa/test_rule_engine.py
@@ -110,6 +110,37 @@ class SantaRuleEngineTestCase(TestCase):
         self.assertTrue(self.enrolled_machine.sync_ok())
         self.assertTrue(self.enrolled_machine2.sync_ok())
 
+    def test_transitive_rules_sync_ok(self):
+        # the transitive rules are created by the client and reported as binary rules
+        for i in range(3):
+            target, rule, _ = self.create_and_serialize_for_iter_rule(target_type=Target.Type.BINARY)
+            MachineRule.objects.create(
+                enrolled_machine=self.enrolled_machine,
+                target=target,
+                policy=rule.policy,
+                version=rule.version,
+                cursor=None
+            )
+        self.enrolled_machine.binary_rule_count = 3 + 17
+        self.enrolled_machine.transitive_rule_count = 17
+        self.assertTrue(self.enrolled_machine.sync_ok())
+
+    def test_transitive_rules_missing_synced_binary_sync_not_ok(self):
+        for i in range(3):
+            target, rule, _ = self.create_and_serialize_for_iter_rule(target_type=Target.Type.BINARY)
+            if i == 0:
+                continue
+            MachineRule.objects.create(
+                enrolled_machine=self.enrolled_machine,
+                target=target,
+                policy=rule.policy,
+                version=rule.version,
+                cursor=None
+            )
+        self.enrolled_machine.binary_rule_count = 3 + 17
+        self.enrolled_machine.transitive_rule_count = 17
+        self.assertFalse(self.enrolled_machine.sync_ok())
+
     def test_multiple_rules_missing_reported_teamid_sync_not_ok(self):
         for target_type, count in ((Target.Type.BINARY, 3), (Target.Type.CERTIFICATE, 2), (Target.Type.TEAM_ID, 1)):
             for i in range(count):

--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -318,6 +318,53 @@ class SantaAPIViewsTestCase(TestCase):
         enrolled_machine = EnrolledMachine.objects.get(enrollment=self.enrollment, hardware_uuid=hardware_uuid)
         self.assertEqual(enrolled_machine.compiler_rule_count, 2147483647)
 
+    def test_preflight_compiler_rule_count_max_int_field_value_overflow(self):
+        data, serial_number, hardware_uuid = self._get_preflight_data()
+        data["compiler_rule_count"] = 2147483648
+        response = self.post_as_json("preflight", hardware_uuid, data)
+        self.assertEqual(response.status_code, 200)
+
+        # Enrolled machine
+        enrolled_machine = EnrolledMachine.objects.get(enrollment=self.enrollment, hardware_uuid=hardware_uuid)
+        self.assertEqual(enrolled_machine.compiler_rule_count, 2147483647)
+
+    def test_preflight_binary_rule_count_not_an_integer(self):
+        data, serial_number, hardware_uuid = self._get_preflight_data()
+        data["binary_rule_count"] = "yolo"
+        with self.assertLogs("zentral.contrib.santa.views.api", level="ERROR") as cm:
+            response = self.post_as_json("preflight", hardware_uuid, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            f"ERROR:zentral.contrib.santa.views.api:Machine {serial_number}: "
+            "reported binary_rule_count yolo not an integer",
+            cm.output
+        )
+
+        # Enrolled machine
+        enrolled_machine = EnrolledMachine.objects.get(enrollment=self.enrollment, hardware_uuid=hardware_uuid)
+        self.assertEqual(enrolled_machine.binary_rule_count, 0)
+
+    def test_preflight_missing_rule_counts_reset(self):
+        # santa omits the rule counts set to 0, they must not keep their previous value
+        EnrolledMachine.objects.filter(pk=self.enrolled_machine.pk).update(
+            binary_rule_count=17, cdhash_rule_count=17, certificate_rule_count=17, compiler_rule_count=17,
+            signingid_rule_count=17, teamid_rule_count=17, transitive_rule_count=17,
+        )
+        data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
+        for key in list(data.keys()):
+            if key.endswith("_rule_count"):
+                del data[key]
+        response = self.post_as_json("preflight", hardware_uuid, data)
+        self.assertEqual(response.status_code, 200)
+        self.enrolled_machine.refresh_from_db()
+        self.assertEqual(self.enrolled_machine.binary_rule_count, 0)
+        self.assertEqual(self.enrolled_machine.cdhash_rule_count, 0)
+        self.assertEqual(self.enrolled_machine.certificate_rule_count, 0)
+        self.assertEqual(self.enrolled_machine.compiler_rule_count, 0)
+        self.assertEqual(self.enrolled_machine.signingid_rule_count, 0)
+        self.assertEqual(self.enrolled_machine.teamid_rule_count, 0)
+        self.assertEqual(self.enrolled_machine.transitive_rule_count, 0)
+
     def test_preflight_binary_rule_count_negative(self):
         data, serial_number, hardware_uuid = self._get_preflight_data()
         data["binary_rule_count"] = -27551562368811008

--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -425,8 +425,21 @@ class SantaAPIViewsTestCase(TestCase):
         json_response = response.json()
         self.assertEqual(json_response["sync_type"], "clean")
 
-    def test_preflight_no_enrollment_no_rule_counts(self):
-        # no enrollment, no rule counts, no clean sync requested → sync type clean
+    def test_preflight_no_enrollment_no_rule_count_no_machine_rule_sync_type_normal(self):
+        # no enrollment, no reported rule, no synced rule, no clean sync requested → sync type normal
+        data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
+        for k in list(data.keys()):
+            if k.endswith("_rule_count"):
+                del data[k]
+        data["request_clean_sync"] = False
+        response = self.post_as_json("preflight", hardware_uuid, data)
+        self.assertEqual(response.status_code, 200)
+        json_response = response.json()
+        self.assertEqual(json_response["sync_type"], "normal")
+
+    def test_preflight_no_enrollment_no_rule_count_machine_rules_sync_type_clean(self):
+        # the client reports no rule, but some rules were synced with it → sync type clean
+        self._add_synced_rule()
         data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
         for k in list(data.keys()):
             if k.endswith("_rule_count"):
@@ -436,10 +449,13 @@ class SantaAPIViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         json_response = response.json()
         self.assertEqual(json_response["sync_type"], "clean")
+        self.assertEqual(MachineRule.objects.filter(enrolled_machine=self.enrolled_machine).count(), 0)
 
-    def _add_synced_rule(self, enrolled_machine=None):
-        target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
-        rule = Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.BLOCKLIST)
+    def _add_synced_rule(self, enrolled_machine=None, target_type=Target.Type.BINARY, configuration=None):
+        identifier = new_team_id() if target_type == Target.Type.TEAM_ID else new_sha256()
+        target = Target.objects.create(type=target_type, identifier=identifier)
+        rule = Rule.objects.create(configuration=configuration or self.configuration,
+                                   target=target, policy=Rule.Policy.BLOCKLIST)
         MachineRule.objects.create(
             enrolled_machine=enrolled_machine or self.enrolled_machine,
             target=target,
@@ -511,18 +527,12 @@ class SantaAPIViewsTestCase(TestCase):
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_preflight_sync_not_ok_conf_without_severity_no_incident_update(self, post_event):
-        # add one synced rule
-        target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
-        rule = Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.BLOCKLIST)
-        MachineRule.objects.create(
-            enrolled_machine=self.enrolled_machine,
-            target=target,
-            policy=rule.policy,
-            version=rule.version,
-            cursor=None
-        )
+        # add two synced rules
+        self._add_synced_rule()
+        self._add_synced_rule(target_type=Target.Type.TEAM_ID)
         data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
         data["binary_rule_count"] = 0  # sync not OK
+        data["teamid_rule_count"] = 1  # the client still reports a rule, no clean sync
         response = self.post_as_json("preflight", hardware_uuid, data)
         self.assertEqual(response.status_code, 200)
         self.enrolled_machine.refresh_from_db()
@@ -604,17 +614,11 @@ class SantaAPIViewsTestCase(TestCase):
         # setup the sync incidents
         self.configuration.sync_incident_severity = Severity.MAJOR.value
         self.configuration.save()
-        # add one synced rule
-        target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
-        rule = Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.BLOCKLIST)
-        MachineRule.objects.create(
-            enrolled_machine=self.enrolled_machine,
-            target=target,
-            policy=rule.policy,
-            version=rule.version,
-            cursor=None
-        )
+        # add two synced rules
+        self._add_synced_rule()
+        self._add_synced_rule(target_type=Target.Type.TEAM_ID)
         data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
+        data["teamid_rule_count"] = 1  # the client still reports a rule, no clean sync
         response = self.post_as_json("preflight", hardware_uuid, data)
         self.assertEqual(response.status_code, 200)
         self.enrolled_machine.refresh_from_db()
@@ -637,17 +641,11 @@ class SantaAPIViewsTestCase(TestCase):
         # simulate sync not ok status
         self.enrolled_machine.last_sync_ok = False
         self.enrolled_machine.save()
-        # add one synced rule
-        target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
-        rule = Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.BLOCKLIST)
-        MachineRule.objects.create(
-            enrolled_machine=self.enrolled_machine,
-            target=target,
-            policy=rule.policy,
-            version=rule.version,
-            cursor=None
-        )
+        # add two synced rules
+        self._add_synced_rule()
+        self._add_synced_rule(target_type=Target.Type.TEAM_ID)
         data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
+        data["teamid_rule_count"] = 1  # the client still reports a rule, no clean sync
         response = self.post_as_json("preflight", hardware_uuid, data)
         self.assertEqual(response.status_code, 200)
         self.enrolled_machine.refresh_from_db()

--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -437,6 +437,78 @@ class SantaAPIViewsTestCase(TestCase):
         json_response = response.json()
         self.assertEqual(json_response["sync_type"], "clean")
 
+    def _add_synced_rule(self, enrolled_machine=None):
+        target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
+        rule = Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.BLOCKLIST)
+        MachineRule.objects.create(
+            enrolled_machine=enrolled_machine or self.enrolled_machine,
+            target=target,
+            policy=rule.policy,
+            version=rule.version,
+            cursor=None
+        )
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_preflight_enrollment_conf_with_severity_no_incident_update(self, post_event):
+        # a machine that just enrolled has no synced rule to be compared with
+        self.configuration.sync_incident_severity = Severity.MAJOR.value
+        self.configuration.save()
+        data, serial_number, hardware_uuid = self._get_preflight_data()
+        # the client still reports the rules of a previous enrollment
+        data["binary_rule_count"] = 5
+        response = self.post_as_json("preflight", hardware_uuid, data)
+        self.assertEqual(response.status_code, 200)
+        enrolled_machine = EnrolledMachine.objects.get(enrollment=self.enrollment, hardware_uuid=hardware_uuid)
+        self.assertIsNone(enrolled_machine.last_sync_ok)
+        events = list(call_args.args[0] for call_args in post_event.call_args_list)
+        preflight_event = events[-1]
+        self.assertIsInstance(preflight_event, SantaPreflightEvent)
+        self.assertEqual(len(preflight_event.metadata.incident_updates), 0)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_preflight_re_enrollment_conf_with_severity_no_incident_update(self, post_event):
+        self.configuration.sync_incident_severity = Severity.MAJOR.value
+        self.configuration.save()
+        self.configuration2.sync_incident_severity = Severity.MAJOR.value
+        self.configuration2.save()
+        self._add_synced_rule()
+        data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
+        data["binary_rule_count"] = 1
+        # same machine, other enrollment → the enrolled machine is replaced
+        response = self.post_as_json("preflight", hardware_uuid, data,
+                                     enrollment_secret=self.enrollment_secret2.secret)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(EnrolledMachine.objects.filter(pk=self.enrolled_machine.pk).count(), 0)
+        enrolled_machine = EnrolledMachine.objects.get(enrollment=self.enrollment2, hardware_uuid=hardware_uuid)
+        self.assertIsNone(enrolled_machine.last_sync_ok)
+        events = list(call_args.args[0] for call_args in post_event.call_args_list)
+        enrollment_event = events[1]
+        self.assertIsInstance(enrollment_event, SantaEnrollmentEvent)
+        self.assertEqual(enrollment_event.payload["action"], "re-enrollment")
+        preflight_event = events[-1]
+        self.assertIsInstance(preflight_event, SantaPreflightEvent)
+        self.assertEqual(len(preflight_event.metadata.incident_updates), 0)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_preflight_clean_sync_requested_in_sync_no_incident_update(self, post_event):
+        # the machine rules are deleted, but the client still has its rules during the preflight
+        self.configuration.sync_incident_severity = Severity.MAJOR.value
+        self.configuration.save()
+        self._add_synced_rule()
+        data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
+        data["binary_rule_count"] = 1
+        data["request_clean_sync"] = True
+        response = self.post_as_json("preflight", hardware_uuid, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["sync_type"], "clean")
+        self.assertEqual(MachineRule.objects.filter(enrolled_machine=self.enrolled_machine).count(), 0)
+        self.enrolled_machine.refresh_from_db()
+        self.assertTrue(self.enrolled_machine.last_sync_ok)
+        events = list(call_args.args[0] for call_args in post_event.call_args_list)
+        preflight_event = events[-1]
+        self.assertIsInstance(preflight_event, SantaPreflightEvent)
+        self.assertEqual(len(preflight_event.metadata.incident_updates), 0)
+
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_preflight_sync_not_ok_conf_without_severity_no_incident_update(self, post_event):
         # add one synced rule

--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -682,6 +682,30 @@ class SantaAPIViewsTestCase(TestCase):
         self.assertIsInstance(preflight_event, SantaPreflightEvent)
         self.assertEqual(len(preflight_event.metadata.incident_updates), 0)
 
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_preflight_reenrollment_other_serial_number_no_incident_update(self, post_event):
+        # santa can be configured to report a machine ID that is not the hardware UUID
+        self.enrolled_machine.last_sync_ok = False
+        self.enrolled_machine.save()
+        data, _, hardware_uuid = self._get_preflight_data(enrolled=True)
+        serial_number = get_random_string(12)
+        data["serial_number"] = serial_number
+        with self.assertLogs("zentral.contrib.santa.views.api", level="ERROR") as cm:
+            response = self.post_as_json("preflight", hardware_uuid, data,
+                                         enrollment_secret=self.enrollment_secret2.secret)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            f"ERROR:zentral.contrib.santa.views.api:Machine {serial_number}: "
+            f"machine ID {hardware_uuid} already used by machine {self.machine_serial_number}",
+            cm.output
+        )
+        events = list(call_args.args[0] for call_args in post_event.call_args_list)
+        enrollment_event = events[1]
+        self.assertIsInstance(enrollment_event, SantaEnrollmentEvent)
+        self.assertEqual(enrollment_event.payload["action"], "re-enrollment")
+        self.assertEqual(enrollment_event.metadata.machine_serial_number, serial_number)
+        self.assertEqual(len(enrollment_event.metadata.incident_updates), 0)
+
     # rule download
 
     def test_rule_download_not_enrolled(self):

--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -510,6 +510,8 @@ class SantaAPIViewsTestCase(TestCase):
         # the machine rules are deleted, but the client still has its rules during the preflight
         self.configuration.sync_incident_severity = Severity.MAJOR.value
         self.configuration.save()
+        self.enrolled_machine.last_sync_ok = True
+        self.enrolled_machine.save()
         self._add_synced_rule()
         data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
         data["binary_rule_count"] = 1
@@ -546,20 +548,12 @@ class SantaAPIViewsTestCase(TestCase):
         self.assertEqual(len(preflight_event.metadata.incident_updates), 0)
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
-    def test_preflight_sync_ok_conf_with_severity_first_time_no_incident_update(self, post_event):
+    def test_preflight_sync_ok_conf_with_severity_first_time_incident_update_none(self, post_event):
         # setup the sync incidents
         self.configuration.sync_incident_severity = Severity.CRITICAL.value
         self.configuration.save()
         # add one synced rule
-        target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
-        rule = Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.BLOCKLIST)
-        MachineRule.objects.create(
-            enrolled_machine=self.enrolled_machine,
-            target=target,
-            policy=rule.policy,
-            version=rule.version,
-            cursor=None
-        )
+        self._add_synced_rule()
         data, serial_number, hardware_uuid = self._get_preflight_data(enrolled=True)
         data["binary_rule_count"] = 1
         response = self.post_as_json("preflight", hardware_uuid, data)
@@ -572,7 +566,11 @@ class SantaAPIViewsTestCase(TestCase):
         preflight_event = events[-1]
         self.assertIsInstance(preflight_event, SantaPreflightEvent)
         self.assertEqual(preflight_event.metadata.machine_serial_number, self.enrolled_machine.serial_number)
-        self.assertEqual(len(preflight_event.metadata.incident_updates), 0)
+        self.assertEqual(len(preflight_event.metadata.incident_updates), 1)
+        incident_update = preflight_event.metadata.incident_updates[0]
+        self.assertEqual(incident_update.incident_type, "santa_sync")
+        self.assertEqual(incident_update.key, {"santa_cfg_pk": self.configuration.pk})
+        self.assertEqual(incident_update.severity, Severity.NONE)
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_preflight_sync_ok_conf_with_severity_resolution_incident_update_none(self, post_event):

--- a/zentral/contrib/santa/models.py
+++ b/zentral/contrib/santa/models.py
@@ -885,6 +885,10 @@ class EnrolledMachine(models.Model):
                 continue
             synced_count = synced_rules.get(target_type.value, 0)
             reported_count = getattr(self, f"{target_type.value.lower()}_rule_count") or 0
+            if target_type == Target.Type.BINARY:
+                # the client adds the transitive rules to its own database as binary rules,
+                # they are reported in the binary rule count, but they are never synced
+                reported_count -= self.transitive_rule_count or 0
             if synced_count != reported_count:
                 logger.error(
                     "Enrolled machine %s: %s rules synced %s, reported %s",

--- a/zentral/contrib/santa/models.py
+++ b/zentral/contrib/santa/models.py
@@ -658,7 +658,9 @@ class Configuration(models.Model):
         try:
             return Severity(self.sync_incident_severity)
         except ValueError:
-            return
+            logger.error("Configuration %s: unknown sync incident severity %s",
+                         self.pk, self.sync_incident_severity)
+            return Severity.NONE
 
     def get_preflight_client_mode(self):
         if self.client_mode == self.MONITOR_MODE:

--- a/zentral/contrib/santa/public_views.py
+++ b/zentral/contrib/santa/public_views.py
@@ -348,8 +348,10 @@ class PreflightView(BaseSyncView):
             self.request_data.get("request_clean_sync")
             # enrollment
             or self.enrollment_action is not None
-            # all rule count keys are missing
-            or all(k not in self.request_data for k in self._iter_rule_count_keys())
+            # the client reports no rule at all, but some rules were synced with it. It has
+            # probably lost its rule database, and the machine rules have to be rebuilt.
+            or (not any(getattr(self.enrolled_machine, k) for k in self._iter_rule_count_keys())
+                and self.enrolled_machine.machinerule_set.exists())
         )
         if clean_sync:
             MachineRule.objects.filter(enrolled_machine=self.enrolled_machine).delete()

--- a/zentral/contrib/santa/public_views.py
+++ b/zentral/contrib/santa/public_views.py
@@ -327,12 +327,21 @@ class PreflightView(BaseSyncView):
 
     def do_post(self):
         self._commit_machine_snapshot()
+        configuration = self.enrolled_machine.enrollment.configuration
         comparable_santa_version = self.enrolled_machine.get_comparable_santa_version()
 
-        response_dict = self.enrolled_machine.enrollment.configuration.get_sync_server_config(
+        response_dict = configuration.get_sync_server_config(
             self.enrolled_machine.serial_number,
             comparable_santa_version,
         )
+
+        # compare the reported rules with the synced ones before the machine rules are updated.
+        # only necessary for the incidents, and a machine that just enrolled has no synced rule
+        # to be compared with.
+        sync_incident_severity = configuration.get_sync_incident_severity()
+        sync_ok = None
+        if sync_incident_severity != Severity.NONE and self.enrollment_action is None:
+            sync_ok = self.enrolled_machine.sync_ok()
 
         # clean sync?
         clean_sync = (
@@ -356,10 +365,7 @@ class PreflightView(BaseSyncView):
 
         # sync incident update?
         incident_update = None
-        configuration = self.enrolled_machine.enrollment.configuration
-        sync_incident_severity = configuration.get_sync_incident_severity()
-        if sync_incident_severity != Severity.NONE:
-            sync_ok = self.enrolled_machine.sync_ok()
+        if sync_ok is not None:
             last_sync_ok = self.enrolled_machine.last_sync_ok
             if sync_ok != last_sync_ok:
                 if last_sync_ok is not None or not sync_ok:  # no incident update if first time and OK

--- a/zentral/contrib/santa/public_views.py
+++ b/zentral/contrib/santa/public_views.py
@@ -241,13 +241,20 @@ class PreflightView(BaseSyncView):
         for other_enrolled_machine in other_enrolled_machines:
             self.enrollment_action = 're-enrollment'
             if other_enrolled_machine.last_sync_ok is False:
-                # close machine incident
-                incident_updates.append(
-                    SyncIncident.build_incident_update(
-                        other_enrolled_machine.enrollment.configuration,
-                        Severity.NONE
+                if other_enrolled_machine.serial_number == enrolled_machine.serial_number:
+                    # close machine incident
+                    incident_updates.append(
+                        SyncIncident.build_incident_update(
+                            other_enrolled_machine.enrollment.configuration,
+                            Severity.NONE
+                        )
                     )
-                )
+                else:
+                    # the incident updates are applied with the serial number of the enrollment
+                    # event, they would close the incident of a machine that is still out of sync
+                    logger.error("Machine %s: machine ID %s already used by machine %s",
+                                 enrolled_machine.serial_number, self.hardware_uuid,
+                                 other_enrolled_machine.serial_number)
             other_enrolled_machine.delete()
 
         # post event

--- a/zentral/contrib/santa/public_views.py
+++ b/zentral/contrib/santa/public_views.py
@@ -175,16 +175,20 @@ class PreflightView(BaseSyncView):
             'santa_version': self.request_data['santa_version'],
         }
         # cleanup rule counts
+        # santa serializes the preflight request with the protobuf JSON mapping, which drops the
+        # fields set to their default value. A missing key means a null count, not an unknown one.
         for key in self._iter_rule_count_keys():
-            val = self.request_data.get(key)
-            if isinstance(val, int):
-                if val > 2147483648:
-                    logger.error("Machine %s: reported %s %s overflow", serial_number, key, val)
-                    val = 2147483647  # max IntegerField value
-                elif val < 0:
-                    logger.error("Machine %s: reported %s %s negative", serial_number, key, val)
-                    val = 0
-                defaults[key] = val
+            val = self.request_data.get(key, 0)
+            if not isinstance(val, int):
+                logger.error("Machine %s: reported %s %s not an integer", serial_number, key, val)
+                val = 0
+            elif val > 2147483647:
+                logger.error("Machine %s: reported %s %s overflow", serial_number, key, val)
+                val = 2147483647  # max IntegerField value
+            elif val < 0:
+                logger.error("Machine %s: reported %s %s negative", serial_number, key, val)
+                val = 0
+            defaults[key] = val
 
         # client mode
         req_client_mode = self.request_data.get('client_mode')

--- a/zentral/contrib/santa/public_views.py
+++ b/zentral/contrib/santa/public_views.py
@@ -370,12 +370,13 @@ class PreflightView(BaseSyncView):
         if sync_ok is not None:
             last_sync_ok = self.enrolled_machine.last_sync_ok
             if sync_ok != last_sync_ok:
-                if last_sync_ok is not None or not sync_ok:  # no incident update if first time and OK
-                    if sync_ok:
-                        severity = Severity.NONE
-                    else:
-                        severity = sync_incident_severity
-                    incident_update = SyncIncident.build_incident_update(configuration, severity)
+                # an update is sent even the first time. The machine could have been re-enrolled
+                # while an incident was open, and nothing else would ever close it.
+                if sync_ok:
+                    severity = Severity.NONE
+                else:
+                    severity = sync_incident_severity
+                incident_update = SyncIncident.build_incident_update(configuration, severity)
                 self.enrolled_machine.last_sync_ok = sync_ok
                 self.enrolled_machine.save()
 


### PR DESCRIPTION
The Santa sync incidents fire for machines that are perfectly in sync. Most of it comes from the preflight comparing the rules the client reports with the rules Zentral synced, using assumptions that stopped being true when Santa moved its sync protocol to protobuf.

Each commit is independent and can be reviewed on its own.

### The reported rule counts

Santa serializes the preflight request with the protobuf JSON mapping, which omits the fields set to their default value, so a count of 0 is simply not sent. The enrolled machine kept its previous value forever, and a machine whose rules were removed stayed permanently out of sync with an incident that could not be closed. All the counts are now reset when they are missing from the request. The overflow guard is fixed at the same time, it let `2147483648` through and triggered a numeric value out of range error.

### The transitive rules

The client creates the transitive rules itself, and stores them as binary rules, so they are included in the reported binary rule count. They are never synced, and they were not subtracted from the reported count: every machine of a configuration with the transitive rules enabled was reported out of sync as soon as a compiler allowlisted a binary. Santa excludes them from its own rules hash for the same reason.

### The comparison and the clean sync

The comparison was made after the clean sync had deleted all the machine rules, but the client only clears its own rule database during the rule download stage, and still reports its rules during the preflight. Every clean sync therefore opened an incident, closed during the next sync. The comparison is now made first, and skipped for a machine that just enrolled, which has no synced rule to be compared with.

The clean sync trigger had the same root cause as the rule counts: "all the rule count keys are missing" now also matches a client that simply has no rule, and a clean sync was forced during each preflight of those machines. It is now based on the reported counts, and only rebuilds the machine rules if some rules were really synced with the machine.

### The incident updates

No update was sent the first time a machine was found in sync. The enrolled machines are replaced during a re-enrollment though, and the new one starts without a known sync state, so the incident of a machine that was out of sync before its re-enrollment could never be closed.

Finally, the incident updates of the replaced enrolled machines are carried by the enrollment event, and applied with the serial number of the machine that just enrolled. The machine ID reported by santa defaults to the hardware UUID, but it can also be a fixed value from the configuration profile, or read from a plist. When it is not unique, the machines keep replacing each other, and each enrollment was closing an incident still open for another machine.

### Not fixed here

Santa also adds the rules from the `StaticRules` configuration profile key to the counts it reports. Zentral has no way to know about them, so those machines still compare as out of sync.

A clean sync that downloads no rule does not clear the client rule database at all: the rule download stage returns before the cleanup is applied. Zentral has already dropped its machine rules by then. This one needs a fix in the client, and a follow up on the Zentral side to only commit the machine rules once the postflight confirms the sync.
