### PR TITLE
tasks: attribute the Google Workspace tag sync and the bulk location asset assignment to their user

### DIFF
--- a/tests/google_workspace/test_api_views.py
+++ b/tests/google_workspace/test_api_views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group
 from django.utils.crypto import get_random_string
 from googleapiclient.errors import HttpError
 
-from accounts.models import User, APIToken
+from accounts.models import User, APIToken, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.google_workspace.models import Connection, GroupTagMapping
@@ -164,6 +164,15 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.client.post(reverse("google_workspace_api:sync_tags", args=(connection.pk,)))
         self.assertEqual(response.status_code, 201)
         self.assertEqual(sorted(response.json().keys()), ['task_id', 'task_result_url'])
+
+    def test_user_group_tag_mappings_task_creates_user_task(self):
+        connection = self._given_connection()
+        self.login("google_workspace.view_connection")
+        response = self.client.post(reverse("google_workspace_api:sync_tags", args=(connection.pk,)))
+        self.assertEqual(response.status_code, 201)
+        # without it the sync is invisible to a user who is not a superuser
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     # ConnectionList
 

--- a/tests/mdm/test_management_asset.py
+++ b/tests/mdm/test_management_asset.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
-from accounts.models import User
+from accounts.models import User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.mdm.models import (Artifact, ArtifactVersion, Asset,
                                         Channel, Location, LocationAsset, Platform, StoreApp)
@@ -251,6 +251,8 @@ class AssetManagementViewsTestCase(TestCase, LoginCase):
         self.assertEqual(task_qs.count(), 1)
         tr = task_qs.first()
         self.assertEqual(tr.task_args, f'"({location_asset.pk}, [{dep_virtual_server.pk}])"')
+        # without it the task is invisible to a user who is not a superuser
+        self.assertEqual(UserTask.objects.get(task_result=tr).user, self.user)
 
     # create_asset_artifact
 

--- a/zentral/contrib/google_workspace/api_views.py
+++ b/zentral/contrib/google_workspace/api_views.py
@@ -31,7 +31,10 @@ class SyncTagsView(APIView):
     def post(self, request, *args, **kwargs):
         connection = get_object_or_404(Connection, pk=kwargs["conn_pk"])
         event_request = EventRequest.build_from_request(self.request)
-        result = sync_group_tag_mappings_task.apply_async((connection.pk, event_request.serialize()))
+        result = sync_group_tag_mappings_task.apply_async(
+            (connection.pk, event_request.serialize()),
+            {"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/google_workspace/tasks.py
+++ b/zentral/contrib/google_workspace/tasks.py
@@ -13,8 +13,10 @@ logger = logging.getLogger('zentral.contrib.google_workspace.tasks')
 @shared_task
 def sync_group_tag_mappings_task(
         connection_pk: uuid,
-        serialized_event_request: str = None
+        serialized_event_request: str = None,
+        **kwargs
         ) -> dict[str, dict[str, str]]:
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     try:
         connection = Connection.objects.get(pk=connection_pk)
     except Connection.DoesNotExist:

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -63,7 +63,8 @@ def sync_software_updates_task():
 
 
 @shared_task
-def bulk_assign_location_asset_task(location_asset_pk, dep_virtual_server_pks):
+def bulk_assign_location_asset_task(location_asset_pk, dep_virtual_server_pks, **kwargs):
+    # kwargs absorbs task_user, added by the view for the UserTask created in the celery signal
     location_asset = LocationAsset.objects.select_related("location", "asset").get(pk=location_asset_pk)
     dep_virtual_servers = DEPVirtualServer.objects.filter(pk__in=dep_virtual_server_pks)
     return {

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -1050,7 +1050,8 @@ class AssociateLocationAssetView(PermissionRequiredMixin, FormView):
 
     def form_valid(self, form):
         bulk_assign_location_asset_task.apply_async(
-            (self.location_asset.pk, [vs.pk for vs in form.cleaned_data["dep_virtual_servers"]])
+            (self.location_asset.pk, [vs.pk for vs in form.cleaned_data["dep_virtual_servers"]]),
+            {"task_user": self.request.user.id}
         )
         messages.info(self.request, "Location asset license association task launched.")
         return redirect(self.location_asset)


### PR DESCRIPTION
Two more tasks a user starts from the web interface that were not attributed to anybody.

## Why it matters

`TaskViewMixin.get_queryset()` in `server/accounts/views/tasks.py` filters the task list for everybody who is not a superuser:

```python
if not self.request.user.is_superuser:
    queryset = queryset.filter(usertask__user=self.request.user)
```

Zentral creates the `UserTask` from the `before_task_publish` signal in `server/server/celery.py`, but only when the published task kwargs carry `task_user`. Without it the task belongs to nobody and never appears in the list of the user who started it.

## What changed

One commit per case, each passing `{"task_user": request.user.id}` as the task kwargs and taking `**kwargs` on the task so the extra kwarg does not raise.

**Google Workspace group tag mappings sync** — started from a button on the connection page. It already passed the serialized event request, so the sync was attributable in the event store but not in the task list.

**MDM bulk location asset assignment** — the view redirects with a *"Location asset license association task launched."* message, so the task list is the only place to follow it. The message pointed at something a non-superuser could not see.

Neither task reads the value: it is consumed at publish time by the signal receiver. No behaviour change for superusers, and none for the tasks themselves.

## Tests

The Google Workspace case gets a new test. For the MDM one the existing `test_associate_location_asset_post` already inspects the `TaskResult`, so the assertion is added there rather than duplicating the setup. I checked both fail without their fix (`accounts.models.UserTask.DoesNotExist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)