### PR TITLE
stores: fix the ClickHouse JSON columns deserialization

### DIFF
--- a/tests/core_stores/test_clickhouse.py
+++ b/tests/core_stores/test_clickhouse.py
@@ -7,8 +7,9 @@ from zentral.core.probes.models import ProbeSource
 from zentral.core.probes.probe import Probe
 from zentral.core.stores.backends.all import StoreBackend
 from zentral.core.stores.backends.clickhouse import ClickHouseStore, ClickHouseStoreSerializer
+from zentral.utils.time import naive_utc_fromisoformat
 from .utils import build_login_event, force_store
-from . import BaseTestStore
+from . import BaseTestStore, get_from_dt, make_event
 
 
 class TestClickHouseStoreStorage(TestCase, BaseTestStore):
@@ -37,6 +38,26 @@ class TestClickHouseStoreStorage(TestCase, BaseTestStore):
     def tearDownClass(cls):
         super().tearDownClass()
         cls.store.client.command(f"TRUNCATE DATABASE `{cls.database}`;")
+
+    def test_fetch_machine_events_json_shared_data(self):
+        # a JSON column only keeps max_dynamic_paths paths (1024 by default) as sub columns.
+        # The extra ones are stored in the shared data structure, where the values keep their
+        # binary type encoding.
+        msn = get_random_string(12)
+        event = make_event(msn=msn)
+        for i in range(1100):
+            event.payload[f"path_{i:04d}"] = [f"val_{i}"]
+        status_time = datetime(2026, 7, 31, 14, 24, 25, 877383)
+        event.payload["status_time"] = status_time.isoformat()
+        self.store.store(event)
+        events, _ = self.store.fetch_machine_events(msn, from_dt=get_from_dt())
+        self.assertEqual(len(events), 1)
+        payload = events[0].payload
+        # ClickHouse infers the datetimes, and formats them back when it serializes the column
+        self.assertEqual(naive_utc_fromisoformat(payload.pop("status_time")), status_time)
+        expected_payload = event.payload.copy()
+        expected_payload.pop("status_time")
+        self.assertEqual(payload, expected_payload)
 
     def test_aggregation_not_implemented(self):
         with self.assertRaises(NotImplementedError) as cm:

--- a/zentral/core/stores/backends/clickhouse/__init__.py
+++ b/zentral/core/stores/backends/clickhouse/__init__.py
@@ -126,8 +126,8 @@ class ClickHouseStore(BaseStore):
         )
 
     def _deserialize_event(self, result):
-        event_d = result["payload"]
-        event_d["_zentral"] = result["metadata"]
+        event_d = json.loads(result["payload"])
+        event_d["_zentral"] = json.loads(result["metadata"])
         event_d["_zentral"]["tags"] = result["tags"]
         event_d["_zentral"]["type"] = result["type"]
         event_d["_zentral"]["created_at"] = self._datetime_to_zentral(result["created_at"])
@@ -217,15 +217,26 @@ class ClickHouseStore(BaseStore):
             params["event_type"] = event_type
         wheres = " AND ".join(wheres)
         query_ctx = self.client.create_query_context(
+            # the JSON paths that do not fit in the column max_dynamic_paths budget are stored in the
+            # shared data structure, where the values keep their binary type encoding. clickhouse-connect
+            # reads them as opaque strings instead of decoding them, and returns raw bytes for the types
+            # it does not reconstruct (Date, DateTime64, Array). Serializing the columns server side
+            # sidesteps this.
             query=(
-                f"SELECT metadata, type, tags, created_at, payload FROM `{self.table_name}` WHERE {wheres} "
+                "SELECT toJSONString(metadata) AS metadata, type, tags, created_at, "
+                f"toJSONString(payload) AS payload FROM `{self.table_name}` WHERE {wheres} "
                 "ORDER BY created_at DESC, metadata.id.:String ASC, metadata.index.:Int64 ASC LIMIT {limit:UInt32}"
             ),
             parameters=params,
-            # the top-K dynamic filter mixes up the `type` primary key column with `created_at`
-            # when `type` is pinned by an equality predicate and the rows are read in order,
-            # and fails with CANNOT_PARSE_DATETIME (seen on 26.5.1.882, TODO: link upstream issue)
-            settings={"use_top_k_dynamic_filtering": 0},
+            settings={
+                # the top-K dynamic filter mixes up the `type` primary key column with `created_at`
+                # when `type` is pinned by an equality predicate and the rows are read in order,
+                # and fails with CANNOT_PARSE_DATETIME (seen on 26.5.1.882, TODO: link upstream issue)
+                "use_top_k_dynamic_filtering": 0,
+                # the JSON columns are serialized by ClickHouse, so the datetimes they contain
+                # are formatted by the server. `iso` is the closest to what we store.
+                "date_time_output_format": "iso",
+            },
         )
         events = []
         cursor = None


### PR DESCRIPTION
## Problem

A machine event page could display a payload value as a Python bytes literal:

```
{'pk': 312,
 'previous_status': {'status': 'OPEN',
                     'status_time': b'\x13\tX\x87I\xa9\xf1e\xc7\x18'},
 'status': 'CLOSED',
 'status_time': datetime.datetime(2026, 8, 3, 13, 56, 8, 367606),
 'type': 'munki_install_failed'}
```

The value is not corrupted. It is a ClickHouse binary encoded value: `0x13` is the
`DateTime64(P)` type tag, `0x09` the precision, and the last 8 bytes a little endian
tick count — here `2026-07-31 14:24:25.877383`.

## Cause

`metadata` and `payload` are `JSON` columns. That type only keeps `max_dynamic_paths`
paths (1024 by default) as sub columns; the extra ones go to the shared data structure,
where the values keep their binary type encoding. `clickhouse-connect` reads those as
opaque strings rather than decoding the embedded type tag, and hands back raw bytes for
the types it does not reconstruct. String, Int, Float and Bool survive — `Date`,
`DateTime64` and `Array` do not.

Since every event type shares the same `payload` column, the path budget is largely
exceeded, and which paths keep a sub column is decided by how often they are non null.
That is what makes the symptom look arbitrary: in the payload above, `status_time` is
set on every event of the type and decodes fine, while `previous_status.status_time` is
only set when a status actually changes, loses its sub column, and comes back as bytes —
right next to `previous_status.status`, which is a String and is unaffected.

## Fix

Let ClickHouse serialize both columns with `toJSONString()` and parse them back, instead
of having the client rebuild them from the sub columns. The datetimes ClickHouse infers
are then formatted by the server, hence the `iso` `date_time_output_format`.

## Tests

`tests.core_stores` passes (266 tests). The new
`test_fetch_machine_events_json_shared_data` stores an event whose payload exceeds the
path budget and checks the round trip; it fails on the unpatched backend.
