### PR TITLE
mdm: attribute a DEP device synchronization to the user who asked for it

### DIFF
--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -6,7 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
@@ -89,6 +90,37 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(sorted(response.json().keys()), ['task_id', 'task_result_url'])
         result = response.json()
         self.assertEqual(result['task_result_url'], reverse("base_api:task_result", args=(result['task_id'],)))
+
+    @patch("zentral.contrib.mdm.api_views.dep.sync_dep_virtual_server_devices_task.apply_async")
+    def test_user_dep_virtual_server_sync_devices_task_kwargs(self, apply_async):
+        apply_async.return_value.id = uuid.uuid4()
+        dep_server = force_dep_virtual_server()
+        self.login("mdm.view_depvirtualserver")
+        response = self.client.post(reverse("mdm_api:dep_virtual_server_sync_devices", args=(dep_server.pk,)),
+                                    query_params={'full_sync': 'True'})
+        self.assertEqual(response.status_code, 201)
+        args, task_kwargs = apply_async.call_args.args
+        self.assertEqual(args, (dep_server.pk,))
+        # the task kwargs, not the apply_async options: force_full_sync has to reach the task
+        self.assertEqual(task_kwargs, {"force_full_sync": True, "task_user": self.user.pk})
+
+    @patch("zentral.contrib.mdm.api_views.dep.sync_dep_virtual_server_devices_task.apply_async")
+    def test_sa_dep_virtual_server_sync_devices_delta_task_kwargs(self, apply_async):
+        apply_async.return_value.id = uuid.uuid4()
+        dep_server = force_dep_virtual_server()
+        self.set_permissions("mdm.view_depvirtualserver")
+        response = self.post(reverse("mdm_api:dep_virtual_server_sync_devices", args=(dep_server.pk,)))
+        self.assertEqual(response.status_code, 201)
+        _, task_kwargs = apply_async.call_args.args
+        self.assertEqual(task_kwargs, {"force_full_sync": False, "task_user": self.service_account.pk})
+
+    def test_user_dep_virtual_server_sync_devices_creates_user_task(self):
+        dep_server = force_dep_virtual_server()
+        self.login("mdm.view_depvirtualserver")
+        response = self.client.post(reverse("mdm_api:dep_virtual_server_sync_devices", args=(dep_server.pk,)))
+        self.assertEqual(response.status_code, 201)
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     def test_user_dep_virtual_server_sync_devices_full(self):
         dep_server = force_dep_virtual_server()

--- a/zentral/contrib/mdm/api_views/dep.py
+++ b/zentral/contrib/mdm/api_views/dep.py
@@ -38,7 +38,9 @@ class DEPVirtualServerSyncDevicesView(GenericAPIView):
         if isinstance(qp, str):
             full_sync = qp.lower() in ('', 'yes', 'y', 't', 'true')
         task = sync_dep_virtual_server_devices_task.apply_async(
-            (server.pk,), force_full_sync=full_sync
+            (server.pk,),
+            {"force_full_sync": full_sync,
+             "task_user": request.user.id}
         )
         serializer = self.serializer_class.from_task(task=task)
         return Response(

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -14,7 +14,8 @@ logger = logging.getLogger("zentral.contrib.mdm.tasks")
 
 
 @shared_task
-def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=False):
+def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=False, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     server = DEPVirtualServer.objects.get(pk=dep_virtual_server_pk)
     result = {"dep_virtual_server": {"pk": server.pk,
                                      "name": server.name},


### PR DESCRIPTION
Two small fixes in the same call, split out of #1581 so the bug fixes land separately from the new events.

## The task was not linked to a user

The task list had nothing to show in its user column for a DEP synchronization. Zentral creates the `UserTask` from the `before_task_publish` signal in `server/server/celery.py`, but only when the task kwargs carry `task_user` — and `DEPVirtualServerSyncDevicesView` never passed it. There was no row to render, so the column was structurally always empty.

It is passed now, the way `sync_repository_task` already does it for the monolith repository sync. A synchronization somebody triggered can be told apart from one Zentral ran on its own.

## `?full_sync` has never worked

Passing `task_user` exposed a bug in the same call:

```python
apply_async((server.pk,), force_full_sync=full_sync)
```

`Task.apply_async` is `(args=None, kwargs=None, task_id=None, producer=None, link=None, link_error=None, shadow=None, **options)`, so `force_full_sync` landed in `**options` — delivery settings such as `countdown` or `queue` — and never reached the task, which always ran with its default `False`.

**The `full_sync` query parameter has therefore never forced a full synchronization**, neither from the HTTP API nor from the *Synchronize* button. The existing test only checked that the response carried a `task_id`, so nothing caught it.

Both values are now passed in the kwargs dict `apply_async` expects, and the task takes `**kwargs` to absorb `task_user`, mirroring the monolith task.

## Tests

Three tests, each of which fails without the fix:

- the task kwargs a full synchronization is published with, asserted as a whole so an option cannot quietly replace a kwarg again
- the same for a delta synchronization triggered by a service account
- the `UserTask` really being created, and pointing at the right user

`tests.mdm`, `tests.server_accounts` and `tests.server_base` are green (3120 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
