### PR TITLE
tasks: attribute the remaining background tasks to the user who started them

### DIFF
--- a/ee/zentral/contrib/intune/api_views.py
+++ b/ee/zentral/contrib/intune/api_views.py
@@ -38,7 +38,9 @@ class StartTenantSync(APIView):
 
     def post(self, request, *args, **kwargs):
         tenant = get_object_or_404(Tenant, tenant_id=self.kwargs["tenant_id"])
-        result = sync_inventory.apply_async(kwargs={'tenant_id': tenant.tenant_id})
+        result = sync_inventory.apply_async(
+            kwargs={'tenant_id': tenant.tenant_id, 'task_user': request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/ee/zentral/contrib/intune/tasks.py
+++ b/ee/zentral/contrib/intune/tasks.py
@@ -49,7 +49,8 @@ def do_sync_inventory(client):
 
 
 @shared_task
-def sync_inventory(tenant_id):
+def sync_inventory(tenant_id, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     tenant = Tenant.objects.get(tenant_id=tenant_id)
     client = Client.from_instance(tenant)
     return do_sync_inventory(client)

--- a/ee/zentral/contrib/wsone/api_views.py
+++ b/ee/zentral/contrib/wsone/api_views.py
@@ -38,7 +38,10 @@ class StartInstanceSync(APIView):
     def post(self, request, *args, **kwargs):
         instance = get_object_or_404(Instance, pk=self.kwargs["pk"])
         event_request = EventRequest.build_from_request(request)
-        result = sync_inventory.apply_async((instance.pk, event_request.serialize()))
+        result = sync_inventory.apply_async(
+            (instance.pk, event_request.serialize()),
+            {"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/ee/zentral/contrib/wsone/tasks.py
+++ b/ee/zentral/contrib/wsone/tasks.py
@@ -52,7 +52,8 @@ def do_sync_inventory(instance, client, serialized_event_request=None):
 
 
 @shared_task
-def sync_inventory(instance_pk, serialized_event_request):
+def sync_inventory(instance_pk, serialized_event_request, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     instance = Instance.objects.get(pk=instance_pk)
     client = Client.from_instance(instance)
     return do_sync_inventory(instance, client, serialized_event_request)

--- a/tests/google_workspace/test_api_views.py
+++ b/tests/google_workspace/test_api_views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group
 from django.utils.crypto import get_random_string
 from googleapiclient.errors import HttpError
 
-from accounts.models import User, APIToken
+from accounts.models import User, APIToken, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.google_workspace.models import Connection, GroupTagMapping
@@ -164,6 +164,15 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.client.post(reverse("google_workspace_api:sync_tags", args=(connection.pk,)))
         self.assertEqual(response.status_code, 201)
         self.assertEqual(sorted(response.json().keys()), ['task_id', 'task_result_url'])
+
+    def test_user_group_tag_mappings_task_creates_user_task(self):
+        connection = self._given_connection()
+        self.login("google_workspace.view_connection")
+        response = self.client.post(reverse("google_workspace_api:sync_tags", args=(connection.pk,)))
+        self.assertEqual(response.status_code, 201)
+        # without it the sync is invisible to a user who is not a superuser
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     # ConnectionList
 

--- a/tests/intune/test_api_views.py
+++ b/tests/intune/test_api_views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.test import TestCase
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
@@ -150,6 +150,15 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("intune.view_tenant", "inventory.change_machinesnapshot")
         response = self.post(reverse("intune_api:start_tenant_sync", args=(tenant.tenant_id,)))
         self.assertEqual(response.status_code, 201)
+
+    def test_start_sync_creates_user_task(self):
+        tenant = force_tenant(self.bu)
+        self.set_permissions("intune.view_tenant", "inventory.change_machinesnapshot")
+        response = self.post(reverse("intune_api:start_tenant_sync", args=(tenant.tenant_id,)))
+        self.assertEqual(response.status_code, 201)
+        # the endpoint is token only, so the task belongs to the service account
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.service_account)
 
     # create tenant
 

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -405,6 +405,14 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.assertIn("task_id", response.data)
         self.assertIn("task_result_url", response.data)
 
+    def test_full_export_creates_user_task(self):
+        self.set_permissions("inventory.view_machinesnapshot")
+        response = self.post(reverse('inventory_api:full_export'))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # the export produces a file, and its download button lives on the task page
+        user_task = UserTask.objects.get(task_result__task_id=response.data["task_id"])
+        self.assertEqual(user_task.user, self.user)
+
     # create meta business unit
 
     def test_create_meta_business_unit_unauthorized(self):

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from rest_framework import status
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import (CurrentMachineSnapshot, MachineSnapshot,
@@ -384,6 +384,13 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn("task_id", response.data)
         self.assertIn("task_result_url", response.data)
+
+    def test_cleanup_creates_user_task(self):
+        self.set_permissions("inventory.delete_machinesnapshot")
+        response = self.post(reverse('inventory_api:cleanup'), {"days": 70})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        user_task = UserTask.objects.get(task_result__task_id=response.data["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     # full export
 

--- a/tests/mdm/test_api_software_updates_views.py
+++ b/tests/mdm/test_api_software_updates_views.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.test import TestCase
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 
@@ -58,6 +58,18 @@ class SoftwareUpdatesAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.post(reverse("mdm_api:sync_software_updates"))
         self.assertEqual(response.status_code, 201)
         self.assertEqual(sorted(response.json().keys()), ['task_id', 'task_result_url'])
+
+    def test_sa_sync_software_updates_creates_user_task(self):
+        self.set_permissions(
+            "mdm.add_softwareupdate",
+            "mdm.change_softwareupdate",
+            "mdm.delete_softwareupdate",
+        )
+        response = self.post(reverse("mdm_api:sync_software_updates"))
+        self.assertEqual(response.status_code, 201)
+        # the endpoint is token only, so the task belongs to the service account
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.service_account)
 
     def test_user_sync_software_updates_unauthorized(self):
         response = self.client.post(reverse("mdm_api:sync_software_updates"))

--- a/tests/mdm/test_management_asset.py
+++ b/tests/mdm/test_management_asset.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
-from accounts.models import User
+from accounts.models import User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.mdm.models import (Artifact, ArtifactVersion, Asset,
                                         Channel, Location, LocationAsset, Platform, StoreApp)
@@ -251,6 +251,8 @@ class AssetManagementViewsTestCase(TestCase, LoginCase):
         self.assertEqual(task_qs.count(), 1)
         tr = task_qs.first()
         self.assertEqual(tr.task_args, f'"({location_asset.pk}, [{dep_virtual_server.pk}])"')
+        # without it the task is invisible to a user who is not a superuser
+        self.assertEqual(UserTask.objects.get(task_result=tr).user, self.user)
 
     # create_asset_artifact
 

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
@@ -2450,6 +2450,15 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.login("osquery.view_distributedqueryresult")
         response = self.client.post(reverse("osquery_api:export_distributed_query_results", args=(dq.pk,)))
         self.assertEqual(response.status_code, 201)
+
+    def test_export_distributed_query_results_creates_user_task(self):
+        dq = self._force_distributed_query()
+        self.login("osquery.view_distributedqueryresult")
+        response = self.client.post(reverse("osquery_api:export_distributed_query_results", args=(dq.pk,)))
+        self.assertEqual(response.status_code, 201)
+        # without it the export is invisible to a user who is not a superuser, download included
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     def test_export_distributed_query_results_unknown_format(self):
         dq = self._force_distributed_query()

--- a/tests/santa/test_api_views.py
+++ b/tests/santa/test_api_views.py
@@ -6,7 +6,7 @@ from django.utils.crypto import get_random_string
 from rest_framework import status
 import yaml
 
-from accounts.models import User, APIToken
+from accounts.models import User, APIToken, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.conf import settings
@@ -730,6 +730,14 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn("task_id", response.data)
         self.assertIn("task_result_url", response.data)
+
+    def test_targets_export_creates_user_task(self):
+        self.login("santa.view_target")
+        response = self.client.post(reverse("santa_api:targets_export") + "?export_format=xlsx")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # without it the export is invisible to a user who is not a superuser, download included
+        user_task = UserTask.objects.get(task_result__task_id=response.data["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     def test_team_id_targets_export(self):
         self.set_permissions("santa.view_target")

--- a/tests/wsone/test_api_views.py
+++ b/tests/wsone/test_api_views.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.test import TestCase
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
@@ -156,3 +156,12 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("wsone.view_instance", "inventory.change_machinesnapshot")
         response = self.post(reverse("wsone_api:start_instance_sync", args=(instance.pk,)))
         self.assertEqual(response.status_code, 201)
+
+    def test_start_sync_creates_user_task(self):
+        instance = self.force_instance()
+        self.set_permissions("wsone.view_instance", "inventory.change_machinesnapshot")
+        response = self.post(reverse("wsone_api:start_instance_sync", args=(instance.pk,)))
+        self.assertEqual(response.status_code, 201)
+        # the endpoint is token only, so the task belongs to the service account
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.service_account)

--- a/zentral/contrib/google_workspace/api_views.py
+++ b/zentral/contrib/google_workspace/api_views.py
@@ -31,7 +31,10 @@ class SyncTagsView(APIView):
     def post(self, request, *args, **kwargs):
         connection = get_object_or_404(Connection, pk=kwargs["conn_pk"])
         event_request = EventRequest.build_from_request(self.request)
-        result = sync_group_tag_mappings_task.apply_async((connection.pk, event_request.serialize()))
+        result = sync_group_tag_mappings_task.apply_async(
+            (connection.pk, event_request.serialize()),
+            {"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/google_workspace/tasks.py
+++ b/zentral/contrib/google_workspace/tasks.py
@@ -13,8 +13,10 @@ logger = logging.getLogger('zentral.contrib.google_workspace.tasks')
 @shared_task
 def sync_group_tag_mappings_task(
         connection_pk: uuid,
-        serialized_event_request: str = None
+        serialized_event_request: str = None,
+        **kwargs
         ) -> dict[str, dict[str, str]]:
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     try:
         connection = Connection.objects.get(pk=connection_pk)
     except Connection.DoesNotExist:

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -381,7 +381,10 @@ class CleanupInventory(APIView):
         serializer = CleanupInventorySerializer(data=request.data)
         if serializer.is_valid():
             event_request = EventRequest.build_from_request(request)
-            result = cleanup_inventory.apply_async((serializer.data["days"], event_request.serialize(),))
+            result = cleanup_inventory.apply_async(
+                (serializer.data["days"], event_request.serialize(),),
+                {"task_user": request.user.id}
+            )
             return Response({"task_id": result.id,
                              "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                             status=status.HTTP_201_CREATED)

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -400,7 +400,9 @@ class FullExport(APIView):
     permission_classes = [DjangoPermissionRequired]
 
     def post(self, request, *args, **kwargs):
-        result = export_full_inventory.apply_async()
+        result = export_full_inventory.apply_async(
+            kwargs={"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/inventory/tasks.py
+++ b/zentral/contrib/inventory/tasks.py
@@ -41,7 +41,8 @@ def cleanup_inventory(days, serialized_event_request, **kwargs):
 
 
 @shared_task
-def export_full_inventory():
+def export_full_inventory(**kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     return do_full_export()
 
 

--- a/zentral/contrib/inventory/tasks.py
+++ b/zentral/contrib/inventory/tasks.py
@@ -22,7 +22,8 @@ from .utils import (MSQuery,
 
 
 @shared_task
-def cleanup_inventory(days, serialized_event_request):
+def cleanup_inventory(days, serialized_event_request, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     max_date = get_cleanup_max_date(days)
     payload = {"days": days, "max_date": max_date}
     post_cleanup_started_event(payload.copy(), serialized_event_request)

--- a/zentral/contrib/mdm/api_views/software_updates.py
+++ b/zentral/contrib/mdm/api_views/software_updates.py
@@ -15,7 +15,9 @@ class SyncSoftwareUpdatesView(APIView):
     permission_classes = [DjangoPermissionRequired]
 
     def post(self, request, *args, **kwargs):
-        result = sync_software_updates_task.apply_async()
+        result = sync_software_updates_task.apply_async(
+            kwargs={"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -64,7 +64,8 @@ def sync_software_updates_task(**kwargs):
 
 
 @shared_task
-def bulk_assign_location_asset_task(location_asset_pk, dep_virtual_server_pks):
+def bulk_assign_location_asset_task(location_asset_pk, dep_virtual_server_pks, **kwargs):
+    # kwargs absorbs task_user, added by the view for the UserTask created in the celery signal
     location_asset = LocationAsset.objects.select_related("location", "asset").get(pk=location_asset_pk)
     dep_virtual_servers = DEPVirtualServer.objects.filter(pk__in=dep_virtual_server_pks)
     return {

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -55,7 +55,8 @@ def define_dep_profile_task(dep_enrollment_pk):
 
 
 @shared_task
-def sync_software_updates_task():
+def sync_software_updates_task(**kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     return sync_software_updates()
 
 

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -1050,7 +1050,8 @@ class AssociateLocationAssetView(PermissionRequiredMixin, FormView):
 
     def form_valid(self, form):
         bulk_assign_location_asset_task.apply_async(
-            (self.location_asset.pk, [vs.pk for vs in form.cleaned_data["dep_virtual_servers"]])
+            (self.location_asset.pk, [vs.pk for vs in form.cleaned_data["dep_virtual_servers"]]),
+            {"task_user": self.request.user.id}
         )
         messages.info(self.request, "Location asset license association task launched.")
         return redirect(self.location_asset)

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -239,7 +239,10 @@ class ExportDistributedQueryResults(APIView):
         export_format = request.GET.get("export_format", "csv")
         if export_format not in ("csv", "ndjson", "xlsx"):
             raise ValidationError({"export_format": "Must be csv, ndjson or xlsx"})
-        result = export_distributed_query_results.apply_async((int(kwargs["pk"]), f".{export_format}"))
+        result = export_distributed_query_results.apply_async(
+            (int(kwargs["pk"]), f".{export_format}"),
+            {"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/osquery/tasks.py
+++ b/zentral/contrib/osquery/tasks.py
@@ -155,6 +155,7 @@ def _export_distributed_query_results(distributed_query, extension):
 
 
 @shared_task
-def export_distributed_query_results(distributed_query_pk, extension):
+def export_distributed_query_results(distributed_query_pk, extension, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     distributed_query = DistributedQuery.objects.get(pk=distributed_query_pk)
     return _export_distributed_query_results(distributed_query, extension)

--- a/zentral/contrib/santa/api_views.py
+++ b/zentral/contrib/santa/api_views.py
@@ -403,7 +403,10 @@ class TargetsExport(APIView):
         if export_format not in ("xlsx", "zip"):
             raise ValidationError("Unknown export format")
         filename = f"santa_targets_export_{timezone.now():%Y-%m-%d_%H-%M-%S}.{export_format}"
-        result = export_targets.apply_async((search_kwargs, export_format, filename))
+        result = export_targets.apply_async(
+            (search_kwargs, export_format, filename),
+            {"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/santa/tasks.py
+++ b/zentral/contrib/santa/tasks.py
@@ -133,5 +133,6 @@ def _export_targets(search_kwargs, export_format, filename):
 
 
 @shared_task
-def export_targets(search_kwargs, export_format, filename):
+def export_targets(search_kwargs, export_format, filename, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     return _export_targets(search_kwargs, export_format, filename)


### PR DESCRIPTION
Nine tasks a user or a service account can start were not linked to whoever started them. 

## Why it matters

`TaskViewMixin.get_queryset()` in `server/accounts/views/tasks.py` filters the task list for everybody who is not a superuser:

```python
if not self.request.user.is_superuser:
    queryset = queryset.filter(usertask__user=self.request.user)
```

`TaskView.get_object()` uses the same queryset, so a task with no `UserTask` row does not merely show an empty user column — it does not appear in the list at all, and its detail page 404s. The download button for a finished export lives on that page (`server/templates/accounts/tasks/_result.html`).

Zentral creates the `UserTask` from the `before_task_publish` signal in `server/server/celery.py`, but only when the published task kwargs carry `task_user`. None of these nine launches passed it.

## What changed

One commit per launch. Each passes `{"task_user": request.user.id}` as the task kwargs and takes `**kwargs` on the task so the extra kwarg does not raise, following what the inventory exports and the monolith repository sync already do. No task reads the value: it is consumed at publish time by the signal receiver.

### Exports that were unreachable

Both are permission-gated — `osquery.view_distributedqueryresult` and `santa.view_target` — so a user without the superuser flag could click *Export*, get a `201` with a task id, and never be able to reach the file.

| Task | Module |
| --- | --- |
| `export_distributed_query_results` | osquery |
| `export_targets` | santa |

### Tasks started from a button, invisible to the user who started them

| Task | Note |
| --- | --- |
| `sync_group_tag_mappings_task` | Google Workspace group tag mappings sync. It already passed the serialized event request, so it was attributable in the event store but not in the task list |
| `bulk_assign_location_asset_task` | MDM bulk location asset assignment. The view redirects with a *"task launched"* message, so the task list is the only place to follow it |

### API-token-only launches

Nothing is broken here — there is no button pointing a user at a task they cannot see. This is consistency, and it makes an API-driven cleanup or export attributable to the integration that triggered it. On these endpoints the task belongs to the **service account** that called them, which the tests assert explicitly.

| Task | Module | Note |
| --- | --- | --- |
| `cleanup_inventory` | inventory | already passed the event request |
| `export_full_inventory` | inventory | produces a file; the other inventory exports already pass `task_user` |
| `sync_software_updates_task` | mdm | |
| `sync_inventory` | intune (`ee/`) | |
| `sync_inventory` | wsone (`ee/`) | already passed the event request |

The two `ee/` changes are edited in place. No code moved between the licence trees.

## Tests

One test per launch, asserting the `UserTask` exists and points at the right user. Each was checked to fail without its fix (`accounts.models.UserTask.DoesNotExist`).

For the MDM bulk assignment the assertion was added to the existing `test_associate_location_asset_post`, which already sets up the POST and inspects the `TaskResult`, rather than duplicating the setup.


🤖 Generated with [Claude Code](https://claude.com/claude-code)