### PR TITLE
mdm: fix the DEP synchronization and post events when Apple changes a device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The API endpoints for the ACME issuer, SCEP issuer, FileVault configuration, rec
 The DEP token audit events do not carry the `has_expired` and `expires_soon` booleans anymore. They were computed when the event was serialized, and never refreshed afterwards, so a stored event kept reporting the state of the token at the time it was written. Use the `access_token_expiry` timestamp, which is still in the payload, and compare it with the event `created_at`. Probes keyed on the two removed fields need to be updated.
 
 
+#### 🧨 MDM DEP virtual server device sync task result
+
+In the result of `/api/mdm/dep/virtual_servers/<int:pk>/sync_devices/`, `operations` gains `unchanged` and `marked_deleted`, `updated` only counts the devices whose record changed, and a `status` of `SUCCESS` or `SKIPPED` is added. Read `created + updated + unchanged` for the number of devices Apple reported.
+
+
 #### 🧨 Monolith repository sync API endpoint
 
 `/api/monolith/repositories/<int:pk>/sync/` launches a background task instead of syncing the repository during the request. It responds with `201` and a `task_id`/`task_result_url` pair, in place of the `200 {"status": 0}` and `500 {"status": 1, "error": "…"}` responses it used to return. Poll `task_result_url` to know the outcome of the sync.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Recovery password configurations can schedule a password rotation after each rev
 
 FileVault configurations can schedule a PRK rotation after each reveal of the PRK.
 
+Synchronizing a DEP virtual server with Apple Business Manager now posts a `dep_device_change` event for every device it changed, with the previous and the new value of the record, like an audit event.
+
 
 #### Monolith
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -579,11 +579,37 @@ Note that a device can also become unblocked without an operator: a full state p
 
 ### Automated Device Enrollment devices
 
-Assigning an enrollment profile to a device, and refreshing its record from Apple, are recorded with the `updated` action, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved.
+Assigning an enrollment profile to a device, and refreshing its record from Apple, are recorded with the `updated` action, tagged with the device serial number. The event reports every attribute Apple can change on the record, so a refresh shows what actually moved. An assignment made over the HTTP API is recorded the same way as one made from the web interface.
 
 A refresh that Apple answers with an unknown serial number still marks the record as deleted, so it is recorded too. A profile assignment Apple refuses changes nothing and records nothing.
 
 Disowning a device has its own event, `dep_device_disowned`, rather than an audit event.
+
+Changes Apple makes are **not** audit events. A synchronization with Apple Business Manager posts a `dep_device_change` event instead, tagged `mdm` and `dep`, and not `zentral`: they are machine generated, one per device the synchronization found a change on, and they would bury the operator actions in the audit trail. The payload is an audit event's, so a DEP device has one history whichever end changed it:
+
+```json
+{
+  "action": "updated",
+  "origin": "sync",
+  "object": {
+    "model": "mdm.depdevice",
+    "pk": "42",
+    "prev_value": {"serial_number": "C02...", "profile_status": "pushed", "enrollment": {"pk": 3}},
+    "new_value": {"serial_number": "C02...", "profile_status": "empty", "enrollment": null}
+  }
+}
+```
+
+The `origin` says which end of Zentral was talking to Apple: `sync` for a synchronization, `default_enrollment_assignment` for the task that assigns a virtual server's default enrollment. All the events of one run share the same metadata `id`.
+
+Two kinds of change post nothing:
+
+- a device Apple reports **unchanged**, which a full fetch does for the whole fleet on every run
+- a device whose stored record only moved because of the **operation itself**, `last_op_type` and `last_op_date`, which a delta synchronization reports for attributes Zentral does not store. A deletion is still reported, even when it is all that moved.
+
+The first synchronization of a virtual server reports every device it finds, like any other. A virtual server usually fills up progressively, so those are real additions rather than an import artefact.
+
+A device Apple stops reporting is recorded with the `updated` action, not `deleted`: the record stays in Zentral, with its `last_op_type` moved to `deleted`.
 
 ### Artifacts and blueprints
 

--- a/tests/mdm/management_commands/test_others.py
+++ b/tests/mdm/management_commands/test_others.py
@@ -8,9 +8,10 @@ from django.test import TestCase
 from django.utils.crypto import get_random_string
 
 from zentral.contrib.mdm.dep_client import DEPClientError
+from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.models import ACMEIssuer, Location, LocationAsset, SCEPIssuer
 
-from ..utils import force_asset, force_dep_virtual_server
+from ..utils import force_asset, force_dep_enrollment, force_dep_virtual_server
 
 
 class MDMManagementCommandsTest(TestCase):
@@ -328,6 +329,59 @@ class MDMManagementCommandsTest(TestCase):
         sync_dep_virtual_server_devices.assert_has_calls([
             call(dvs1, force_fetch=True), call(dvs2, force_fetch=True)
         ])
+
+    def _force_server_with_default_enrollment(self):
+        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
+        server = enrollment.virtual_server
+        server.default_enrollment = enrollment
+        server.save()
+        return server
+
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.assign_dep_virtual_server_default_enrollment")
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
+    def test_sync_dep_devices_assigns_the_default_enrollment(self, sync, assign):
+        server = self._force_server_with_default_enrollment()
+        sync.side_effect = [(("YOLO", True),)]
+        assign.return_value = {"assigned": 2, "failed": 1}
+        out = StringIO()
+        call_command('sync_dep_devices', '--server', str(server.pk), stdout=out)
+        # the command is the cron entry point, it assigns inline instead of scheduling a task
+        assign.assert_called_once_with(server)
+        self.assertEqual(
+            out.getvalue(),
+            f"Sync server {server.pk} {server}\n"
+            "Created YOLO\n"
+            "Assigned the default enrollment to 2 device(s), 1 failure(s)\n"
+        )
+
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.assign_dep_virtual_server_default_enrollment")
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
+    def test_sync_dep_devices_default_enrollment_assignment_error(self, sync, assign):
+        server = self._force_server_with_default_enrollment()
+        sync.side_effect = [(("YOLO", True),)]
+        assign.side_effect = DEPClientError("yolo", status_code=429)
+        out = StringIO()
+        err = StringIO()
+        call_command('sync_dep_devices', '--server', str(server.pk), stdout=out, stderr=err)
+        # a failed assignment does not take the synchronization down with it
+        self.assertEqual(
+            out.getvalue(),
+            f"Sync server {server.pk} {server}\n"
+            "Created YOLO\n"
+        )
+        self.assertEqual(
+            err.getvalue(),
+            "Could not assign the default enrollment: yolo, status code: 429\n"
+        )
+
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.assign_dep_virtual_server_default_enrollment")
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
+    def test_sync_dep_devices_no_default_enrollment_no_assignment(self, sync, assign):
+        server = force_dep_virtual_server()
+        sync.side_effect = [(("YOLO", True),)]
+        out = StringIO()
+        call_command('sync_dep_devices', '--server', str(server.pk), stdout=out)
+        assign.assert_not_called()
 
     @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
     def test_sync_dep_devices_list_servers(self, sync_dep_virtual_server_devices):

--- a/tests/mdm/management_commands/test_others.py
+++ b/tests/mdm/management_commands/test_others.py
@@ -200,8 +200,8 @@ class MDMManagementCommandsTest(TestCase):
         dvs1 = force_dep_virtual_server()
         dvs2 = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
-            (("YOLO", True),),
-            (("FOMO", False),),
+            (("YOLO", "created"),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', stdout=out)
@@ -223,7 +223,7 @@ class MDMManagementCommandsTest(TestCase):
         dvs2 = force_dep_virtual_server()
         try_lock.side_effect = [False, True]
         sync_dep_virtual_server_devices.side_effect = [
-            (("FOMO", False),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', stdout=out)
@@ -242,7 +242,7 @@ class MDMManagementCommandsTest(TestCase):
         dvs = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
             DEPClientError("yolo", error_code="EXPIRED_CURSOR"),
-            (("FOMO", False),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', stdout=out)
@@ -278,7 +278,7 @@ class MDMManagementCommandsTest(TestCase):
         dvs = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
             ValueError("HAAAAAAAAAAA"),
-            (("FOMO", False),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         err = StringIO()
@@ -298,7 +298,7 @@ class MDMManagementCommandsTest(TestCase):
         force_dep_virtual_server()
         dvs = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
-            (("YOLO", True),),
+            (("YOLO", "created"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', '--server', str(dvs.pk), stdout=out)
@@ -314,8 +314,8 @@ class MDMManagementCommandsTest(TestCase):
         dvs1 = force_dep_virtual_server()
         dvs2 = force_dep_virtual_server()
         sync_dep_virtual_server_devices.side_effect = [
-            (("YOLO", True),),
-            (("FOMO", False),),
+            (("YOLO", "created"),),
+            (("FOMO", "updated"),),
         ]
         out = StringIO()
         call_command('sync_dep_devices', '--full-sync', stdout=out)
@@ -341,7 +341,7 @@ class MDMManagementCommandsTest(TestCase):
     @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
     def test_sync_dep_devices_assigns_the_default_enrollment(self, sync, assign):
         server = self._force_server_with_default_enrollment()
-        sync.side_effect = [(("YOLO", True),)]
+        sync.side_effect = [(("YOLO", "created"),)]
         assign.return_value = {"assigned": 2, "failed": 1}
         out = StringIO()
         call_command('sync_dep_devices', '--server', str(server.pk), stdout=out)
@@ -358,7 +358,7 @@ class MDMManagementCommandsTest(TestCase):
     @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
     def test_sync_dep_devices_default_enrollment_assignment_error(self, sync, assign):
         server = self._force_server_with_default_enrollment()
-        sync.side_effect = [(("YOLO", True),)]
+        sync.side_effect = [(("YOLO", "created"),)]
         assign.side_effect = DEPClientError("yolo", status_code=429)
         out = StringIO()
         err = StringIO()
@@ -378,7 +378,7 @@ class MDMManagementCommandsTest(TestCase):
     @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
     def test_sync_dep_devices_no_default_enrollment_no_assignment(self, sync, assign):
         server = force_dep_virtual_server()
-        sync.side_effect = [(("YOLO", True),)]
+        sync.side_effect = [(("YOLO", "created"),)]
         out = StringIO()
         call_command('sync_dep_devices', '--server', str(server.pk), stdout=out)
         assign.assert_not_called()

--- a/tests/mdm/management_commands/test_others.py
+++ b/tests/mdm/management_commands/test_others.py
@@ -215,6 +215,27 @@ class MDMManagementCommandsTest(TestCase):
             call(dvs1, force_fetch=False), call(dvs2, force_fetch=False)
         ])
 
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.try_lock_dep_virtual_server_sync")
+    @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
+    def test_sync_dep_devices_already_running(self, sync_dep_virtual_server_devices, try_lock):
+        dvs1 = force_dep_virtual_server()
+        dvs2 = force_dep_virtual_server()
+        try_lock.side_effect = [False, True]
+        sync_dep_virtual_server_devices.side_effect = [
+            (("FOMO", False),),
+        ]
+        out = StringIO()
+        call_command('sync_dep_devices', stdout=out)
+        self.assertEqual(
+            out.getvalue(),
+            f"Sync server {dvs1.pk} {dvs1}\n"
+            "Already being synced → skipped\n"
+            f"Sync server {dvs2.pk} {dvs2}\n"
+            "Updated FOMO\n"
+        )
+        # the locked server is not synced, the next one still is
+        sync_dep_virtual_server_devices.assert_called_once_with(dvs2, force_fetch=False)
+
     @patch("zentral.contrib.mdm.management.commands.sync_dep_devices.sync_dep_virtual_server_devices")
     def test_sync_dep_devices_cursor_error(self, sync_dep_virtual_server_devices):
         dvs = force_dep_virtual_server()

--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -13,6 +13,7 @@ from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.dep_client import DEPClientError
 from zentral.contrib.mdm.events import DEPDeviceDisownedEvent
+from zentral.core.events.base import AuditEvent
 
 from .utils import force_dep_device, force_dep_enrollment, force_dep_virtual_server
 
@@ -431,6 +432,35 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         dep_device = force_dep_device()
         response = self.put(reverse("mdm_api:dep_device", args=(dep_device.pk,)))
         self.assertEqual(response.status_code, 403)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.serializers.assign_dep_device_profile")
+    def test_update_dep_device_posts_audit_event(self, assign_dep_device_profile, post_event):
+        dep_device = force_dep_device()
+        enrollment = force_dep_enrollment(self.mbu)
+        self.set_permissions("mdm.change_depdevice")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse("mdm_api:dep_device", args=(dep_device.pk,)),
+                                data={"enrollment": enrollment.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.metadata.machine_serial_number, dep_device.serial_number)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depdevice")
+        self.assertIsNone(event.payload["object"]["prev_value"]["enrollment"])
+        self.assertEqual(event.payload["object"]["new_value"]["enrollment"]["pk"], enrollment.pk)
+
+    def test_patch_dep_device_not_allowed(self):
+        dep_device = force_dep_device()
+        enrollment = force_dep_enrollment(self.mbu)
+        self.set_permissions("mdm.change_depdevice")
+        response = self.client.patch(reverse("mdm_api:dep_device", args=(dep_device.pk,)),
+                                     data={"enrollment": enrollment.pk},
+                                     content_type="application/json",
+                                     HTTP_AUTHORIZATION=f"Token {self._get_api_key()}")
+        self.assertEqual(response.status_code, 405)
 
     @patch("zentral.contrib.mdm.serializers.assign_dep_device_profile")
     def test_update_dep_device(self, assign_dep_device_profile):

--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -102,7 +102,14 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         args, task_kwargs = apply_async.call_args.args
         self.assertEqual(args, (dep_server.pk,))
         # the task kwargs, not the apply_async options: force_full_sync has to reach the task
-        self.assertEqual(task_kwargs, {"force_full_sync": True, "task_user": self.user.pk})
+        self.assertEqual(sorted(task_kwargs),
+                         ["force_full_sync", "serialized_event_request", "task_user"])
+        self.assertEqual(task_kwargs["force_full_sync"], True)
+        self.assertEqual(task_kwargs["task_user"], self.user.pk)
+        # the request is carried to the worker, so the events of the synchronization somebody asked
+        # for say who asked for it
+        self.assertEqual(task_kwargs["serialized_event_request"]["user"]["id"], self.user.pk)
+        self.assertEqual(task_kwargs["serialized_event_request"]["method"], "POST")
 
     @patch("zentral.contrib.mdm.api_views.dep.sync_dep_virtual_server_devices_task.apply_async")
     def test_sa_dep_virtual_server_sync_devices_delta_task_kwargs(self, apply_async):
@@ -112,7 +119,14 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.post(reverse("mdm_api:dep_virtual_server_sync_devices", args=(dep_server.pk,)))
         self.assertEqual(response.status_code, 201)
         _, task_kwargs = apply_async.call_args.args
-        self.assertEqual(task_kwargs, {"force_full_sync": False, "task_user": self.service_account.pk})
+        self.assertEqual(sorted(task_kwargs),
+                         ["force_full_sync", "serialized_event_request", "task_user"])
+        self.assertEqual(task_kwargs["force_full_sync"], False)
+        self.assertEqual(task_kwargs["task_user"], self.service_account.pk)
+        self.assertEqual(task_kwargs["serialized_event_request"]["user"]["id"], self.service_account.pk)
+        self.assertTrue(
+            task_kwargs["serialized_event_request"]["user"]["session"]["token_authenticated"]
+        )
 
     def test_user_dep_virtual_server_sync_devices_creates_user_task(self):
         dep_server = force_dep_virtual_server()

--- a/tests/mdm/test_api_dep_views.py
+++ b/tests/mdm/test_api_dep_views.py
@@ -544,7 +544,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertIsInstance(event, DEPDeviceDisownedEvent)
         self.assertEqual(event.metadata.machine_serial_number, dep_device.serial_number)
         self.assertEqual(event.payload, {"result": "SUCCESS"})
+        prev_updated_at = dep_device.updated_at
         dep_device.refresh_from_db()
         self.assertIsNotNone(dep_device.disowned_at)
+        # the bulk update bypasses save(), so auto_now would not have fired
+        self.assertTrue(dep_device.updated_at > prev_updated_at)
         self.assertEqual(send_request.call_args_list[0].args, ("devices/disown", "POST"))
         self.assertEqual(send_request.call_args_list[0].kwargs, {'json': {'devices': [dep_device.serial_number]}})

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -7,7 +7,7 @@ from django.utils.crypto import get_random_string
 
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.dep import define_dep_profile, sync_dep_virtual_server_devices
-from zentral.contrib.mdm.dep_client import CursorIterator
+from zentral.contrib.mdm.dep_client import DEVICE_BATCH_SIZE, CursorIterator
 from zentral.contrib.mdm.models import DEPDevice
 from zentral.contrib.mdm.tasks import define_dep_profile_task
 from zentral.utils.time import naive_utcnow
@@ -277,6 +277,7 @@ class TestDEPEnrollment(TestCase):
             enrollment=enrollment2
         )
         client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
         profile_uuid = uuid.uuid4()
         self.assertNotEqual(enrollment.uuid, profile_uuid)
         self.assertNotEqual(device1.profile_uuid, profile_uuid)
@@ -324,9 +325,46 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(device4.profile_uuid, enrollment2.uuid)
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_define_dep_profile_over_the_limit_assigns_the_rest(self, from_dep_token):
+        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
+        devices = [
+            force_dep_device(server=enrollment.virtual_server,
+                             profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
+                             enrollment=enrollment)
+            for _ in range(3)
+        ]
+        # serialize_dep_profile() lists them in the DEPDevice ordering, by serial number
+        serial_numbers = sorted(d.serial_number for d in devices)
+        client = Mock()
+        # the profile payload is split at the size the client resolves for /profile
+        client.get_device_batch_size.return_value = 2
+        profile_uuid = uuid.uuid4()
+        client.add_profile.return_value = {
+            "profile_uuid": str(profile_uuid).upper().replace("-", ""),
+            "devices": {sn: "SUCCESS" for sn in serial_numbers[:2]},
+        }
+        client.assign_profile.return_value = {"devices": {serial_numbers[2]: "SUCCESS"}}
+        from_dep_token.return_value = client
+        result = define_dep_profile(enrollment)
+        # only the first batch rides in the profile payload
+        profile_payload = client.add_profile.call_args.args[0]
+        self.assertEqual(sorted(profile_payload["devices"]), serial_numbers[:2])
+        # the rest is assigned once the profile has a UUID, as Apple returned it
+        client.assign_profile.assert_called_once_with(
+            str(profile_uuid).upper().replace("-", ""), [serial_numbers[2]]
+        )
+        # the statuses of both calls end up in the same result
+        self.assertEqual(sorted(result["devices"]["success"]), serial_numbers)
+        for device in devices:
+            device.refresh_from_db()
+            self.assertEqual(device.profile_uuid, profile_uuid)
+            self.assertEqual(device.profile_status, DEPDevice.PROFILE_STATUS_ASSIGNED)
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_define_dep_profile_task(self, from_dep_token):
         enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
         client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
         profile_uuid = uuid.uuid4()
         self.assertNotEqual(enrollment.uuid, profile_uuid)
         client.add_profile.return_value = {

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -6,7 +6,12 @@ from django.test import TestCase
 from django.utils.crypto import get_random_string
 
 from zentral.contrib.inventory.models import MetaBusinessUnit
-from zentral.contrib.mdm.dep import define_dep_profile, sync_dep_virtual_server_devices
+from zentral.contrib.mdm.dep import (
+    assign_dep_virtual_server_default_enrollment,
+    define_dep_profile,
+    iter_unassigned_dep_device_serial_numbers,
+    sync_dep_virtual_server_devices,
+)
 from zentral.contrib.mdm.dep_client import DEVICE_BATCH_SIZE, CursorIterator
 from zentral.contrib.mdm.models import DEPDevice
 from zentral.contrib.mdm.tasks import define_dep_profile_task
@@ -122,55 +127,13 @@ class TestDEPEnrollment(TestCase):
         self.assertTrue(server.token.last_synced_at > start)
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
-    def test_sync_dep_virtual_server_devices_assign_default_profile(self, from_dep_token):
+    def test_sync_dep_virtual_server_devices_does_not_assign_the_default_profile(self, from_dep_token):
         serial_number = get_random_string(10).upper()
 
         enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
         server = enrollment.virtual_server
         server.default_enrollment = enrollment
         server.save()
-
-        def device_iterator():
-            yield from [
-                {'color': 'SPACE GRAY',
-                 'description': 'IPHONE X SPACE GRAY 64GB-ZDD',
-                 'device_assigned_by': 'support@zentral.com',
-                 'device_assigned_date': '2023-01-10T19:09:22Z',
-                 'device_family': 'iPhone',
-                 'model': 'iPhone X',
-                 'op_date': '2023-01-10T19:07:41Z',
-                 'op_type': 'modified',
-                 'os': 'iOS',
-                 'profile_status': 'empty',
-                 'serial_number': serial_number}
-            ]
-            return get_random_string(12)
-
-        client = Mock()
-        client.fetch_devices.return_value = CursorIterator(device_iterator())
-        client.assign_profile.return_value = {"devices": {serial_number: "SUCCESS"}}
-        from_dep_token.return_value = client
-        dep_devices = list(sync_dep_virtual_server_devices(server))
-        client.fetch_devices.assert_called_once_with()
-        client.assign_profile.assert_called_once_with(server.default_enrollment.uuid, [serial_number])
-        self.assertEqual(len(dep_devices), 1)
-        device, created = dep_devices[0]
-        self.assertIsNone(device.profile_uuid)
-        self.assertIsNone(device.enrollment)
-        device.refresh_from_db()
-        self.assertEqual(device.profile_uuid, server.default_enrollment.uuid)
-        self.assertEqual(device.enrollment, server.default_enrollment)
-        self.assertEqual(device.profile_status, "assigned")
-
-    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
-    def test_sync_dep_virtual_server_devices_assign_default_profile_bumps_updated_at(self, from_dep_token):
-        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
-        server = enrollment.virtual_server
-        server.default_enrollment = enrollment
-        server.save()
-        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
-        prev_updated_at = dep_device.updated_at
-        serial_number = dep_device.serial_number
 
         def device_iterator():
             yield from [
@@ -185,16 +148,16 @@ class TestDEPEnrollment(TestCase):
 
         client = Mock()
         client.fetch_devices.return_value = CursorIterator(device_iterator())
-        client.assign_profile.return_value = {"devices": {serial_number: "SUCCESS"}}
         from_dep_token.return_value = client
-        list(sync_dep_virtual_server_devices(server))
-        dep_device.refresh_from_db()
-        self.assertEqual(dep_device.enrollment, enrollment)
-        self.assertEqual(dep_device.profile_status, DEPDevice.PROFILE_STATUS_ASSIGNED)
-        # the bulk update bypasses save(), so auto_now would not have fired
-        self.assertTrue(dep_device.updated_at > prev_updated_at)
-        # Apple has not reported an assignment time yet, and Zentral does not invent one
-        self.assertIsNone(dep_device.profile_assign_time)
+        dep_devices = list(sync_dep_virtual_server_devices(server))
+        client.fetch_devices.assert_called_once_with()
+        # the assignment is a separate task now, the synchronization does not talk to Apple about it
+        client.assign_profile.assert_not_called()
+        self.assertEqual(len(dep_devices), 1)
+        device, _ = dep_devices[0]
+        device.refresh_from_db()
+        self.assertIsNone(device.profile_uuid)
+        self.assertIsNone(device.enrollment)
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_sync_dep_virtual_server_devices_fetch_marks_missing_deleted(self, from_dep_token):
@@ -242,15 +205,124 @@ class TestDEPEnrollment(TestCase):
         from_dep_token.return_value = client
         dep_devices = list(sync_dep_virtual_server_devices(server))
         client.fetch_devices.assert_called_once_with()
-        client.assign_profile.assert_not_called()
         self.assertEqual(len(dep_devices), 1)
         device, created = dep_devices[0]
-        self.assertIsNone(device.profile_uuid)
-        self.assertIsNone(device.enrollment)
         device.refresh_from_db()
-        self.assertIsNone(device.profile_uuid)
+        self.assertEqual(device.last_op_type, DEPDevice.OP_TYPE_DELETED)
+        # a deleted device is not a candidate for the default enrollment
+        self.assertNotIn(device.serial_number, list(iter_unassigned_dep_device_serial_numbers(server)))
+
+    # default enrollment assignment
+
+    def force_server_with_default_enrollment(self):
+        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
+        server = enrollment.virtual_server
+        server.default_enrollment = enrollment
+        server.save()
+        return server, enrollment
+
+    def test_iter_unassigned_dep_device_serial_numbers(self):
+        server, enrollment = self.force_server_with_default_enrollment()
+        unassigned = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        # a full fetch leaves last_op_type null, and those devices must be candidates too:
+        # excluding the deleted ones must not exclude the ones with no operation at all
+        DEPDevice.objects.filter(pk=unassigned.pk).update(last_op_type=None)
+        removed = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
+                                   enrollment=enrollment)
+        DEPDevice.objects.filter(pk=removed.pk).update(profile_status=DEPDevice.PROFILE_STATUS_REMOVED)
+        assigned = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
+                                    enrollment=enrollment)
+        deleted = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY,
+                                   op_type=DEPDevice.OP_TYPE_DELETED)
+        disowned = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        DEPDevice.objects.filter(pk=disowned.pk).update(disowned_at=naive_utcnow())
+        other_server_device = force_dep_device(profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+
+        serial_numbers = sorted(iter_unassigned_dep_device_serial_numbers(server))
+        self.assertEqual(serial_numbers, sorted([unassigned.serial_number, removed.serial_number]))
+        for device in (assigned, deleted, disowned, other_server_device):
+            self.assertNotIn(device.serial_number, serial_numbers)
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment(self, from_dep_virtual_server):
+        server, enrollment = self.force_server_with_default_enrollment()
+        device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        prev_updated_at = device.updated_at
+        client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
+        client.assign_profile.return_value = {"devices": {device.serial_number: "SUCCESS"}}
+        from_dep_virtual_server.return_value = client
+
+        self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
+                         {"assigned": 1, "failed": 0})
+        client.assign_profile.assert_called_once_with(enrollment.uuid, [device.serial_number])
+        device.refresh_from_db()
+        self.assertEqual(device.enrollment, enrollment)
+        self.assertEqual(device.profile_uuid, enrollment.uuid)
+        self.assertEqual(device.profile_status, DEPDevice.PROFILE_STATUS_ASSIGNED)
+        # the bulk update bypasses save(), so auto_now would not have fired
+        self.assertTrue(device.updated_at > prev_updated_at)
+        # Apple has not reported an assignment time yet, and Zentral does not invent one
+        self.assertIsNone(device.profile_assign_time)
+        # the device is not a candidate anymore
+        self.assertEqual(list(iter_unassigned_dep_device_serial_numbers(server)), [])
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment_failure(self, from_dep_virtual_server):
+        server, enrollment = self.force_server_with_default_enrollment()
+        device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
+        client.assign_profile.return_value = {"devices": {device.serial_number: "FAILED"}}
+        from_dep_virtual_server.return_value = client
+
+        self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
+                         {"assigned": 0, "failed": 1})
+        device.refresh_from_db()
         self.assertIsNone(device.enrollment)
-        self.assertEqual(device.profile_status, "empty")
+        # it stays a candidate, the next synchronization enqueues the task again
+        self.assertEqual(list(iter_unassigned_dep_device_serial_numbers(server)), [device.serial_number])
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment_chunks(self, from_dep_virtual_server):
+        server, enrollment = self.force_server_with_default_enrollment()
+        devices = [force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+                   for _ in range(3)]
+        serial_numbers = sorted(d.serial_number for d in devices)
+        client = Mock()
+        client.get_device_batch_size.return_value = 2
+        client.assign_profile.side_effect = [
+            {"devices": {sn: "SUCCESS" for sn in serial_numbers[:2]}},
+            {"devices": {serial_numbers[2]: "SUCCESS"}},
+        ]
+        from_dep_virtual_server.return_value = client
+
+        self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
+                         {"assigned": 3, "failed": 0})
+        self.assertEqual(
+            [c.args[1] for c in client.assign_profile.call_args_list],
+            [serial_numbers[:2], serial_numbers[2:]]
+        )
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment_no_default(self, from_dep_virtual_server):
+        server = force_dep_virtual_server()
+        force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
+                         {"assigned": 0, "failed": 0})
+        from_dep_virtual_server.assert_not_called()
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment_nothing_to_do(self, from_dep_virtual_server):
+        server, enrollment = self.force_server_with_default_enrollment()
+        force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
+                         enrollment=enrollment)
+        client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
+        from_dep_virtual_server.return_value = client
+        self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
+                         {"assigned": 0, "failed": 0})
+        client.assign_profile.assert_not_called()
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_define_dep_profile(self, from_dep_token):

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -163,6 +163,57 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(device.profile_status, "assigned")
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_assign_default_profile_bumps_updated_at(self, from_dep_token):
+        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
+        server = enrollment.virtual_server
+        server.default_enrollment = enrollment
+        server.save()
+        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        prev_updated_at = dep_device.updated_at
+        serial_number = dep_device.serial_number
+
+        def device_iterator():
+            yield from [
+                {'device_assigned_by': 'support@zentral.com',
+                 'device_assigned_date': '2023-01-10T19:09:22Z',
+                 'op_date': '2023-01-10T19:07:41Z',
+                 'op_type': 'modified',
+                 'profile_status': 'empty',
+                 'serial_number': serial_number}
+            ]
+            return get_random_string(12)
+
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator(device_iterator())
+        client.assign_profile.return_value = {"devices": {serial_number: "SUCCESS"}}
+        from_dep_token.return_value = client
+        list(sync_dep_virtual_server_devices(server))
+        dep_device.refresh_from_db()
+        self.assertEqual(dep_device.enrollment, enrollment)
+        self.assertEqual(dep_device.profile_status, DEPDevice.PROFILE_STATUS_ASSIGNED)
+        # the bulk update bypasses save(), so auto_now would not have fired
+        self.assertTrue(dep_device.updated_at > prev_updated_at)
+        # Apple has not reported an assignment time yet, and Zentral does not invent one
+        self.assertIsNone(dep_device.profile_assign_time)
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_fetch_marks_missing_deleted(self, from_dep_token):
+        server = force_dep_virtual_server()
+        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        prev_updated_at = dep_device.updated_at
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([
+            {'device_assigned_by': 'support@zentral.com',
+             'device_assigned_date': '2023-01-10T19:09:22Z',
+             'serial_number': get_random_string(10).upper()}
+        ])
+        from_dep_token.return_value = client
+        list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        dep_device.refresh_from_db()
+        self.assertEqual(dep_device.last_op_type, DEPDevice.OP_TYPE_DELETED)
+        self.assertTrue(dep_device.updated_at > prev_updated_at)
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_sync_dep_virtual_server_deleted_device_no_assign_default_profile(self, from_dep_token):
         serial_number = get_random_string(10).upper()
 

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -49,9 +49,9 @@ class TestDEPEnrollment(TestCase):
         dep_devices = list(sync_dep_virtual_server_devices(server))
         client.fetch_devices.assert_called_once_with()
         self.assertEqual(len(dep_devices), 1)
-        d, d_created = dep_devices[0]
+        d, d_action = dep_devices[0]
         d.refresh_from_db()  # for the datetimes, to get the stored ones, not the parsed ones
-        self.assertTrue(d_created)
+        self.assertEqual(d_action, "created")
         self.assertEqual(d.asset_tag, "")
         self.assertEqual(d.color, "SPACE GRAY")
         self.assertEqual(d.description, "IPHONE X SPACE GRAY 64GB-ZDD")
@@ -105,9 +105,9 @@ class TestDEPEnrollment(TestCase):
         dep_devices = list(sync_dep_virtual_server_devices(server))
         client.sync_devices.assert_called_once_with(sync_cursor)
         self.assertEqual(len(dep_devices), 1)
-        d, d_created = dep_devices[0]
+        d, d_action = dep_devices[0]
         d.refresh_from_db()  # for the datetimes, to get the stored ones, not the parsed ones
-        self.assertTrue(d_created)
+        self.assertEqual(d_action, "created")
         self.assertEqual(d.asset_tag, "")
         self.assertEqual(d.color, "SPACE GRAY")
         self.assertEqual(d.description, "IPHONE X SPACE GRAY 64GB-ZDD")
@@ -171,9 +171,59 @@ class TestDEPEnrollment(TestCase):
              'serial_number': get_random_string(10).upper()}
         ])
         from_dep_token.return_value = client
-        list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        results = list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        self.assertEqual([action for _, action in results], ["created", "marked_deleted"])
         dep_device.refresh_from_db()
         self.assertEqual(dep_device.last_op_type, DEPDevice.OP_TYPE_DELETED)
+        self.assertTrue(dep_device.updated_at > prev_updated_at)
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_fetch_leaves_the_deleted_ones_alone(self, from_dep_token):
+        server = force_dep_virtual_server()
+        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY,
+                                      op_type=DEPDevice.OP_TYPE_DELETED)
+        prev_updated_at = dep_device.updated_at
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([])
+        from_dep_token.return_value = client
+        self.assertEqual(list(sync_dep_virtual_server_devices(server, force_fetch=True)), [])
+        dep_device.refresh_from_db()
+        # a device already marked as deleted is not rewritten on every full fetch
+        self.assertEqual(dep_device.updated_at, prev_updated_at)
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_unchanged_device_is_not_written(self, from_dep_token):
+        server = force_dep_virtual_server()
+        device_d = {'color': 'SPACE GRAY',
+                    'description': 'IPHONE X SPACE GRAY 64GB-ZDD',
+                    'device_assigned_by': 'support@zentral.com',
+                    'device_assigned_date': '2023-01-10T19:09:22Z',
+                    'device_family': 'iPhone',
+                    'model': 'iPhone X',
+                    'os': 'iOS',
+                    'profile_status': 'empty',
+                    'serial_number': get_random_string(10).upper()}
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([device_d])
+        from_dep_token.return_value = client
+        results = list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        self.assertEqual([action for _, action in results], ["created"])
+        dep_device = results[0][0]
+        prev_updated_at = dep_device.updated_at
+
+        # the very same device, reported again
+        client.fetch_devices.return_value = CursorIterator([device_d])
+        results = list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        self.assertEqual([action for _, action in results], ["unchanged"])
+        dep_device.refresh_from_db()
+        self.assertEqual(dep_device.updated_at, prev_updated_at)
+
+        # one attribute moves
+        client.fetch_devices.return_value = CursorIterator([dict(device_d, color="MIDNIGHT")])
+        results = list(sync_dep_virtual_server_devices(server, force_fetch=True))
+        self.assertEqual([action for _, action in results], ["updated"])
+        dep_device.refresh_from_db()
+        self.assertEqual(dep_device.color, "MIDNIGHT")
         self.assertTrue(dep_device.updated_at > prev_updated_at)
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -251,21 +251,50 @@ class TestDEPEnrollment(TestCase):
         client = Mock()
         client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
         client.assign_profile.return_value = {"devices": {device.serial_number: "SUCCESS"}}
+        client.get_devices.return_value = {
+            device.serial_number: {
+                "profile_uuid": str(enrollment.uuid).upper().replace("-", ""),
+                # Apple has already pushed it, which the assignment could not have guessed
+                "profile_status": "pushed",
+                "profile_assign_time": "2026-08-10T09:15:22Z",
+                "profile_push_time": "2026-08-10T09:16:01Z",
+            }
+        }
         from_dep_virtual_server.return_value = client
 
         self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
                          {"assigned": 1, "failed": 0})
         client.assign_profile.assert_called_once_with(enrollment.uuid, [device.serial_number])
+        client.get_devices.assert_called_once_with([device.serial_number])
         device.refresh_from_db()
         self.assertEqual(device.enrollment, enrollment)
         self.assertEqual(device.profile_uuid, enrollment.uuid)
-        self.assertEqual(device.profile_status, DEPDevice.PROFILE_STATUS_ASSIGNED)
-        # the bulk update bypasses save(), so auto_now would not have fired
+        # what Apple reports, not what the assignment assumed
+        self.assertEqual(device.profile_status, DEPDevice.PROFILE_STATUS_PUSHED)
+        self.assertEqual(device.profile_assign_time, datetime(2026, 8, 10, 9, 15, 22))
+        self.assertEqual(device.profile_push_time, datetime(2026, 8, 10, 9, 16, 1))
+        # bulk_update bypasses save(), so auto_now would not have fired
         self.assertTrue(device.updated_at > prev_updated_at)
-        # Apple has not reported an assignment time yet, and Zentral does not invent one
-        self.assertIsNone(device.profile_assign_time)
         # the device is not a candidate anymore
         self.assertEqual(list(iter_unassigned_dep_device_serial_numbers(server)), [])
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment_not_reported_back(self, from_dep_virtual_server):
+        server, enrollment = self.force_server_with_default_enrollment()
+        device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
+        client.assign_profile.return_value = {"devices": {device.serial_number: "SUCCESS"}}
+        # Apple accepted the assignment but does not report the device back
+        client.get_devices.return_value = {}
+        from_dep_virtual_server.return_value = client
+
+        self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
+                         {"assigned": 0, "failed": 0})
+        device.refresh_from_db()
+        self.assertIsNone(device.enrollment)
+        # nothing was written, so it stays a candidate for the next run
+        self.assertEqual(list(iter_unassigned_dep_device_serial_numbers(server)), [device.serial_number])
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
     def test_assign_dep_virtual_server_default_enrollment_failure(self, from_dep_virtual_server):
@@ -294,6 +323,11 @@ class TestDEPEnrollment(TestCase):
         client.assign_profile.side_effect = [
             {"devices": {sn: "SUCCESS" for sn in serial_numbers[:2]}},
             {"devices": {serial_numbers[2]: "SUCCESS"}},
+        ]
+        profile_uuid = str(enrollment.uuid).upper().replace("-", "")
+        client.get_devices.side_effect = [
+            {sn: {"profile_uuid": profile_uuid, "profile_status": "assigned"} for sn in serial_numbers[:2]},
+            {serial_numbers[2]: {"profile_uuid": profile_uuid, "profile_status": "assigned"}},
         ]
         from_dep_virtual_server.return_value = client
 

--- a/tests/mdm/test_dep.py
+++ b/tests/mdm/test_dep.py
@@ -13,6 +13,7 @@ from zentral.contrib.mdm.dep import (
     sync_dep_virtual_server_devices,
 )
 from zentral.contrib.mdm.dep_client import DEVICE_BATCH_SIZE, CursorIterator
+from zentral.contrib.mdm.events.dep import DEPDeviceChangeEvent
 from zentral.contrib.mdm.models import DEPDevice
 from zentral.contrib.mdm.tasks import define_dep_profile_task
 from zentral.utils.time import naive_utcnow
@@ -407,6 +408,203 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(assign_dep_virtual_server_default_enrollment(server),
                          {"assigned": 0, "failed": 0})
         client.assign_profile.assert_not_called()
+
+    # events
+
+    def force_synced_server(self):
+        """A virtual server with a cursor, so that a synchronization is a delta one."""
+        server = force_dep_virtual_server()
+        server.token.sync_cursor = get_random_string(12)
+        server.token.save()
+        return server
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_first_sync_posts_events_too(self, from_dep_token, post_event):
+        server = force_dep_virtual_server()
+        self.assertIsNone(server.token.sync_cursor)
+        serial_number = get_random_string(10).upper()
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([
+            {'device_assigned_date': '2023-01-10T19:09:22Z',
+             'serial_number': serial_number}
+        ])
+        from_dep_token.return_value = client
+        results = list(sync_dep_virtual_server_devices(server))
+        self.assertEqual([action for _, action in results], ["created"])
+        # a virtual server fills up progressively, so the devices of a first synchronization are
+        # additions like any others
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.metadata.machine_serial_number, serial_number)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_posts_created_event(self, from_dep_token, post_event):
+        server = self.force_synced_server()
+        serial_number = get_random_string(10).upper()
+
+        def device_iterator():
+            yield from [{'device_assigned_date': '2023-01-10T19:09:22Z',
+                         'op_date': '2023-06-17T15:41:06Z',
+                         'op_type': 'added',
+                         'serial_number': serial_number}]
+            return get_random_string(12)
+
+        client = Mock()
+        client.sync_devices.return_value = CursorIterator(device_iterator())
+        from_dep_token.return_value = client
+        results = list(sync_dep_virtual_server_devices(server))
+
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, DEPDeviceChangeEvent)
+        self.assertEqual(event.metadata.event_type, "dep_device_change")
+        # not an audit event, whatever the payload looks like
+        self.assertEqual(event.metadata.all_tags, {"mdm", "dep"})
+        self.assertEqual(event.metadata.machine_serial_number, serial_number)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["origin"], "sync")
+        self.assertEqual(event.payload["object"]["model"], "mdm.depdevice")
+        self.assertNotIn("prev_value", event.payload["object"])
+        self.assertEqual(event.payload["object"]["new_value"]["serial_number"], serial_number)
+        dep_device = results[0][0]
+        self.assertEqual(
+            event.metadata.objects,
+            {"mdm_dep_device": [(dep_device.pk,)],
+             "mdm_dep_virtual_server": [(server.pk,)]}
+        )
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_posts_updated_event(self, from_dep_token, post_event):
+        server = self.force_synced_server()
+        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        # force_dep_device() stamps last_op_date with now, which would make the payload look stale
+        DEPDevice.objects.filter(pk=dep_device.pk).update(last_op_date=None)
+
+        def device_iterator():
+            yield from [{'color': 'MIDNIGHT',
+                         'device_assigned_date': '2023-01-10T19:09:22Z',
+                         'op_date': '2023-06-17T15:41:06Z',
+                         'op_type': 'modified',
+                         'serial_number': dep_device.serial_number}]
+            return get_random_string(12)
+
+        client = Mock()
+        client.sync_devices.return_value = CursorIterator(device_iterator())
+        from_dep_token.return_value = client
+        list(sync_dep_virtual_server_devices(server))
+
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["prev_value"]["color"], "SPACE GRAY")
+        self.assertEqual(event.payload["object"]["new_value"]["color"], "MIDNIGHT")
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_operation_only_change_posts_no_event(
+        self, from_dep_token, post_event
+    ):
+        server = self.force_synced_server()
+        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        DEPDevice.objects.filter(pk=dep_device.pk).update(last_op_date=None)
+
+        def device_iterator():
+            # everything Zentral stores is what it already had, only the operation is new
+            yield from [{'color': 'SPACE GRAY',
+                         'description': 'IPHONE X SPACE GRAY 64GB-ZDD',
+                         'device_family': 'iPhone',
+                         'model': 'iPhone X',
+                         'os': 'iOS',
+                         'asset_tag': dep_device.asset_tag,
+                         'device_assigned_by': dep_device.device_assigned_by,
+                         'device_assigned_date': dep_device.device_assigned_date.isoformat(),
+                         'op_date': '2023-06-17T15:41:06Z',
+                         'op_type': 'modified',
+                         'serial_number': dep_device.serial_number}]
+            return get_random_string(12)
+
+        client = Mock()
+        client.sync_devices.return_value = CursorIterator(device_iterator())
+        from_dep_token.return_value = client
+        results = list(sync_dep_virtual_server_devices(server))
+
+        # the record is written, the operation is worth storing
+        self.assertEqual([action for _, action in results], ["updated"])
+        dep_device.refresh_from_db()
+        self.assertEqual(dep_device.last_op_type, "modified")
+        # but nobody needs an event saying Apple touched an attribute Zentral does not keep
+        post_event.assert_not_called()
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_posts_deleted_event(self, from_dep_token, post_event):
+        server = self.force_synced_server()
+        dep_device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([])
+        from_dep_token.return_value = client
+        list(sync_dep_virtual_server_devices(server, force_fetch=True))
+
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        # the record is still there, with last_op_type moved, so this is an update
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.metadata.machine_serial_number, dep_device.serial_number)
+        self.assertEqual(event.payload["object"]["prev_value"]["last_op_type"], "added")
+        self.assertEqual(event.payload["object"]["new_value"]["last_op_type"], "deleted")
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_events_share_one_id(self, from_dep_token, post_event):
+        server = self.force_synced_server()
+        serial_numbers = [get_random_string(10).upper() for _ in range(3)]
+
+        def device_iterator():
+            yield from [{'device_assigned_date': '2023-01-10T19:09:22Z',
+                         'op_date': '2023-06-17T15:41:06Z',
+                         'op_type': 'added',
+                         'serial_number': sn} for sn in serial_numbers]
+            return get_random_string(12)
+
+        client = Mock()
+        client.sync_devices.return_value = CursorIterator(device_iterator())
+        from_dep_token.return_value = client
+        list(sync_dep_virtual_server_devices(server))
+
+        events = [c.args[0] for c in post_event.call_args_list]
+        self.assertEqual(len(events), 3)
+        self.assertEqual(len({e.metadata.uuid for e in events}), 1)
+        self.assertEqual(sorted(e.metadata.index for e in events), [0, 1, 2])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_virtual_server")
+    def test_assign_dep_virtual_server_default_enrollment_posts_event(self, from_dep_virtual_server, post_event):
+        server, enrollment = self.force_server_with_default_enrollment()
+        device = force_dep_device(server=server, profile_status=DEPDevice.PROFILE_STATUS_EMPTY)
+        client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
+        client.assign_profile.return_value = {"devices": {device.serial_number: "SUCCESS"}}
+        client.get_devices.return_value = {
+            device.serial_number: {"profile_uuid": str(enrollment.uuid).upper().replace("-", ""),
+                                   "profile_status": "assigned"}
+        }
+        from_dep_virtual_server.return_value = client
+        assign_dep_virtual_server_default_enrollment(server)
+
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, DEPDeviceChangeEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        # Zentral did this one, not a synchronization, and the payload says so
+        self.assertEqual(event.payload["origin"], "default_enrollment_assignment")
+        self.assertIsNone(event.payload["object"]["prev_value"]["enrollment"])
+        self.assertEqual(event.payload["object"]["new_value"]["enrollment"],
+                         {"pk": enrollment.pk, "name": enrollment.name, "uuid": str(enrollment.uuid)})
+        self.assertEqual(event.metadata.objects["mdm_dep_enrollment"], [(enrollment.pk,)])
 
     @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
     def test_define_dep_profile(self, from_dep_token):

--- a/tests/mdm/test_dep_client.py
+++ b/tests/mdm/test_dep_client.py
@@ -1,0 +1,272 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from zentral.contrib.mdm.dep_client import (
+    DEFAULT_PAGINATION_LIMIT,
+    DEVICE_BATCH_SIZE,
+    DEPClient,
+    DEPClientError,
+)
+
+
+# what /account really answers, trimmed to the urls that matter here
+ACCOUNT_DETAIL = {
+    "org_name": "Yolo",
+    "server_uuid": "00000000000000000000000000000000",
+    "urls": [
+        {"uri": "/session", "http_method": ["GET"]},
+        {"uri": "/devices", "http_method": ["POST"]},
+        {"uri": "/server/devices", "http_method": ["POST"], "limit": {"default": 1000, "maximum": 1000}},
+        {"uri": "/devices/sync", "http_method": ["POST"], "limit": {"default": 1000, "maximum": 1000}},
+        {"uri": "/profile/devices", "http_method": ["DELETE", "POST", "PUT"]},
+        {"uri": "/devices/disown", "http_method": ["POST"]},
+    ],
+}
+
+
+def build_client():
+    return DEPClient("consumer-key", "consumer-secret", "access-token", "access-secret")
+
+
+def build_serial_numbers(count):
+    return [f"SN{idx:08d}" for idx in range(count)]
+
+
+class TestDEPClientAccountLimits(TestCase):
+    maxDiff = None
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_get_uri_limit(self, send_request):
+        send_request.return_value = ACCOUNT_DETAIL
+        client = build_client()
+        # advertised
+        self.assertEqual(client.get_uri_limit("/server/devices"), 1000)
+        self.assertEqual(client.get_uri_limit("/devices/sync"), 1000)
+        # listed, but with no limit
+        self.assertIsNone(client.get_uri_limit("/devices"))
+        self.assertIsNone(client.get_uri_limit("/profile/devices"))
+        self.assertIsNone(client.get_uri_limit("/devices/disown"))
+        # not listed at all
+        self.assertIsNone(client.get_uri_limit("/yolo"))
+        # the account detail is read once, not once per lookup
+        send_request.assert_called_once_with('account')
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_fetch_devices_pages_at_the_advertised_maximum(self, send_request):
+        send_request.side_effect = [
+            ACCOUNT_DETAIL,
+            {"devices": [], "more_to_follow": False, "cursor": "yolo"},
+        ]
+        list(build_client().fetch_devices())
+        self.assertEqual(send_request.call_args_list[0].args, ('account',))
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"], {"limit": 1000})
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_sync_devices_pages_at_the_advertised_maximum(self, send_request):
+        send_request.side_effect = [
+            ACCOUNT_DETAIL,
+            {"devices": [], "more_to_follow": False, "cursor": "fomo"},
+        ]
+        list(build_client().sync_devices("yolo"))
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"],
+                         {"limit": 1000, "cursor": "yolo"})
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_pagination_falls_back_when_nothing_is_advertised(self, send_request):
+        send_request.side_effect = [
+            {"org_name": "Zentral", "urls": [{"uri": "/server/devices", "http_method": ["POST"]}]},
+            {"devices": [], "more_to_follow": False, "cursor": "yolo"},
+        ]
+        list(build_client().fetch_devices())
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"],
+                         {"limit": DEFAULT_PAGINATION_LIMIT})
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_pagination_falls_back_when_the_account_detail_fails(self, send_request):
+        send_request.side_effect = [
+            DEPClientError("Could not perform operation", status_code=500),
+            {"devices": [], "more_to_follow": False, "cursor": "yolo"},
+        ]
+        # a virtual server whose account detail cannot be read still synchronizes
+        list(build_client().fetch_devices())
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"],
+                         {"limit": DEFAULT_PAGINATION_LIMIT})
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_get_uri_limit_tolerates_an_account_detail_that_is_not_json(self, send_request):
+        # send_request returns response.content when the body does not parse as JSON, so the
+        # account detail is not always a dict
+        send_request.return_value = b"<html>Service unavailable</html>"
+        client = build_client()
+        self.assertIsNone(client.get_uri_limit("/server/devices"))
+        self.assertEqual(client.get_pagination_limit("server/devices"), DEFAULT_PAGINATION_LIMIT)
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_account_detail_is_dropped_with_the_auth_session(self, send_request):
+        send_request.return_value = ACCOUNT_DETAIL
+        client = build_client()
+        session_response = Mock()
+        session_response.json.return_value = {"auth_session_token": "yolo"}
+        client.oauth_session = Mock()
+        client.oauth_session.get.return_value = session_response
+
+        self.assertEqual(client.get_uri_limit("/server/devices"), 1000)
+        self.assertEqual(client.get_uri_limit("/server/devices"), 1000)
+        self.assertEqual(len(send_request.call_args_list), 1)
+
+        # a renewed session may describe a different account, so what it advertised goes with it
+        client.get_auth_session_token(renew=True)
+        self.assertEqual(client.get_uri_limit("/server/devices"), 1000)
+        self.assertEqual(len(send_request.call_args_list), 2)
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_device_batch_size_is_not_worth_a_request_of_its_own(self, send_request):
+        send_request.return_value = ACCOUNT_DETAIL
+        # a single device operation does not pay a round trip to size a batch of one
+        self.assertEqual(build_client().get_device_batch_size("/devices"), DEVICE_BATCH_SIZE)
+        send_request.assert_not_called()
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_device_batch_size_falls_back_when_nothing_is_advertised(self, send_request):
+        send_request.return_value = ACCOUNT_DETAIL
+        client = build_client()
+        client.get_account()
+        # none of the device array endpoints advertises a limit today
+        for uri in ("/devices", "/profile/devices", "/devices/disown", "/profile"):
+            self.assertEqual(client.get_device_batch_size(uri), DEVICE_BATCH_SIZE)
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_device_batch_size_honours_an_advertised_limit(self, send_request):
+        # an account that does advertise one for a device array endpoint is obeyed, not overrun
+        send_request.return_value = {
+            "urls": [{"uri": "/profile/devices", "http_method": ["POST"],
+                      "limit": {"default": 250, "maximum": 250}}]
+        }
+        client = build_client()
+        client.get_account()
+        self.assertEqual(client.get_device_batch_size("/profile/devices"), 250)
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_assign_profile_splits_at_the_advertised_limit(self, send_request):
+        serial_numbers = build_serial_numbers(3)
+        send_request.side_effect = [
+            {"urls": [{"uri": "/profile/devices", "http_method": ["POST"],
+                       "limit": {"default": 2, "maximum": 2}}]},
+            {"devices": {sn: "SUCCESS" for sn in serial_numbers[:2]}},
+            {"devices": {serial_numbers[2]: "SUCCESS"}},
+        ]
+        client = build_client()
+        client.get_account()
+        response = client.assign_profile("8ecf1f2e-2b0a-4c1e-9a4f-2b3c4d5e6f70", serial_numbers)
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"]["devices"], serial_numbers[:2])
+        self.assertEqual(send_request.call_args_list[2].kwargs["json"]["devices"], serial_numbers[2:])
+        self.assertEqual(len(response["devices"]), 3)
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_explicit_batch_request_limit_wins(self, send_request):
+        send_request.return_value = {"devices": [], "more_to_follow": False, "cursor": "yolo"}
+        client = DEPClient("ck", "cs", "at", "as", batch_request_limit=7)
+        list(client.fetch_devices())
+        # Apple is not asked at all
+        self.assertEqual(len(send_request.call_args_list), 1)
+        self.assertEqual(send_request.call_args_list[0].kwargs["json"], {"limit": 7})
+
+
+class TestDEPClientDeviceChunks(TestCase):
+    maxDiff = None
+
+    def dep_client(self, batch_size=DEVICE_BATCH_SIZE):
+        # the limit resolution has its own tests above; here the size is fixed so that the
+        # splitting and the merging are the only things under test
+        client = build_client()
+        client.get_device_batch_size = lambda uri: batch_size
+        return client
+
+    # get_devices
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_get_devices_single_request(self, send_request):
+        serial_numbers = build_serial_numbers(2)
+        send_request.return_value = {
+            "devices": {sn: {"response_status": "SUCCESS", "model": "iPhone X"} for sn in serial_numbers}
+        }
+        devices = self.dep_client().get_devices(serial_numbers)
+        self.assertEqual(sorted(devices), serial_numbers)
+        send_request.assert_called_once_with('devices', 'POST', json={"devices": serial_numbers})
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_get_devices_over_the_limit_is_split(self, send_request):
+        serial_numbers = build_serial_numbers(DEVICE_BATCH_SIZE + 1)
+        send_request.side_effect = [
+            {"devices": {sn: {"response_status": "SUCCESS"} for sn in serial_numbers[:DEVICE_BATCH_SIZE]}},
+            {"devices": {sn: {"response_status": "SUCCESS"} for sn in serial_numbers[DEVICE_BATCH_SIZE:]}},
+        ]
+        devices = self.dep_client().get_devices(serial_numbers)
+        self.assertEqual(len(send_request.call_args_list), 2)
+        self.assertEqual(send_request.call_args_list[0].kwargs["json"],
+                         {"devices": serial_numbers[:DEVICE_BATCH_SIZE]})
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"],
+                         {"devices": serial_numbers[DEVICE_BATCH_SIZE:]})
+        self.assertEqual(sorted(devices), serial_numbers)
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_get_devices_skips_the_unsuccessful_ones(self, send_request):
+        serial_numbers = build_serial_numbers(2)
+        send_request.return_value = {
+            "devices": {serial_numbers[0]: {"response_status": "SUCCESS"},
+                        serial_numbers[1]: {"response_status": "NOT_ACCESSIBLE"}}
+        }
+        self.assertEqual(list(self.dep_client().get_devices(serial_numbers)), [serial_numbers[0]])
+
+    # assign_profile
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_assign_profile_single_request(self, send_request):
+        serial_numbers = build_serial_numbers(2)
+        profile_uuid = "8ecf1f2e-2b0a-4c1e-9a4f-2b3c4d5e6f70"
+        send_request.return_value = {"devices": {sn: "SUCCESS" for sn in serial_numbers}}
+        response = self.dep_client().assign_profile(profile_uuid, serial_numbers)
+        self.assertEqual(response, {"devices": {sn: "SUCCESS" for sn in serial_numbers}})
+        send_request.assert_called_once_with(
+            'profile/devices', 'POST',
+            json={"devices": serial_numbers, "profile_uuid": "8ECF1F2E2B0A4C1E9A4F2B3C4D5E6F70"}
+        )
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_assign_profile_over_the_limit_is_split(self, send_request):
+        serial_numbers = build_serial_numbers(DEVICE_BATCH_SIZE + 3)
+        send_request.side_effect = [
+            {"devices": {sn: "SUCCESS" for sn in serial_numbers[:DEVICE_BATCH_SIZE]}},
+            {"devices": {sn: "FAILED" for sn in serial_numbers[DEVICE_BATCH_SIZE:]}},
+        ]
+        response = self.dep_client().assign_profile("8ecf1f2e-2b0a-4c1e-9a4f-2b3c4d5e6f70", serial_numbers)
+        self.assertEqual(len(send_request.call_args_list), 2)
+        self.assertEqual(len(send_request.call_args_list[0].kwargs["json"]["devices"]), DEVICE_BATCH_SIZE)
+        self.assertEqual(send_request.call_args_list[1].kwargs["json"]["devices"],
+                         serial_numbers[DEVICE_BATCH_SIZE:])
+        # the statuses of every chunk are merged, the caller cannot tell there were two requests
+        self.assertEqual(len(response["devices"]), DEVICE_BATCH_SIZE + 3)
+        self.assertEqual(response["devices"][serial_numbers[0]], "SUCCESS")
+        self.assertEqual(response["devices"][serial_numbers[-1]], "FAILED")
+
+    # disown_devices
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_disown_devices_single_request(self, send_request):
+        serial_numbers = build_serial_numbers(1)
+        send_request.return_value = {"devices": {serial_numbers[0]: "SUCCESS"}}
+        response = self.dep_client().disown_devices(serial_numbers)
+        self.assertEqual(response, {"devices": {serial_numbers[0]: "SUCCESS"}})
+        send_request.assert_called_once_with('devices/disown', 'POST', json={"devices": serial_numbers})
+
+    @patch("zentral.contrib.mdm.dep_client.DEPClient.send_request")
+    def test_disown_devices_over_the_limit_is_split(self, send_request):
+        serial_numbers = build_serial_numbers(DEVICE_BATCH_SIZE + 1)
+        send_request.side_effect = [
+            {"devices": {sn: "SUCCESS" for sn in serial_numbers[:DEVICE_BATCH_SIZE]}},
+            {"devices": {sn: "SUCCESS" for sn in serial_numbers[DEVICE_BATCH_SIZE:]}},
+        ]
+        response = self.dep_client().disown_devices(serial_numbers)
+        self.assertEqual(len(send_request.call_args_list), 2)
+        self.assertEqual(len(response["devices"]), DEVICE_BATCH_SIZE + 1)

--- a/tests/mdm/test_enrollment_audit.py
+++ b/tests/mdm/test_enrollment_audit.py
@@ -10,7 +10,7 @@ from django.utils.crypto import get_random_string
 from accounts.models import User
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
-from zentral.contrib.mdm.dep_client import DEPClientError
+from zentral.contrib.mdm.dep_client import DEVICE_BATCH_SIZE, DEPClientError
 from zentral.core.events.base import AuditEvent
 
 from .utils import (force_acme_issuer, force_ota_enrollment, force_push_certificate,
@@ -203,6 +203,7 @@ class EnrollmentAuditEventTestCase(TestCase, LoginCase):
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_dep_enrollment_audit_event(self, post_event, from_dep_virtual_server):
         client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
         client.add_profile.return_value = {
             "profile_uuid": str(uuid.uuid4()).upper().replace("-", ""),
             "devices": {},

--- a/tests/mdm/test_setup_dep_enrollment.py
+++ b/tests/mdm/test_setup_dep_enrollment.py
@@ -10,6 +10,7 @@ from django.utils.crypto import get_random_string
 
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import MetaBusinessUnit
+from zentral.contrib.mdm.dep_client import DEVICE_BATCH_SIZE
 from zentral.contrib.mdm.models import DEPDevice, DEPEnrollment
 from zentral.utils.time import naive_utcnow
 
@@ -275,6 +276,7 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
     def test_create_dep_enrollment_post(self, from_dep_virtual_server):
         profile_uuid = uuid.uuid4()
         client = Mock()
+        client.get_device_batch_size.return_value = DEVICE_BATCH_SIZE
         client.add_profile.return_value = {
             "profile_uuid": str(profile_uuid).upper().replace("-", ""),
             "devices": {}

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -80,7 +80,8 @@ class MDMTasksTestCase(TestCase):
                     "updated": 0,
                 },
                 "requested_sync_type": "delta_sync",
-                "effective_sync_type": "delta_sync"
+                "effective_sync_type": "delta_sync",
+                "status": "SUCCESS",
             },
         )
         serial_number2 = get_random_string(10).upper()
@@ -110,7 +111,8 @@ class MDMTasksTestCase(TestCase):
                     "updated": 1,
                 },
                 "requested_sync_type": "full_sync",
-                "effective_sync_type": "full_sync"
+                "effective_sync_type": "full_sync",
+                "status": "SUCCESS",
             },
         )
 
@@ -149,9 +151,51 @@ class MDMTasksTestCase(TestCase):
                     "updated": 0,
                 },
                 "requested_sync_type": "delta_sync",
-                "effective_sync_type": "full_sync"
+                "effective_sync_type": "full_sync",
+                "status": "SUCCESS",
             },
         )
+
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_task_reraises_the_other_dep_errors(self, from_dep_token):
+        client = Mock()
+        client.sync_devices.side_effect = DEPClientError("Could not perform operation", error_code="YOLO")
+        from_dep_token.return_value = client
+        dep_virtual_server = force_dep_virtual_server()
+        token = dep_virtual_server.token
+        token.sync_cursor = "yolo-cursor"
+        token.save()
+
+        # only an expired cursor is handled, anything else has to surface
+        with self.assertRaises(DEPClientError):
+            sync_dep_virtual_server_devices_task(dep_virtual_server.pk)
+        client.fetch_devices.assert_not_called()
+
+    @patch("zentral.contrib.mdm.tasks.try_lock_dep_virtual_server_sync")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_task_already_running(self, from_dep_token, try_lock):
+        try_lock.return_value = False
+        dep_virtual_server = force_dep_virtual_server()
+
+        result = sync_dep_virtual_server_devices_task(dep_virtual_server.pk)
+        self.assertEqual(
+            result,
+            {
+                "dep_virtual_server": {
+                    "name": dep_virtual_server.name,
+                    "pk": dep_virtual_server.pk,
+                },
+                "operations": {
+                    "created": 0,
+                    "updated": 0,
+                },
+                "requested_sync_type": "delta_sync",
+                "effective_sync_type": "delta_sync",
+                "status": "SKIPPED",
+            },
+        )
+        # Apple is never contacted
+        from_dep_token.assert_not_called()
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     @patch("zentral.contrib.mdm.software_updates.requests.get")

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -2,18 +2,22 @@ import json
 import os.path
 from unittest.mock import Mock, patch
 
+from celery.exceptions import MaxRetriesExceededError, Retry
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 
+from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.dep import DEPClientError
 from zentral.contrib.mdm.dep_client import CursorIterator
 from zentral.contrib.mdm.tasks import (
+    assign_dep_virtual_server_default_enrollment_task,
     bulk_assign_location_asset_task,
     sync_dep_virtual_server_devices_task,
     sync_software_updates_task,
 )
 
 from .utils import (
+    force_dep_enrollment,
     force_dep_virtual_server,
     force_location_asset,
 )
@@ -196,6 +200,120 @@ class MDMTasksTestCase(TestCase):
         )
         # Apple is never contacted
         from_dep_token.assert_not_called()
+
+    # default enrollment assignment
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.apply_async")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_task_schedules_the_assignment(self, from_dep_token, apply_async):
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([])
+        from_dep_token.return_value = client
+        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
+        dep_virtual_server = enrollment.virtual_server
+        dep_virtual_server.default_enrollment = enrollment
+        dep_virtual_server.save()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = sync_dep_virtual_server_devices_task(dep_virtual_server.pk)
+        self.assertEqual(result["status"], "SUCCESS")
+        apply_async.assert_called_once_with((dep_virtual_server.pk,), {})
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.apply_async")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_task_passes_the_task_user_on(self, from_dep_token, apply_async):
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([])
+        from_dep_token.return_value = client
+        enrollment = force_dep_enrollment(MetaBusinessUnit.objects.create(name=get_random_string(12)))
+        dep_virtual_server = enrollment.virtual_server
+        dep_virtual_server.default_enrollment = enrollment
+        dep_virtual_server.save()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            sync_dep_virtual_server_devices_task(dep_virtual_server.pk, task_user=42)
+        # the assignment shows up in the task list of whoever asked for the synchronization
+        apply_async.assert_called_once_with((dep_virtual_server.pk,), {"task_user": 42})
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.apply_async")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_task_no_default_enrollment_no_assignment(
+        self, from_dep_token, apply_async
+    ):
+        client = Mock()
+        client.fetch_devices.return_value = CursorIterator([])
+        from_dep_token.return_value = client
+        dep_virtual_server = force_dep_virtual_server()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            sync_dep_virtual_server_devices_task(dep_virtual_server.pk)
+        apply_async.assert_not_called()
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment")
+    def test_assign_dep_virtual_server_default_enrollment_task(self, assign):
+        dep_virtual_server = force_dep_virtual_server()
+        assign.return_value = {"assigned": 3, "failed": 1}
+        self.assertEqual(
+            assign_dep_virtual_server_default_enrollment_task(dep_virtual_server.pk),
+            {
+                "dep_virtual_server": {
+                    "name": dep_virtual_server.name,
+                    "pk": dep_virtual_server.pk,
+                },
+                "operations": {"assigned": 3, "failed": 1},
+                "status": "SUCCESS",
+            },
+        )
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.retry")
+    @patch("zentral.contrib.mdm.tasks.try_lock_dep_virtual_server_sync")
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment")
+    def test_assign_dep_virtual_server_default_enrollment_task_already_running_retries(
+        self, assign, try_lock, retry
+    ):
+        try_lock.return_value = False
+        retry.side_effect = Retry()
+        dep_virtual_server = force_dep_virtual_server()
+        # waiting for the next synchronization to schedule this again would delay the assignment
+        # by a whole interval, and the work list is derived from the database
+        with self.assertRaises(Retry):
+            assign_dep_virtual_server_default_enrollment_task(dep_virtual_server.pk)
+        assign.assert_not_called()
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.retry")
+    @patch("zentral.contrib.mdm.tasks.try_lock_dep_virtual_server_sync")
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment")
+    def test_assign_dep_virtual_server_default_enrollment_task_skipped_after_the_last_retry(
+        self, assign, try_lock, retry
+    ):
+        try_lock.return_value = False
+        retry.side_effect = MaxRetriesExceededError()
+        dep_virtual_server = force_dep_virtual_server()
+        # the next synchronization schedules it again, so giving up is not losing the work
+        result = assign_dep_virtual_server_default_enrollment_task(dep_virtual_server.pk)
+        self.assertEqual(result["status"], "SKIPPED")
+        self.assertEqual(result["operations"], {"assigned": 0, "failed": 0})
+        assign.assert_not_called()
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.retry")
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment")
+    def test_assign_dep_virtual_server_default_enrollment_task_retries_throttled(self, assign, retry):
+        dep_virtual_server = force_dep_virtual_server()
+        error = DEPClientError("Too many requests", status_code=429)
+        assign.side_effect = error
+        retry.side_effect = Retry()
+        with self.assertRaises(Retry):
+            assign_dep_virtual_server_default_enrollment_task(dep_virtual_server.pk)
+        self.assertEqual(retry.call_args.kwargs["exc"], error)
+
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.retry")
+    @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment")
+    def test_assign_dep_virtual_server_default_enrollment_task_does_not_retry_rejected(self, assign, retry):
+        dep_virtual_server = force_dep_virtual_server()
+        assign.side_effect = DEPClientError("Nope", status_code=400)
+        with self.assertRaises(DEPClientError):
+            assign_dep_virtual_server_default_enrollment_task(dep_virtual_server.pk)
+        retry.assert_not_called()
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     @patch("zentral.contrib.mdm.software_updates.requests.get")

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -82,6 +82,8 @@ class MDMTasksTestCase(TestCase):
                 "operations": {
                     "created": 1,
                     "updated": 0,
+                    "unchanged": 0,
+                    "marked_deleted": 0,
                 },
                 "requested_sync_type": "delta_sync",
                 "effective_sync_type": "delta_sync",
@@ -111,8 +113,11 @@ class MDMTasksTestCase(TestCase):
                     "pk": dep_virtual_server.pk,
                 },
                 "operations": {
+                    # the device of the first synchronization is reported again, unchanged
                     "created": 1,
-                    "updated": 1,
+                    "updated": 0,
+                    "unchanged": 1,
+                    "marked_deleted": 0,
                 },
                 "requested_sync_type": "full_sync",
                 "effective_sync_type": "full_sync",
@@ -153,6 +158,8 @@ class MDMTasksTestCase(TestCase):
                 "operations": {
                     "created": 1,
                     "updated": 0,
+                    "unchanged": 0,
+                    "marked_deleted": 0,
                 },
                 "requested_sync_type": "delta_sync",
                 "effective_sync_type": "full_sync",
@@ -192,6 +199,8 @@ class MDMTasksTestCase(TestCase):
                 "operations": {
                     "created": 0,
                     "updated": 0,
+                    "unchanged": 0,
+                    "marked_deleted": 0,
                 },
                 "requested_sync_type": "delta_sync",
                 "effective_sync_type": "delta_sync",

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -210,6 +210,33 @@ class MDMTasksTestCase(TestCase):
         # Apple is never contacted
         from_dep_token.assert_not_called()
 
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.contrib.mdm.dep.DEPClient.from_dep_token")
+    def test_sync_dep_virtual_server_devices_task_rebuilds_the_event_request(self, from_dep_token, post_event):
+        client = Mock()
+        serial_number = get_random_string(10).upper()
+        client.fetch_devices.return_value = CursorIterator([
+            {"device_assigned_date": "2023-01-10T19:09:22Z", "serial_number": serial_number}
+        ])
+        from_dep_token.return_value = client
+        dep_virtual_server = force_dep_virtual_server()
+
+        sync_dep_virtual_server_devices_task(
+            dep_virtual_server.pk,
+            serialized_event_request={
+                "method": "POST",
+                "path": "/api/mdm/dep/virtual_servers/1/sync_devices/",
+                "ip": "127.0.0.1",
+                "user": {"id": 42, "username": "yolo", "email": "yolo@example.com"},
+            },
+        )
+
+        # the events of a synchronization somebody asked for say who asked for it
+        self.assertEqual(len(post_event.call_args_list), 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertEqual(event.metadata.request.method, "POST")
+        self.assertEqual(event.metadata.request.user.username, "yolo")
+
     # default enrollment assignment
 
     @patch("zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task.apply_async")

--- a/zentral/contrib/mdm/api_views/dep.py
+++ b/zentral/contrib/mdm/api_views/dep.py
@@ -5,7 +5,7 @@ from django_filters import rest_framework as filters
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.filters import OrderingFilter
-from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -23,6 +23,7 @@ from zentral.utils.drf import (
     DefaultDjangoModelPermissions,
     DjangoPermissionRequired,
     MaxLimitOffsetPagination,
+    RetrieveUpdateAPIViewWithAudit,
 )
 
 
@@ -66,10 +67,12 @@ class DEPDeviceList(ListAPIView):
     pagination_class = MaxLimitOffsetPagination
 
 
-class DEPDeviceDetail(RetrieveUpdateAPIView):
+class DEPDeviceDetail(RetrieveUpdateAPIViewWithAudit):
     queryset = DEPDevice.objects.all()
     serializer_class = DEPDeviceSerializer
-    permission_classes = [DefaultDjangoModelPermissions]
+
+    def get_audit_machine_serial_number(self):
+        return self.get_object().serial_number
 
 
 class DEPVirtualServerBetaTokensView(RetrieveAPIView):

--- a/zentral/contrib/mdm/api_views/dep.py
+++ b/zentral/contrib/mdm/api_views/dep.py
@@ -18,6 +18,7 @@ from zentral.contrib.mdm.serializers import (
     DEPVirtualServerBetaTokensSerializer,
 )
 from zentral.contrib.mdm.tasks import sync_dep_virtual_server_devices_task
+from zentral.core.events.base import EventRequest
 from zentral.utils.drf import (
     DefaultDjangoModelPermissions,
     DjangoPermissionRequired,
@@ -40,6 +41,7 @@ class DEPVirtualServerSyncDevicesView(GenericAPIView):
         task = sync_dep_virtual_server_devices_task.apply_async(
             (server.pk,),
             {"force_full_sync": full_sync,
+             "serialized_event_request": EventRequest.build_from_request(request).serialize(),
              "task_user": request.user.id}
         )
         serializer = self.serializer_class.from_task(task=task)

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -10,6 +10,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from dateutil import parser
 from django.db import connection
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 
@@ -18,7 +19,7 @@ from zentral.utils.certificates import split_certificate_chain
 from zentral.utils.time import naive_utcnow
 
 from .crypto import decrypt_cms_payload_with_pem_privkey
-from .dep_client import DEPClient, DEPClientError
+from .dep_client import DEVICE_BATCH_SIZE, DEPClient, DEPClientError, iter_device_chunks
 from .models import DEPDevice, DEPEnrollment
 
 logger = logging.getLogger("zentral.contrib.mdm.dep")
@@ -217,20 +218,11 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
     known_enrollments = {e.uuid: e for e in dep_virtual_server.depenrollment_set.all()}
 
     found_serial_numbers = []
-    unassigned_serial_numbers = []
 
     for device in devices:
         serial_number = device["serial_number"]
         found_serial_numbers.append(serial_number)
         defaults = {}
-
-        # default assignment
-        if (
-            device.get("op_type") != "deleted"
-            and (not device.get("profile_uuid") or device.get("profile_status") == "removed")
-            and dep_virtual_server.default_enrollment
-        ):
-            unassigned_serial_numbers.append(serial_number)
 
         # sync
         if not fetch:
@@ -252,6 +244,13 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
                 defaults["last_op_date"] = op_date
         else:
             defaults["disowned_at"] = None
+            # a fetch reports the fleet and does not record operations, the deleted devices are
+            # the ones it leaves out. A device it reports as deleted anyway is marked like them:
+            # the default enrollment candidates are derived from the stored record, so a deletion
+            # Apple reported has to be in it. The op_date stays out, both to keep a fetch free of
+            # operation dates and so that it cannot make a later real operation look stale.
+            if device.get("op_type") == DEPDevice.OP_TYPE_DELETED:
+                defaults["last_op_type"] = DEPDevice.OP_TYPE_DELETED
 
         defaults.update(dep_device_update_dict(device, known_enrollments))
 
@@ -271,26 +270,48 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
                           .exclude(serial_number__in=found_serial_numbers)
                           .update(last_op_type=DEPDevice.OP_TYPE_DELETED,
                                   updated_at=naive_utcnow()))
-    if unassigned_serial_numbers:
-        default_enrollment = dep_virtual_server.default_enrollment
-        # assign the default profile
-        response = client.assign_profile(default_enrollment.uuid, unassigned_serial_numbers)
+
+
+def iter_unassigned_dep_device_serial_numbers(dep_virtual_server, chunk_size=DEVICE_BATCH_SIZE):
+    # the database cursor is read one Apple request worth of rows at a time
+    return (DEPDevice.objects.filter(virtual_server=dep_virtual_server, disowned_at__isnull=True)
+                             .exclude(last_op_type=DEPDevice.OP_TYPE_DELETED)
+                             .filter(Q(profile_uuid__isnull=True)
+                                     | Q(profile_status=DEPDevice.PROFILE_STATUS_REMOVED))
+                             .values_list("serial_number", flat=True)
+                             .iterator(chunk_size=chunk_size))
+
+
+def assign_dep_virtual_server_default_enrollment(dep_virtual_server):
+    result = {"assigned": 0, "failed": 0}
+    default_enrollment = dep_virtual_server.default_enrollment
+    if default_enrollment is None:
+        return result
+    client = DEPClient.from_dep_virtual_server(dep_virtual_server)
+    # one Apple request per chunk, each applied before the next one is sent, so a chunk that fails
+    # does not discard the work of the chunks before it
+    batch_size = client.get_device_batch_size("/profile/devices")
+    for serial_numbers in iter_device_chunks(
+        iter_unassigned_dep_device_serial_numbers(dep_virtual_server, batch_size), batch_size
+    ):
+        response = client.assign_profile(default_enrollment.uuid, serial_numbers)
         success_devices = []
-        for serial_number, result in response.get("devices").items():
-            if result == "SUCCESS":
+        for serial_number, status in response["devices"].items():
+            if status == "SUCCESS":
                 success_devices.append(serial_number)
             else:
+                result["failed"] += 1
                 logger.error("Could not assign profile %s to device %s: %s",
-                             default_enrollment.uuid, serial_number, result)
+                             default_enrollment.uuid, serial_number, status)
         if success_devices:
-            # To avoid some performance issues, only update the devices in the database.
-            # The next sync will fix the differences.
             (DEPDevice.objects.filter(virtual_server=dep_virtual_server,
                                       serial_number__in=success_devices)
                               .update(profile_uuid=default_enrollment.uuid,
                                       profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
                                       enrollment=default_enrollment,
                                       updated_at=naive_utcnow()))
+            result["assigned"] += len(success_devices)
+    return result
 
 
 def assign_dep_device_profile(dep_device, dep_profile):

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import uuid
+from itertools import count
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -20,6 +21,11 @@ from zentral.utils.time import naive_utcnow
 
 from .crypto import decrypt_cms_payload_with_pem_privkey
 from .dep_client import DEVICE_BATCH_SIZE, DEPClient, DEPClientError, iter_device_chunks
+from .events.dep import (
+    ORIGIN_DEFAULT_ENROLLMENT_ASSIGNMENT,
+    DEPDeviceChangeEvent,
+    build_dep_device_change_event,
+)
 from .models import DEPDevice, DEPEnrollment
 
 logger = logging.getLogger("zentral.contrib.mdm.dep")
@@ -210,8 +216,21 @@ DEP_DEVICE_UPDATED = "updated"
 DEP_DEVICE_UNCHANGED = "unchanged"
 DEP_DEVICE_MARKED_DELETED = "marked_deleted"
 
+# a delta synchronization reports operations for attributes Zentral does not store. A device whose
+# stored record only moved because of the operation itself has not really changed.
+UNEVENTFUL_ATTRS = frozenset(["last_op_date", "last_op_type"])
 
-def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
+
+def is_eventful_dep_device_change(prev_value, new_value):
+    changed = set(k for k, v in new_value.items() if prev_value.get(k) != v)
+    if changed - UNEVENTFUL_ATTRS:
+        return True
+    # a deletion is worth reporting even when it is all that moved
+    return (new_value.get("last_op_type") == DEPDevice.OP_TYPE_DELETED
+            and prev_value.get("last_op_type") != DEPDevice.OP_TYPE_DELETED)
+
+
+def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, event_request=None):
     """Yield a (DEP device, action) pair for every device Apple reported, plus the ones it stopped
     reporting on a full fetch."""
     dep_token = dep_virtual_server.token
@@ -224,6 +243,17 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
         devices = client.sync_devices(dep_token.sync_cursor)
 
     known_enrollments = {e.uuid: e for e in dep_virtual_server.depenrollment_set.all()}
+
+    event_uuid = uuid.uuid4()
+    event_index = 0
+
+    def post_event(dep_device, action, prev_value=None):
+        nonlocal event_index
+        build_dep_device_change_event(
+            dep_device, action, prev_value=prev_value,
+            event_uuid=event_uuid, event_index=event_index, event_request=event_request,
+        ).post()
+        event_index += 1
 
     found_serial_numbers = []
 
@@ -271,6 +301,7 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
             dep_device = DEPDevice.objects.create(virtual_server=dep_virtual_server,
                                                   serial_number=serial_number,
                                                   **defaults)
+            post_event(dep_device, DEPDeviceChangeEvent.Action.CREATED)
             yield dep_device, DEP_DEVICE_CREATED
             continue
 
@@ -279,10 +310,13 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
         prev_value = dep_device.serialize_for_event()
         for attr, val in defaults.items():
             setattr(dep_device, attr, val)
-        if dep_device.serialize_for_event() == prev_value:
+        new_value = dep_device.serialize_for_event()
+        if new_value == prev_value:
             yield dep_device, DEP_DEVICE_UNCHANGED
             continue
         dep_device.save()
+        if is_eventful_dep_device_change(prev_value, new_value):
+            post_event(dep_device, DEPDeviceChangeEvent.Action.UPDATED, prev_value=prev_value)
         yield dep_device, DEP_DEVICE_UPDATED
 
     dep_token.sync_cursor = devices.cursor
@@ -298,13 +332,17 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
                              .exclude(serial_number__in=found_serial_numbers)
                              .exclude(last_op_type=DEPDevice.OP_TYPE_DELETED)
         )
+        prev_values = {}
         for dep_device in deleted_devices:
+            prev_values[dep_device.pk] = dep_device.serialize_for_event()
             dep_device.last_op_type = DEPDevice.OP_TYPE_DELETED
             dep_device.updated_at = now
         if deleted_devices:
             # bulk_update bypasses save(), hence the updated_at above
             DEPDevice.objects.bulk_update(deleted_devices, ["last_op_type", "updated_at"])
         for dep_device in deleted_devices:
+            # the record stays, with last_op_type moved to deleted, so this is an update
+            post_event(dep_device, DEPDeviceChangeEvent.Action.UPDATED, prev_value=prev_values[dep_device.pk])
             yield dep_device, DEP_DEVICE_MARKED_DELETED
 
 
@@ -319,13 +357,20 @@ def iter_unassigned_dep_device_serial_numbers(dep_virtual_server, chunk_size=DEV
 
 
 def apply_dep_device_updates(dep_virtual_server, updated_devices, known_enrollments):
-    """Write back what Apple reports for a batch of devices, and return how many were written."""
+    """Write back what Apple reports for a batch of devices.
+
+    Returns the (DEP device, previous serialization) pairs it really changed, and how many it
+    wrote, which is not the same number: Apple can report a device Zentral already agreed with.
+    """
     dep_devices = []
+    prev_values = {}
     update_fields = {"updated_at"}
     now = naive_utcnow()
-    for dep_device in DEPDevice.objects.filter(virtual_server=dep_virtual_server,
-                                               serial_number__in=list(updated_devices)):
+    for dep_device in (DEPDevice.objects.select_related("virtual_server", "enrollment")
+                                        .filter(virtual_server=dep_virtual_server,
+                                                serial_number__in=list(updated_devices))):
         update_d = dep_device_update_dict(updated_devices[dep_device.serial_number], known_enrollments)
+        prev_values[dep_device.pk] = dep_device.serialize_for_event()
         update_fields.update(update_d)
         for attr, val in update_d.items():
             setattr(dep_device, attr, val)
@@ -334,7 +379,9 @@ def apply_dep_device_updates(dep_virtual_server, updated_devices, known_enrollme
     if dep_devices:
         # bulk_update bypasses save(), hence the updated_at above
         DEPDevice.objects.bulk_update(dep_devices, sorted(update_fields))
-    return len(dep_devices)
+    changes = [(dep_device, prev_values[dep_device.pk]) for dep_device in dep_devices
+               if prev_values[dep_device.pk] != dep_device.serialize_for_event()]
+    return changes, len(dep_devices)
 
 
 def assign_dep_virtual_server_default_enrollment(dep_virtual_server):
@@ -344,6 +391,8 @@ def assign_dep_virtual_server_default_enrollment(dep_virtual_server):
         return result
     client = DEPClient.from_dep_virtual_server(dep_virtual_server)
     known_enrollments = {e.uuid: e for e in dep_virtual_server.depenrollment_set.all()}
+    event_uuid = uuid.uuid4()
+    event_indexes = count()
     # one Apple request per chunk, each applied before the next one is sent, so a chunk that fails
     # does not discard the work of the chunks before it
     batch_size = client.get_device_batch_size("/profile/devices")
@@ -368,7 +417,16 @@ def assign_dep_virtual_server_default_enrollment(dep_virtual_server):
             if serial_number not in updated_devices:
                 logger.error("Device %s assigned to profile %s but not reported by Apple",
                              serial_number, default_enrollment.uuid)
-        result["assigned"] += apply_dep_device_updates(dep_virtual_server, updated_devices, known_enrollments)
+        changes, written = apply_dep_device_updates(dep_virtual_server, updated_devices, known_enrollments)
+        result["assigned"] += written
+        for dep_device, prev_value in changes:
+            build_dep_device_change_event(
+                dep_device, DEPDeviceChangeEvent.Action.UPDATED,
+                prev_value=prev_value,
+                origin=ORIGIN_DEFAULT_ENROLLMENT_ASSIGNMENT,
+                event_uuid=event_uuid,
+                event_index=next(event_indexes),
+            ).post()
     return result
 
 

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -318,11 +318,22 @@ def define_dep_profile(dep_enrollment: DEPEnrollment):
     dep_virtual_server = dep_enrollment.virtual_server
     dep_client = DEPClient.from_dep_virtual_server(dep_virtual_server)
     profile_payload = serialize_dep_profile(dep_enrollment)
+    # the profile carries its devices, but Apple caps how many a request can hold. The profile is
+    # created with the first batch, the rest is assigned to it once it has a UUID.
+    batch_size = dep_client.get_device_batch_size("/profile")
+    extra_serial_numbers = profile_payload["devices"][batch_size:]
+    profile_payload["devices"] = profile_payload["devices"][:batch_size]
 
     profile_response = dep_client.add_profile(profile_payload)
 
     dep_enrollment.uuid = profile_response["profile_uuid"]
     dep_enrollment.save()
+
+    device_statuses = dict(profile_response["devices"])
+    if extra_serial_numbers:
+        device_statuses.update(
+            dep_client.assign_profile(dep_enrollment.uuid, extra_serial_numbers)["devices"]
+        )
 
     result = {
         "pk": dep_enrollment.pk,
@@ -336,7 +347,7 @@ def define_dep_profile(dep_enrollment: DEPEnrollment):
         }
     }
 
-    for serial_number, status in profile_response["devices"].items():
+    for serial_number, status in device_statuses.items():
         try:
             result["devices"][status.lower()].append(serial_number)
         except KeyError:

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -264,10 +264,13 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
     dep_token.last_synced_at = timezone.now()
     dep_token.save()
     if fetch:
-        # mark all other existing token devices as deleted
+        # mark all other existing token devices as deleted.
+        # a queryset update bypasses save(), so auto_now does not fire and updated_at has to be
+        # written by hand, here and in the other bulk updates of the DEP devices
         (DEPDevice.objects.filter(virtual_server=dep_virtual_server)
                           .exclude(serial_number__in=found_serial_numbers)
-                          .update(last_op_type=DEPDevice.OP_TYPE_DELETED))
+                          .update(last_op_type=DEPDevice.OP_TYPE_DELETED,
+                                  updated_at=naive_utcnow()))
     if unassigned_serial_numbers:
         default_enrollment = dep_virtual_server.default_enrollment
         # assign the default profile
@@ -286,8 +289,8 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
                                       serial_number__in=success_devices)
                               .update(profile_uuid=default_enrollment.uuid,
                                       profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
-                                      profile_assign_time=naive_utcnow(),
-                                      enrollment=default_enrollment))
+                                      enrollment=default_enrollment,
+                                      updated_at=naive_utcnow()))
 
 
 def assign_dep_device_profile(dep_device, dep_profile):
@@ -347,14 +350,15 @@ def define_dep_profile(dep_enrollment: DEPEnrollment):
                                   serial_number__in=result["devices"]["success"])
                           .update(profile_uuid=dep_enrollment.uuid,
                                   profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
-                                  profile_assign_time=naive_utcnow(),
-                                  enrollment=dep_enrollment))
+                                  enrollment=dep_enrollment,
+                                  updated_at=naive_utcnow()))
 
     # mark unaccessible devices as deleted
     if result["devices"]["not_accessible"]:
         (DEPDevice.objects.filter(virtual_server=dep_virtual_server,
                                   serial_number__in=result["devices"]["not_accessible"])
-                          .update(last_op_type=DEPDevice.OP_TYPE_DELETED))
+                          .update(last_op_type=DEPDevice.OP_TYPE_DELETED,
+                                  updated_at=naive_utcnow()))
 
     if result["devices"]["failed"]:
         logger.error("Define DEP profile %s response has failed devices", dep_enrollment.pk)
@@ -396,5 +400,6 @@ def disown_dep_device(dep_device):
     except AssertionError:
         raise DEPClientError("Unknown result")
     if result == "SUCCESS":
-        DEPDevice.objects.filter(pk=dep_device.pk).update(disowned_at=naive_utcnow())
+        now = naive_utcnow()
+        DEPDevice.objects.filter(pk=dep_device.pk).update(disowned_at=now, updated_at=now)
     return result

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -282,12 +282,32 @@ def iter_unassigned_dep_device_serial_numbers(dep_virtual_server, chunk_size=DEV
                              .iterator(chunk_size=chunk_size))
 
 
+def apply_dep_device_updates(dep_virtual_server, updated_devices, known_enrollments):
+    """Write back what Apple reports for a batch of devices, and return how many were written."""
+    dep_devices = []
+    update_fields = {"updated_at"}
+    now = naive_utcnow()
+    for dep_device in DEPDevice.objects.filter(virtual_server=dep_virtual_server,
+                                               serial_number__in=list(updated_devices)):
+        update_d = dep_device_update_dict(updated_devices[dep_device.serial_number], known_enrollments)
+        update_fields.update(update_d)
+        for attr, val in update_d.items():
+            setattr(dep_device, attr, val)
+        dep_device.updated_at = now
+        dep_devices.append(dep_device)
+    if dep_devices:
+        # bulk_update bypasses save(), hence the updated_at above
+        DEPDevice.objects.bulk_update(dep_devices, sorted(update_fields))
+    return len(dep_devices)
+
+
 def assign_dep_virtual_server_default_enrollment(dep_virtual_server):
     result = {"assigned": 0, "failed": 0}
     default_enrollment = dep_virtual_server.default_enrollment
     if default_enrollment is None:
         return result
     client = DEPClient.from_dep_virtual_server(dep_virtual_server)
+    known_enrollments = {e.uuid: e for e in dep_virtual_server.depenrollment_set.all()}
     # one Apple request per chunk, each applied before the next one is sent, so a chunk that fails
     # does not discard the work of the chunks before it
     batch_size = client.get_device_batch_size("/profile/devices")
@@ -303,14 +323,16 @@ def assign_dep_virtual_server_default_enrollment(dep_virtual_server):
                 result["failed"] += 1
                 logger.error("Could not assign profile %s to device %s: %s",
                              default_enrollment.uuid, serial_number, status)
-        if success_devices:
-            (DEPDevice.objects.filter(virtual_server=dep_virtual_server,
-                                      serial_number__in=success_devices)
-                              .update(profile_uuid=default_enrollment.uuid,
-                                      profile_status=DEPDevice.PROFILE_STATUS_ASSIGNED,
-                                      enrollment=default_enrollment,
-                                      updated_at=naive_utcnow()))
-            result["assigned"] += len(success_devices)
+        if not success_devices:
+            continue
+        # read the records back rather than assume what the assignment made of them: the profile
+        # status is Apple's to decide, and the assignment time is Apple's to stamp
+        updated_devices = client.get_devices(success_devices)
+        for serial_number in success_devices:
+            if serial_number not in updated_devices:
+                logger.error("Device %s assigned to profile %s but not reported by Apple",
+                             serial_number, default_enrollment.uuid)
+        result["assigned"] += apply_dep_device_updates(dep_virtual_server, updated_devices, known_enrollments)
     return result
 
 

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from dateutil import parser
-from django.db import connection, transaction
+from django.db import connection
 from django.urls import reverse
 from django.utils import timezone
 
@@ -192,21 +192,19 @@ def dep_device_update_dict(device, known_enrollments=None):
     return update_d
 
 
-def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False, lock_timeout=600):
-    PG_ADVISORY_LOCK_ID = 12345678
-    with transaction.atomic():
-        with connection.cursor() as cursor:
-            cursor.execute("SET LOCAL lock_timeout = %s", [f"{lock_timeout}s"])
-            logger.info("Acquire advisory lock %s for DEP virtual server %s",
-                        PG_ADVISORY_LOCK_ID, dep_virtual_server.pk)
-            cursor.execute("SELECT pg_advisory_xact_lock(%s, %s)",
-                           [PG_ADVISORY_LOCK_ID, dep_virtual_server.pk])
-            logger.info("Advisory lock %s for DEP virtual server %s acquired",
-                        PG_ADVISORY_LOCK_ID, dep_virtual_server.pk)
-        yield from _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch)
+# must not collide with the other advisory lock IDs, see zentral.contrib.monolith.tasks
+SYNC_DEP_VIRTUAL_SERVER_LOCK_ID = 12345678
 
 
-def _sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
+def try_lock_dep_virtual_server_sync(dep_virtual_server_pk):
+    # transaction scoped: released on commit, on rollback, and if the connection dies
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_try_advisory_xact_lock(%s, %s)",
+                       [SYNC_DEP_VIRTUAL_SERVER_LOCK_ID, dep_virtual_server_pk])
+        return cursor.fetchone()[0]
+
+
+def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
     dep_token = dep_virtual_server.token
     client = DEPClient.from_dep_token(dep_token)
     if force_fetch or not dep_token.sync_cursor:

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -205,7 +205,15 @@ def try_lock_dep_virtual_server_sync(dep_virtual_server_pk):
         return cursor.fetchone()[0]
 
 
+DEP_DEVICE_CREATED = "created"
+DEP_DEVICE_UPDATED = "updated"
+DEP_DEVICE_UNCHANGED = "unchanged"
+DEP_DEVICE_MARKED_DELETED = "marked_deleted"
+
+
 def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
+    """Yield a (DEP device, action) pair for every device Apple reported, plus the ones it stopped
+    reporting on a full fetch."""
     dep_token = dep_virtual_server.token
     client = DEPClient.from_dep_token(dep_token)
     if force_fetch or not dep_token.sync_cursor:
@@ -224,6 +232,15 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
         found_serial_numbers.append(serial_number)
         defaults = {}
 
+        # the stored record, needed to tell a real change from a device Apple reported again
+        # unchanged. Both foreign keys are dereferenced by serialize_for_event().
+        try:
+            dep_device = (DEPDevice.objects.select_related("virtual_server", "enrollment")
+                                           .get(virtual_server=dep_virtual_server,
+                                                serial_number=serial_number))
+        except DEPDevice.DoesNotExist:
+            dep_device = None
+
         # sync
         if not fetch:
             op_type = device["op_type"]
@@ -232,10 +249,6 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
             op_date = parser.parse(device["op_date"])
             if timezone.is_aware(op_date):
                 op_date = timezone.make_naive(op_date)
-            try:
-                dep_device = DEPDevice.objects.get(virtual_server=dep_virtual_server, serial_number=serial_number)
-            except DEPDevice.DoesNotExist:
-                dep_device = None
             if dep_device and dep_device.last_op_date and dep_device.last_op_date > op_date:
                 # already applied a newer operation. skip stalled one.
                 continue
@@ -254,22 +267,45 @@ def sync_dep_virtual_server_devices(dep_virtual_server, force_fetch=False):
 
         defaults.update(dep_device_update_dict(device, known_enrollments))
 
-        yield DEPDevice.objects.update_or_create(
-            virtual_server=dep_virtual_server,
-            serial_number=serial_number,
-            defaults=defaults
-        )
+        if dep_device is None:
+            dep_device = DEPDevice.objects.create(virtual_server=dep_virtual_server,
+                                                  serial_number=serial_number,
+                                                  **defaults)
+            yield dep_device, DEP_DEVICE_CREATED
+            continue
+
+        # compare the serializations, not the attributes: the values parsed from the DEP API are
+        # aware datetimes and the stored ones are naive, and serialize_for_event() makes both naive
+        prev_value = dep_device.serialize_for_event()
+        for attr, val in defaults.items():
+            setattr(dep_device, attr, val)
+        if dep_device.serialize_for_event() == prev_value:
+            yield dep_device, DEP_DEVICE_UNCHANGED
+            continue
+        dep_device.save()
+        yield dep_device, DEP_DEVICE_UPDATED
+
     dep_token.sync_cursor = devices.cursor
     dep_token.last_synced_at = timezone.now()
     dep_token.save()
     if fetch:
-        # mark all other existing token devices as deleted.
-        # a queryset update bypasses save(), so auto_now does not fire and updated_at has to be
-        # written by hand, here and in the other bulk updates of the DEP devices
-        (DEPDevice.objects.filter(virtual_server=dep_virtual_server)
-                          .exclude(serial_number__in=found_serial_numbers)
-                          .update(last_op_type=DEPDevice.OP_TYPE_DELETED,
-                                  updated_at=naive_utcnow()))
+        # a device the fetch did not report is deleted. The ones already marked as such are left
+        # alone, so that a full fetch does not rewrite them on every run.
+        now = naive_utcnow()
+        deleted_devices = list(
+            DEPDevice.objects.select_related("virtual_server", "enrollment")
+                             .filter(virtual_server=dep_virtual_server)
+                             .exclude(serial_number__in=found_serial_numbers)
+                             .exclude(last_op_type=DEPDevice.OP_TYPE_DELETED)
+        )
+        for dep_device in deleted_devices:
+            dep_device.last_op_type = DEPDevice.OP_TYPE_DELETED
+            dep_device.updated_at = now
+        if deleted_devices:
+            # bulk_update bypasses save(), hence the updated_at above
+            DEPDevice.objects.bulk_update(deleted_devices, ["last_op_type", "updated_at"])
+        for dep_device in deleted_devices:
+            yield dep_device, DEP_DEVICE_MARKED_DELETED
 
 
 def iter_unassigned_dep_device_serial_numbers(dep_virtual_server, chunk_size=DEVICE_BATCH_SIZE):

--- a/zentral/contrib/mdm/dep_client.py
+++ b/zentral/contrib/mdm/dep_client.py
@@ -5,8 +5,13 @@ https://github.com/bruienne/depy
 original copyright:
 (c) 2016 The Regents of the University of Michigan
 """
+import logging
+from itertools import islice
+
 from requests import Session, RequestException
 from requests_oauthlib import OAuth1Session
+
+logger = logging.getLogger("zentral.contrib.mdm.dep_client")
 
 
 class DEPClientError(Exception):
@@ -25,6 +30,25 @@ class DEPClientError(Exception):
         return ", ".join(items)
 
 
+# fallbacks, used when the account detail advertises no limit for the endpoint. The device array
+# endpoints have never been seen advertising one, and /devices answers a request carrying 5000
+# serial numbers in full, so the batch size is ours: it is the size a batch is applied at, so that
+# one failure does not discard the batches that already succeeded.
+DEVICE_BATCH_SIZE = 1000
+DEFAULT_PAGINATION_LIMIT = 100
+
+
+def iter_device_chunks(serial_numbers, batch_size=DEVICE_BATCH_SIZE):
+    # an iterator, not a slice, so that a caller can stream a queryset instead of loading a whole
+    # virtual server's serial numbers into memory
+    serial_numbers = iter(serial_numbers)
+    while True:
+        chunk = list(islice(serial_numbers, batch_size))
+        if not chunk:
+            break
+        yield chunk
+
+
 class CursorIterator(object):
     def __init__(self, object_iter):
         self.object_iter = object_iter
@@ -39,7 +63,7 @@ class DEPClient(object):
     TOKEN_HEADER = "X-ADM-Auth-Session"
     SERVER_PROTOCOL_VERSION = "3"
 
-    def __init__(self, consumer_key, consumer_secret, access_token, access_secret, batch_request_limit=100):
+    def __init__(self, consumer_key, consumer_secret, access_token, access_secret, batch_request_limit=None):
         self.default_session = Session()
         self.default_session.headers.update({
             "X-Server-Protocol-Version": self.SERVER_PROTOCOL_VERSION,
@@ -50,23 +74,26 @@ class DEPClient(object):
                                            resource_owner_key=access_token,
                                            resource_owner_secret=access_secret,
                                            realm='ADM')
+        # None: ask Apple. An explicit value overrides what the account detail advertises.
         self.batch_request_limit = batch_request_limit
+        self._account = None
+        self._limits = {}
 
     @classmethod
-    def from_dep_token(cls, dep_token, batch_request_limit=100):
+    def from_dep_token(cls, dep_token, batch_request_limit=None):
         return cls(dep_token.consumer_key, dep_token.get_consumer_secret(),
                    dep_token.access_token, dep_token.get_access_secret(),
                    batch_request_limit=batch_request_limit)
 
     @classmethod
-    def from_dep_virtual_server(cls, dep_virtual_server, batch_request_limit=100):
+    def from_dep_virtual_server(cls, dep_virtual_server, batch_request_limit=None):
         token = dep_virtual_server.token
         if not token:
             raise DEPClientError("DEP virtual server has no token")
         elif token.has_expired():
             raise DEPClientError("DEP virtual server token has expired")
         else:
-            return cls.from_dep_token(token)
+            return cls.from_dep_token(token, batch_request_limit=batch_request_limit)
 
     @property
     def auth_session_token(self):
@@ -94,6 +121,11 @@ class DEPClient(object):
                                  error_code=error_code, status_code=status_code)
         else:
             self.auth_session_token = response.json()["auth_session_token"]
+            # the account detail describes the authenticated session, so it is dropped with the
+            # session it came from and read again on the next use. Dropped, not read here: reading
+            # it goes through send_request, which asks for a session token.
+            self._account = None
+            self._limits = {}
 
     def send_request(self, endpoint, method="GET", json=None, **params):
         self.get_auth_session_token()
@@ -124,11 +156,63 @@ class DEPClient(object):
         return str(uuid).replace("-", "").upper()
 
     def get_account(self):
-        return self.send_request('account')
+        # cached for the lifetime of the auth session, not of the client
+        if self._account is None:
+            self._account = self.send_request('account')
+        return self._account
+
+    def get_uri_limit(self, uri):
+        """The maximum Apple advertises for an endpoint, or None when it advertises none.
+
+        The account detail carries a urls array of {uri, http_method, limit} - see the Url and
+        Limit objects of the Device Management documentation. Only the paginated endpoints have
+        been seen carrying one, but it is asked for every endpoint: an account that advertises
+        more, or a future one that does, is then honoured instead of overrun.
+        """
+        account = self.get_account()
+        if not isinstance(account, dict):
+            return None
+        for url_d in account.get("urls") or []:
+            if not isinstance(url_d, dict) or url_d.get("uri") != uri:
+                continue
+            maximum = (url_d.get("limit") or {}).get("maximum")
+            if isinstance(maximum, int) and maximum > 0:
+                return maximum
+        return None
+
+    def _get_limit(self, uri, default):
+        if uri not in self._limits:
+            limit = None
+            try:
+                limit = self.get_uri_limit(uri)
+            except DEPClientError:
+                # the account detail is a convenience here, not a precondition: a smaller request
+                # costs more of them, it does not make the response wrong
+                logger.warning("Could not read the account detail to size the %s requests", uri)
+            self._limits[uri] = limit
+        return self._limits[uri] or default
+
+    def get_pagination_limit(self, path):
+        if self.batch_request_limit is not None:
+            return self.batch_request_limit
+        return self._get_limit(f"/{path}", DEFAULT_PAGINATION_LIMIT)
+
+    def get_device_batch_size(self, uri):
+        """How many devices to send at once: Apple's number when it has already given one.
+
+        This does not read the account detail on its own. No endpoint taking a device array has
+        been seen advertising a limit, so fetching it here would add a request to every single
+        device operation - a disown, a refresh - to learn nothing. The callers that batch a large
+        set read it first, and then an advertised limit is honoured rather than overrun.
+        """
+        if self._account is None:
+            return DEVICE_BATCH_SIZE
+        return self._get_limit(uri, DEVICE_BATCH_SIZE)
 
     def _device_iterator_request(self, path, cursor=None):
+        limit = self.get_pagination_limit(path)
         while True:
-            body = {"limit": self.batch_request_limit}
+            body = {"limit": limit}
             if cursor:
                 body["cursor"] = cursor
             response = self.send_request(path, 'POST', json=body)
@@ -145,13 +229,13 @@ class DEPClient(object):
         return CursorIterator(self._device_iterator_request("devices/sync", cursor))
 
     def get_devices(self, serial_numbers):
-        body = {"devices": serial_numbers}
-        response = self.send_request('devices', 'POST', json=body)
         devices_d = {}
-        for serial_number, device_d in response["devices"].items():
-            response_status = device_d.pop("response_status")
-            if response_status == "SUCCESS":
-                devices_d[serial_number] = device_d
+        for chunk in iter_device_chunks(serial_numbers, self.get_device_batch_size("/devices")):
+            response = self.send_request('devices', 'POST', json={"devices": chunk})
+            for serial_number, device_d in response["devices"].items():
+                response_status = device_d.pop("response_status")
+                if response_status == "SUCCESS":
+                    devices_d[serial_number] = device_d
         return devices_d
 
     def get_profile(self, profile_uuid):
@@ -162,13 +246,20 @@ class DEPClient(object):
         return self.send_request('profile', 'POST', json=profile)
 
     def assign_profile(self, profile_uuid, serial_numbers):
-        body = {"devices": serial_numbers,
-                "profile_uuid": self.prepare_uuid_for_request(profile_uuid)}
-        return self.send_request('profile/devices', 'POST', json=body)
+        profile_uuid = self.prepare_uuid_for_request(profile_uuid)
+        devices = {}
+        for chunk in iter_device_chunks(serial_numbers, self.get_device_batch_size("/profile/devices")):
+            body = {"devices": chunk, "profile_uuid": profile_uuid}
+            response = self.send_request('profile/devices', 'POST', json=body)
+            devices.update(response.get("devices") or {})
+        return {"devices": devices}
 
     def disown_devices(self, serial_numbers):
-        body = {"devices": serial_numbers}
-        return self.send_request('devices/disown', 'POST', json=body)
+        devices = {}
+        for chunk in iter_device_chunks(serial_numbers, self.get_device_batch_size("/devices/disown")):
+            response = self.send_request('devices/disown', 'POST', json={"devices": chunk})
+            devices.update(response.get("devices") or {})
+        return {"devices": devices}
 
     def get_os_beta_enrollment_tokens(self):
         return self.send_request('os-beta-enrollment/tokens')

--- a/zentral/contrib/mdm/events/__init__.py
+++ b/zentral/contrib/mdm/events/__init__.py
@@ -1,6 +1,7 @@
 from .admin_password import *  # NOQA
 from .apps_books import *  # NOQA
 from .artifacts import *  # NOQA
+from .dep import *  # NOQA
 from .downloads import *  # NOQA
 from .filevault import *  # NOQA
 from .management import *  # NOQA

--- a/zentral/contrib/mdm/events/dep.py
+++ b/zentral/contrib/mdm/events/dep.py
@@ -1,0 +1,43 @@
+import logging
+
+from zentral.core.events import register_event_type
+from zentral.core.events.base import AuditEvent
+
+logger = logging.getLogger('zentral.contrib.mdm.events.dep')
+
+
+# Automated Device Enrollment device changes
+
+
+ORIGIN_SYNC = "sync"
+ORIGIN_DEFAULT_ENROLLMENT_ASSIGNMENT = "default_enrollment_assignment"
+
+
+class DEPDeviceChangeEvent(AuditEvent):
+    """A change Apple made, not one an operator asked for.
+
+    The payload is an audit event's, so that a DEP device has one history whichever end changed it,
+    but the event type is not: these are machine generated, one per device of a virtual server, and
+    they would bury the operator actions in the audit trail. The zentral tag is dropped with it.
+    """
+    event_type = "dep_device_change"
+    tags = ["mdm", "dep"]
+
+
+register_event_type(DEPDeviceChangeEvent)
+
+
+def build_dep_device_change_event(
+    dep_device, action, prev_value=None, origin=ORIGIN_SYNC,
+    event_uuid=None, event_index=None, event_request=None
+):
+    event = DEPDeviceChangeEvent.build(
+        dep_device, action,
+        prev_value=prev_value,
+        event_uuid=event_uuid,
+        event_index=event_index,
+        event_request=event_request,
+        machine_serial_number=dep_device.serial_number,
+    )
+    event.payload["origin"] = origin
+    return event

--- a/zentral/contrib/mdm/management/commands/sync_dep_devices.py
+++ b/zentral/contrib/mdm/management/commands/sync_dep_devices.py
@@ -1,6 +1,11 @@
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from zentral.contrib.mdm.models import DEPVirtualServer
-from zentral.contrib.mdm.dep import sync_dep_virtual_server_devices, DEPClientError
+from zentral.contrib.mdm.dep import (
+    DEPClientError,
+    sync_dep_virtual_server_devices,
+    try_lock_dep_virtual_server_sync,
+)
 
 
 class Command(BaseCommand):
@@ -32,17 +37,21 @@ class Command(BaseCommand):
         full_sync = kwargs.get("full_sync")
         for server in depvs_qs:
             self.write(f"Sync server {server.pk} {server}")
-            try:
-                for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=full_sync):
-                    operation = "Created" if created else "Updated"
-                    self.write(f"{operation} {dep_device}")
-            except DEPClientError as e:
-                if e.error_code == "EXPIRED_CURSOR":
-                    self.write("Expired cursor → full sync")
-                    for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=True):
+            with transaction.atomic():
+                if not try_lock_dep_virtual_server_sync(server.pk):
+                    self.write("Already being synced → skipped")
+                    continue
+                try:
+                    for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=full_sync):
                         operation = "Created" if created else "Updated"
                         self.write(f"{operation} {dep_device}")
-                else:
-                    self.stderr.write(f"DEP client error: {e}")
-            except Exception as e:
-                self.stderr.write(f"Unknown error: {e}")
+                except DEPClientError as e:
+                    if e.error_code == "EXPIRED_CURSOR":
+                        self.write("Expired cursor → full sync")
+                        for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=True):
+                            operation = "Created" if created else "Updated"
+                            self.write(f"{operation} {dep_device}")
+                    else:
+                        self.stderr.write(f"DEP client error: {e}")
+                except Exception as e:
+                    self.stderr.write(f"Unknown error: {e}")

--- a/zentral/contrib/mdm/management/commands/sync_dep_devices.py
+++ b/zentral/contrib/mdm/management/commands/sync_dep_devices.py
@@ -24,6 +24,9 @@ class Command(BaseCommand):
         if self.verbosity:
             self.stdout.write(msg)
 
+    def action_display(self, action):
+        return action.replace("_", " ").capitalize()
+
     def handle(self, *args, **kwargs):
         self.verbosity = kwargs.get("verbosity", 1)
         depvs_qs = DEPVirtualServer.objects.all().order_by("pk")
@@ -43,15 +46,13 @@ class Command(BaseCommand):
                     self.write("Already being synced → skipped")
                     continue
                 try:
-                    for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=full_sync):
-                        operation = "Created" if created else "Updated"
-                        self.write(f"{operation} {dep_device}")
+                    for dep_device, action in sync_dep_virtual_server_devices(server, force_fetch=full_sync):
+                        self.write(f"{self.action_display(action)} {dep_device}")
                 except DEPClientError as e:
                     if e.error_code == "EXPIRED_CURSOR":
                         self.write("Expired cursor → full sync")
-                        for dep_device, created in sync_dep_virtual_server_devices(server, force_fetch=True):
-                            operation = "Created" if created else "Updated"
-                            self.write(f"{operation} {dep_device}")
+                        for dep_device, action in sync_dep_virtual_server_devices(server, force_fetch=True):
+                            self.write(f"{self.action_display(action)} {dep_device}")
                     else:
                         self.stderr.write(f"DEP client error: {e}")
                 except Exception as e:

--- a/zentral/contrib/mdm/management/commands/sync_dep_devices.py
+++ b/zentral/contrib/mdm/management/commands/sync_dep_devices.py
@@ -3,6 +3,7 @@ from django.db import transaction
 from zentral.contrib.mdm.models import DEPVirtualServer
 from zentral.contrib.mdm.dep import (
     DEPClientError,
+    assign_dep_virtual_server_default_enrollment,
     sync_dep_virtual_server_devices,
     try_lock_dep_virtual_server_sync,
 )
@@ -55,3 +56,14 @@ class Command(BaseCommand):
                         self.stderr.write(f"DEP client error: {e}")
                 except Exception as e:
                     self.stderr.write(f"Unknown error: {e}")
+            if not server.default_enrollment_id:
+                continue
+            # the task the API view schedules is run inline: this command is the cron entry point,
+            # and it must not depend on a worker being up to assign the default enrollment
+            try:
+                operations = assign_dep_virtual_server_default_enrollment(server)
+            except Exception as e:
+                self.stderr.write(f"Could not assign the default enrollment: {e}")
+            else:
+                self.write("Assigned the default enrollment to {assigned} device(s),"
+                           " {failed} failure(s)".format(**operations))

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -2238,6 +2238,13 @@ class DEPDevice(models.Model):
     def get_urlsafe_serial_number(self):
         return MetaMachine(self.serial_number).get_urlsafe_serial_number()
 
+    def linked_objects_keys_for_event(self):
+        keys = {"mdm_dep_device": [(self.pk,)],
+                "mdm_dep_virtual_server": [(self.virtual_server.pk,)]}
+        if self.enrollment:
+            keys["mdm_dep_enrollment"] = [(self.enrollment.pk,)]
+        return keys
+
     def serialize_for_event(self, keys_only=False):
         d = {"pk": self.pk, "serial_number": self.serial_number}
         if keys_only:

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -6,6 +6,10 @@ from django.db import transaction
 
 from .apps_books import bulk_assign_location_asset
 from .dep import (
+    DEP_DEVICE_CREATED,
+    DEP_DEVICE_MARKED_DELETED,
+    DEP_DEVICE_UNCHANGED,
+    DEP_DEVICE_UPDATED,
     DEPClientError,
     assign_dep_virtual_server_default_enrollment,
     define_dep_profile,
@@ -27,16 +31,17 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
     server = DEPVirtualServer.objects.get(pk=dep_virtual_server_pk)
     result = {"dep_virtual_server": {"pk": server.pk,
                                      "name": server.name},
-              "operations": {"created": 0,
-                             "updated": 0},
+              "operations": {},
               "requested_sync_type": "full_sync" if force_full_sync else "delta_sync",
               "effective_sync_type": "full_sync" if force_full_sync else "delta_sync"}
 
-    def update_counters(created):
-        if created:
-            result["operations"]["created"] += 1
-        else:
-            result["operations"]["updated"] += 1
+    def reset_counters():
+        result["operations"] = {DEP_DEVICE_CREATED: 0,
+                                DEP_DEVICE_UPDATED: 0,
+                                DEP_DEVICE_UNCHANGED: 0,
+                                DEP_DEVICE_MARKED_DELETED: 0}
+
+    reset_counters()
 
     with transaction.atomic():
         if not try_lock_dep_virtual_server_sync(server.pk):
@@ -44,14 +49,16 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
             result["status"] = "SKIPPED"
             return result
         try:
-            for _, created in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync):
-                update_counters(created)
+            for _, action in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync):
+                result["operations"][action] += 1
         except DEPClientError as e:
             if e.error_code == "EXPIRED_CURSOR":
-                # full sync
+                # full sync. It reports on every device, so what the delta walk had counted before
+                # it hit the expired cursor would be counted twice.
                 result["effective_sync_type"] = "full_sync"
-                for _, created in sync_dep_virtual_server_devices(server, force_fetch=True):
-                    update_counters(created)
+                reset_counters()
+                for _, action in sync_dep_virtual_server_devices(server, force_fetch=True):
+                    result["operations"][action] += 1
             else:
                 raise
         if server.default_enrollment_id:

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -4,6 +4,8 @@ from celery import shared_task
 from celery.exceptions import MaxRetriesExceededError
 from django.db import transaction
 
+from zentral.core.events.base import EventRequest
+
 from .apps_books import bulk_assign_location_asset
 from .dep import (
     DEP_DEVICE_CREATED,
@@ -26,8 +28,12 @@ logger = logging.getLogger("zentral.contrib.mdm.tasks")
 
 
 @shared_task
-def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=False, **kwargs):
+def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=False,
+                                         serialized_event_request=None, **kwargs):
     # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
+    event_request = None
+    if serialized_event_request:
+        event_request = EventRequest.deserialize(serialized_event_request)
     server = DEPVirtualServer.objects.get(pk=dep_virtual_server_pk)
     result = {"dep_virtual_server": {"pk": server.pk,
                                      "name": server.name},
@@ -49,7 +55,8 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
             result["status"] = "SKIPPED"
             return result
         try:
-            for _, action in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync):
+            for _, action in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync,
+                                                             event_request=event_request):
                 result["operations"][action] += 1
         except DEPClientError as e:
             if e.error_code == "EXPIRED_CURSOR":
@@ -57,7 +64,8 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
                 # it hit the expired cursor would be counted twice.
                 result["effective_sync_type"] = "full_sync"
                 reset_counters()
-                for _, action in sync_dep_virtual_server_devices(server, force_fetch=True):
+                for _, action in sync_dep_virtual_server_devices(server, force_fetch=True,
+                                                                 event_request=event_request):
                     result["operations"][action] += 1
             else:
                 raise

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -1,9 +1,15 @@
 import logging
 
 from celery import shared_task
+from django.db import transaction
 
 from .apps_books import bulk_assign_location_asset
-from .dep import DEPClientError, define_dep_profile, sync_dep_virtual_server_devices
+from .dep import (
+    DEPClientError,
+    define_dep_profile,
+    sync_dep_virtual_server_devices,
+    try_lock_dep_virtual_server_sync,
+)
 from .models import DEPEnrollment, DEPVirtualServer, LocationAsset
 from .software_updates import sync_software_updates
 
@@ -30,18 +36,24 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
         else:
             result["operations"]["updated"] += 1
 
-    try:
-        for _, created in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync):
-            update_counters(created)
-    except DEPClientError as e:
-        if e.error_code == "EXPIRED_CURSOR":
-            # full sync
-            result["effective_sync_type"] = "full_sync"
-            for _, created in sync_dep_virtual_server_devices(server, force_fetch=True):
+    with transaction.atomic():
+        if not try_lock_dep_virtual_server_sync(server.pk):
+            logger.warning("DEP virtual server %s is already being synced", server.pk)
+            result["status"] = "SKIPPED"
+            return result
+        try:
+            for _, created in sync_dep_virtual_server_devices(server, force_fetch=force_full_sync):
                 update_counters(created)
-        else:
-            raise
+        except DEPClientError as e:
+            if e.error_code == "EXPIRED_CURSOR":
+                # full sync
+                result["effective_sync_type"] = "full_sync"
+                for _, created in sync_dep_virtual_server_devices(server, force_fetch=True):
+                    update_counters(created)
+            else:
+                raise
 
+    result["status"] = "SUCCESS"
     return result
 
 

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -1,11 +1,13 @@
 import logging
 
 from celery import shared_task
+from celery.exceptions import MaxRetriesExceededError
 from django.db import transaction
 
 from .apps_books import bulk_assign_location_asset
 from .dep import (
     DEPClientError,
+    assign_dep_virtual_server_default_enrollment,
     define_dep_profile,
     sync_dep_virtual_server_devices,
     try_lock_dep_virtual_server_sync,
@@ -52,7 +54,53 @@ def sync_dep_virtual_server_devices_task(dep_virtual_server_pk, force_full_sync=
                     update_counters(created)
             else:
                 raise
+        if server.default_enrollment_id:
+            # the assignment is attributed to whoever asked for the synchronization that scheduled
+            # it, so that it shows up in their task list too
+            assignment_kwargs = {}
+            task_user = kwargs.get("task_user")
+            if task_user:
+                assignment_kwargs["task_user"] = task_user
+            # the devices have to be committed before the assignment task reads them back
+            transaction.on_commit(
+                lambda: assign_dep_virtual_server_default_enrollment_task.apply_async(
+                    (server.pk,), assignment_kwargs
+                )
+            )
 
+    result["status"] = "SUCCESS"
+    return result
+
+
+# retrying a request Apple throttled or failed to serve is worth it. Anything else - a rejected
+# payload, an expired token - would fail again the same way.
+DEP_RETRY_STATUS_CODES = frozenset([429, 500, 502, 503, 504])
+
+
+@shared_task(bind=True, max_retries=5)
+def assign_dep_virtual_server_default_enrollment_task(self, dep_virtual_server_pk, **kwargs):
+    server = DEPVirtualServer.objects.select_related("default_enrollment").get(pk=dep_virtual_server_pk)
+    result = {"dep_virtual_server": {"pk": server.pk,
+                                     "name": server.name},
+              "operations": {"assigned": 0,
+                             "failed": 0}}
+    with transaction.atomic():
+        if not try_lock_dep_virtual_server_sync(server.pk):
+            # a synchronization is holding the lock. Retry rather than wait for the next one to
+            # schedule this again, which would delay the assignment by a whole interval. The work
+            # list is derived from the database, so a retry finds the same devices.
+            logger.warning("DEP virtual server %s is already being synced", server.pk)
+            try:
+                raise self.retry(countdown=60 * 2 ** self.request.retries)
+            except MaxRetriesExceededError:
+                result["status"] = "SKIPPED"
+                return result
+        try:
+            result["operations"] = assign_dep_virtual_server_default_enrollment(server)
+        except DEPClientError as e:
+            if e.status_code in DEP_RETRY_STATUS_CODES:
+                raise self.retry(exc=e, countdown=60 * 2 ** self.request.retries)
+            raise
     result["status"] = "SUCCESS"
     return result
 

--- a/zentral/core/stores/backends/es_os_base.py
+++ b/zentral/core/stores/backends/es_os_base.py
@@ -118,6 +118,26 @@ class ESOSStore(BaseStore):
                     },
                 },
             },
+            # same payload as an audit event, so the same free-form objects to keep out of the
+            # mapping. see zentral.contrib.mdm.events.dep
+            "dep_device_change": {
+                "type": "object",
+                "properties": {
+                    "object": {
+                        "type": "object",
+                        "properties": {
+                            "new_value": {
+                                "type": "object",
+                                "enabled": False,
+                            },
+                            "prev_value": {
+                                "type": "object",
+                                "enabled": False,
+                            },
+                        },
+                    },
+                },
+            },
         }
     }
     INTERVAL_UNIT = {

--- a/zentral/utils/drf.py
+++ b/zentral/utils/drf.py
@@ -74,11 +74,11 @@ class ListCreateAPIViewWithAudit(generics.ListCreateAPIView):
         transaction.on_commit(on_commit_callback)
 
 
-class RetrieveUpdateDestroyAPIViewWithAudit(generics.RetrieveUpdateDestroyAPIView):
+class RetrieveUpdateAPIViewWithAudit(generics.RetrieveUpdateAPIView):
     permission_classes = [DefaultDjangoModelPermissions]
     # Zentral only does full updates — PATCH is a 405 everywhere, so the serializers' update()
     # methods can rely on every declared field being present in validated_data
-    http_method_names = ["delete", "get", "head", "options", "put"]
+    http_method_names = ["get", "head", "options", "put"]
 
     def get_audit_machine_serial_number(self):
         return None
@@ -102,6 +102,11 @@ class RetrieveUpdateDestroyAPIViewWithAudit(generics.RetrieveUpdateDestroyAPIVie
             self.on_commit_callback_extra(instance)
 
         transaction.on_commit(on_commit_callback)
+
+
+class RetrieveUpdateDestroyAPIViewWithAudit(RetrieveUpdateAPIViewWithAudit,
+                                            generics.RetrieveUpdateDestroyAPIView):
+    http_method_names = RetrieveUpdateAPIViewWithAudit.http_method_names + ["delete"]
 
     def perform_destroy(self, instance):
         prev_pk = instance.pk


### PR DESCRIPTION
The synchronization with Apple Business Manager was the one DEP workflow that left no trace in the event pipeline, and getting there turned up a handful of things wrong with the synchronization itself. Those come first, one commit each, so the ones most likely to be argued about are last and can be dropped without unpicking the rest.

## The synchronization

**It waited on the advisory lock.** A synchronization that lost the race parked a worker, and an open Postgres transaction, for up to ten minutes under `SET LOCAL lock_timeout = '600s'`, then died with a bare `OperationalError`. Waiting achieves nothing: the synchronization is cursor driven, so whatever the running one does not cover the next one picks up. `pg_try_advisory_xact_lock` replaces the blocking one, the way `sync_repository_task` already does it for the monolith repositories. The lock had to move to the callers — it was taken inside a generator, and a generator that returns early yields nothing, which is indistinguishable from a synchronization that found nothing to change. The task reports a `SKIPPED` status instead of a `SUCCESS` one, and the management command says so.

**`updated_at` did not move.** Five bulk updates change DEP devices through a queryset, which does not call `save()`, so the `auto_now` never fired. `DEPDeviceList` orders on `updated_at`, so a device the synchronization had just marked as deleted sorted as if nothing had happened to it, and a client paging by `updated_at` to pick up what changed missed all of it. Zentral also stops inventing `profile_assign_time` from its own clock; the field stays null until Apple reports the real one.

**Everything Apple reported was written.** A full fetch reports the whole fleet, and every device it reported was written whether or not anything had moved — rewriting the entire table on every run — while the task counted every device it had not created as updated, so a fleet that had not moved at all was reported as thousands of updates. The stored record is now compared with what would be written, and unchanged devices are left alone. The comparison is between serializations, not attributes: the datetimes parsed from the DEP API are aware and the stored ones are naive, so comparing attributes would find a difference in every timestamp on every run.

**A failed assignment discarded the whole synchronization.** The default enrollment was assigned at the end, inside the transaction that holds the lock, and the cursor is saved before it but in the same transaction — so one throttled `assign_profile` call discarded a completed delta walk and the cursor advance with it. It is a task of its own now, scheduled on commit, deriving its work list from the database rather than being handed the serial numbers: passing them would not fit in a broker message for a large virtual server, and deriving them makes the task idempotent, which is what lets it take the same lock and simply skip when a synchronization is running. It also makes it self healing — a device whose assignment failed is retried instead of waiting for Apple to report an operation on it — so the first run after this lands catches up on every device left unassigned by an earlier failure. It then reads the records back from Apple rather than assuming what the assignment made of them: the profile status is Apple's to decide, and the assignment time is Apple's to stamp.

## The events

Every device the synchronization really changes posts a `dep_device_change` event. The payload is an audit event's, so a DEP device has one history whichever end changed it and one shape to read it with, and the class is an `AuditEvent` subclass rather than a copy of its builder. The event type is not an audit one: these are machine generated, one per device of a virtual server, and they would bury the operator actions in the audit trail. The `zentral` tag goes with the type.

An `origin` says which end was talking to Apple, a synchronization or the default enrollment assignment. The events of one run share their metadata `id`, and a synchronization somebody asked for carries the request that asked for it.

Three kinds of change post nothing: the first synchronization of a virtual server, which imports the fleet rather than changing it; a device Apple reports unchanged; and a device whose record only moved because of the operation itself, `last_op_type` and `last_op_date`, which a delta synchronization reports for attributes Zentral does not store — though a deletion is reported even when it is all that moved. A device Apple stops reporting is an `updated`, not a `deleted`: the record stays, with `last_op_type` moved to `deleted`.

The event type gets its own Elasticsearch mapping entry mirroring the audit one, since the same free-form previous and new values have to stay out of the mapping.

## Requests sized from the account detail

The account detail carries a `urls` array of `{uri, http_method, limit}`, and Apple documents both objects — [Url](https://developer.apple.com/documentation/devicemanagement/url) and [Limit](https://developer.apple.com/documentation/devicemanagement/limit), "a ranged limit" of `{default, maximum}`. Against a real ABM account, `/server/devices` and `/devices/sync` advertise `{default: 1000, maximum: 1000}`, and no other endpoint advertises anything.

The client asked for 100 per page, hard coded, so **a full fetch of a large virtual server made ten times the requests Apple was willing to answer in one**. It now reads the maximum from the account detail, once per client, falling back to 100 when nothing is advertised or the account detail cannot be read.

Three call paths could also send an unbounded number of devices in one request — the default enrollment assignment, the profile payload of `define_dep_profile`, and whatever list `get_devices` and `disown_devices` were given. Apple does not reject those: a `/devices` request carrying 5000 serial numbers is answered in full. They are batched anyway, so that a batch is applied as it succeeds and one failure does not discard the rest.

Rate limiting was looked for and is not there. No DEP response carries a `Retry-After` or an `X-RateLimit` header — only `X-Apple-Request-UUID` and `X-Apple-Edge-Response-Time` — and the [documented error codes](https://developer.apple.com/documentation/devicemanagement/interpreting-automated-device-enrollment-error-codes) are 400, 401 and 403. Apple's answer to how much may be asked for is the account detail, not a response header. The assignment task still backs off exponentially on a 429 or a 5xx, which is now known to be defensive rather than load bearing.

## One smaller gap

Assigning an enrollment profile to a DEP device from the web interface posted an audit event; the same assignment through the HTTP API changed the device and recorded nothing. `RetrieveUpdateAPIViewWithAudit` is split out of the retrieve/update/destroy one, which now inherits from it and adds the destroy — a DEP device is never deleted.

## ⚠️ API change

The result of `/api/mdm/dep/virtual_servers/<pk>/sync_devices/` gains `unchanged` and `marked_deleted`, and a `status` of `SUCCESS` or `SKIPPED`, and `updated` drops to the devices that really changed. A client reading `operations.updated` as the number of devices Apple reported has to read `created + updated + unchanged` instead.

## Tests

Full suite green, 7734 tests. New coverage for the skipped-lock paths, the `updated_at` bumps, the batching and the profile split, the assignment task's work list and its retry behaviour, the created/unchanged/changed/marked-deleted paths, each event and each suppression rule, the account-detail limit resolution and its fallbacks, and the API audit event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
