### PR TITLE
tasks: attribute the remaining API-triggered tasks to the user who asked for them

### DIFF
--- a/ee/zentral/contrib/intune/api_views.py
+++ b/ee/zentral/contrib/intune/api_views.py
@@ -38,7 +38,9 @@ class StartTenantSync(APIView):
 
     def post(self, request, *args, **kwargs):
         tenant = get_object_or_404(Tenant, tenant_id=self.kwargs["tenant_id"])
-        result = sync_inventory.apply_async(kwargs={'tenant_id': tenant.tenant_id})
+        result = sync_inventory.apply_async(
+            kwargs={'tenant_id': tenant.tenant_id, 'task_user': request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/ee/zentral/contrib/intune/tasks.py
+++ b/ee/zentral/contrib/intune/tasks.py
@@ -49,7 +49,8 @@ def do_sync_inventory(client):
 
 
 @shared_task
-def sync_inventory(tenant_id):
+def sync_inventory(tenant_id, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     tenant = Tenant.objects.get(tenant_id=tenant_id)
     client = Client.from_instance(tenant)
     return do_sync_inventory(client)

--- a/ee/zentral/contrib/wsone/api_views.py
+++ b/ee/zentral/contrib/wsone/api_views.py
@@ -38,7 +38,10 @@ class StartInstanceSync(APIView):
     def post(self, request, *args, **kwargs):
         instance = get_object_or_404(Instance, pk=self.kwargs["pk"])
         event_request = EventRequest.build_from_request(request)
-        result = sync_inventory.apply_async((instance.pk, event_request.serialize()))
+        result = sync_inventory.apply_async(
+            (instance.pk, event_request.serialize()),
+            {"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/ee/zentral/contrib/wsone/tasks.py
+++ b/ee/zentral/contrib/wsone/tasks.py
@@ -52,7 +52,8 @@ def do_sync_inventory(instance, client, serialized_event_request=None):
 
 
 @shared_task
-def sync_inventory(instance_pk, serialized_event_request):
+def sync_inventory(instance_pk, serialized_event_request, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     instance = Instance.objects.get(pk=instance_pk)
     client = Client.from_instance(instance)
     return do_sync_inventory(instance, client, serialized_event_request)

--- a/tests/intune/test_api_views.py
+++ b/tests/intune/test_api_views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.test import TestCase
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
@@ -150,6 +150,15 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("intune.view_tenant", "inventory.change_machinesnapshot")
         response = self.post(reverse("intune_api:start_tenant_sync", args=(tenant.tenant_id,)))
         self.assertEqual(response.status_code, 201)
+
+    def test_start_sync_creates_user_task(self):
+        tenant = force_tenant(self.bu)
+        self.set_permissions("intune.view_tenant", "inventory.change_machinesnapshot")
+        response = self.post(reverse("intune_api:start_tenant_sync", args=(tenant.tenant_id,)))
+        self.assertEqual(response.status_code, 201)
+        # the endpoint is token only, so the task belongs to the service account
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.service_account)
 
     # create tenant
 

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -405,6 +405,14 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.assertIn("task_id", response.data)
         self.assertIn("task_result_url", response.data)
 
+    def test_full_export_creates_user_task(self):
+        self.set_permissions("inventory.view_machinesnapshot")
+        response = self.post(reverse('inventory_api:full_export'))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # the export produces a file, and its download button lives on the task page
+        user_task = UserTask.objects.get(task_result__task_id=response.data["task_id"])
+        self.assertEqual(user_task.user, self.user)
+
     # create meta business unit
 
     def test_create_meta_business_unit_unauthorized(self):

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from rest_framework import status
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import (CurrentMachineSnapshot, MachineSnapshot,
@@ -384,6 +384,13 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn("task_id", response.data)
         self.assertIn("task_result_url", response.data)
+
+    def test_cleanup_creates_user_task(self):
+        self.set_permissions("inventory.delete_machinesnapshot")
+        response = self.post(reverse('inventory_api:cleanup'), {"days": 70})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        user_task = UserTask.objects.get(task_result__task_id=response.data["task_id"])
+        self.assertEqual(user_task.user, self.user)
 
     # full export
 

--- a/tests/mdm/test_api_software_updates_views.py
+++ b/tests/mdm/test_api_software_updates_views.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.test import TestCase
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 
@@ -58,6 +58,18 @@ class SoftwareUpdatesAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.post(reverse("mdm_api:sync_software_updates"))
         self.assertEqual(response.status_code, 201)
         self.assertEqual(sorted(response.json().keys()), ['task_id', 'task_result_url'])
+
+    def test_sa_sync_software_updates_creates_user_task(self):
+        self.set_permissions(
+            "mdm.add_softwareupdate",
+            "mdm.change_softwareupdate",
+            "mdm.delete_softwareupdate",
+        )
+        response = self.post(reverse("mdm_api:sync_software_updates"))
+        self.assertEqual(response.status_code, 201)
+        # the endpoint is token only, so the task belongs to the service account
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.service_account)
 
     def test_user_sync_software_updates_unauthorized(self):
         response = self.client.post(reverse("mdm_api:sync_software_updates"))

--- a/tests/wsone/test_api_views.py
+++ b/tests/wsone/test_api_views.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.test import TestCase
 
-from accounts.models import APIToken, User
+from accounts.models import APIToken, User, UserTask
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
@@ -156,3 +156,12 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("wsone.view_instance", "inventory.change_machinesnapshot")
         response = self.post(reverse("wsone_api:start_instance_sync", args=(instance.pk,)))
         self.assertEqual(response.status_code, 201)
+
+    def test_start_sync_creates_user_task(self):
+        instance = self.force_instance()
+        self.set_permissions("wsone.view_instance", "inventory.change_machinesnapshot")
+        response = self.post(reverse("wsone_api:start_instance_sync", args=(instance.pk,)))
+        self.assertEqual(response.status_code, 201)
+        # the endpoint is token only, so the task belongs to the service account
+        user_task = UserTask.objects.get(task_result__task_id=response.json()["task_id"])
+        self.assertEqual(user_task.user, self.service_account)

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -381,7 +381,10 @@ class CleanupInventory(APIView):
         serializer = CleanupInventorySerializer(data=request.data)
         if serializer.is_valid():
             event_request = EventRequest.build_from_request(request)
-            result = cleanup_inventory.apply_async((serializer.data["days"], event_request.serialize(),))
+            result = cleanup_inventory.apply_async(
+                (serializer.data["days"], event_request.serialize(),),
+                {"task_user": request.user.id}
+            )
             return Response({"task_id": result.id,
                              "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                             status=status.HTTP_201_CREATED)

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -400,7 +400,9 @@ class FullExport(APIView):
     permission_classes = [DjangoPermissionRequired]
 
     def post(self, request, *args, **kwargs):
-        result = export_full_inventory.apply_async()
+        result = export_full_inventory.apply_async(
+            kwargs={"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/inventory/tasks.py
+++ b/zentral/contrib/inventory/tasks.py
@@ -41,7 +41,8 @@ def cleanup_inventory(days, serialized_event_request, **kwargs):
 
 
 @shared_task
-def export_full_inventory():
+def export_full_inventory(**kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     return do_full_export()
 
 

--- a/zentral/contrib/inventory/tasks.py
+++ b/zentral/contrib/inventory/tasks.py
@@ -22,7 +22,8 @@ from .utils import (MSQuery,
 
 
 @shared_task
-def cleanup_inventory(days, serialized_event_request):
+def cleanup_inventory(days, serialized_event_request, **kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     max_date = get_cleanup_max_date(days)
     payload = {"days": days, "max_date": max_date}
     post_cleanup_started_event(payload.copy(), serialized_event_request)

--- a/zentral/contrib/mdm/api_views/software_updates.py
+++ b/zentral/contrib/mdm/api_views/software_updates.py
@@ -15,7 +15,9 @@ class SyncSoftwareUpdatesView(APIView):
     permission_classes = [DjangoPermissionRequired]
 
     def post(self, request, *args, **kwargs):
-        result = sync_software_updates_task.apply_async()
+        result = sync_software_updates_task.apply_async(
+            kwargs={"task_user": request.user.id}
+        )
         return Response({"task_id": result.id,
                          "task_result_url": reverse("base_api:task_result", args=(result.id,))},
                         status=status.HTTP_201_CREATED)

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -55,7 +55,8 @@ def define_dep_profile_task(dep_enrollment_pk):
 
 
 @shared_task
-def sync_software_updates_task():
+def sync_software_updates_task(**kwargs):
+    # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
     return sync_software_updates()
 
 


### PR DESCRIPTION
Nothing here is broken today: every one of these endpoints is API-token only, so there is no button in the web interface pointing a user at a task they cannot see. This is consistency, so that every task somebody starts shows up in the task list of whoever started it.

## Why

`TaskViewMixin.get_queryset()` in `server/accounts/views/tasks.py` filters the task list for everybody who is not a superuser:

```python
if not self.request.user.is_superuser:
    queryset = queryset.filter(usertask__user=self.request.user)
```

Zentral creates the `UserTask` from the `before_task_publish` signal in `server/server/celery.py`, but only when the published task kwargs carry `task_user`.

## What changed

One commit per launch, each passing `task_user` in the task kwargs and taking `**kwargs` on the task so the extra kwarg does not raise:

| Commit | Task | Note |
|---|---|---|
| `inventory: attribute a cleanup to the user who asked for it` | `cleanup_inventory` | already passed the event request, so it was attributable in the event store but not in the task list |
| `inventory: attribute a full export to the user who asked for it` | `export_full_inventory` | produces a file, and the download button sits on the task page; the other inventory exports already pass `task_user` |
| `mdm: attribute a software updates sync to the user who asked for it` | `sync_software_updates_task` | |
| `intune: attribute a tenant inventory sync to the user who asked for it` | `sync_inventory` | |
| `wsone: attribute an instance inventory sync to the user who asked for it` | `sync_inventory` | already passed the event request |

The two Intune and Workspace ONE changes are under `ee/`, edited in place. No code moved between the licence trees.

Since all five endpoints are token only, the task belongs to the **service account** that called them, which the new tests assert explicitly. That is a different shape from the session-based cases in the earlier PRs, and it is what makes an API-driven cleanup or export attributable to the integration that triggered it.

## Tests

One test per launch, asserting the `UserTask` exists and points at the right user.


🤖 Generated with [Claude Code](https://claude.com/claude-code)