### PR TITLE
mdm: report the enrollment in the enrollment session events

### DIFF
--- a/tests/mdm/test_dep_enrollment.py
+++ b/tests/mdm/test_dep_enrollment.py
@@ -61,7 +61,10 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(session.status, "STARTED")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "dep", "status": "STARTED"}}
+            {"enrollment_session": {"pk": session.pk, "type": "dep", "status": "STARTED",
+                                    "dep_enrollment": {"pk": enrollment.pk,
+                                                       "name": enrollment.name,
+                                                       "uuid": str(enrollment.uuid)}}}
         )
 
     def test_dep_enrollment_session_no_acme_payload(self):

--- a/tests/mdm/test_ota_enrollment.py
+++ b/tests/mdm/test_ota_enrollment.py
@@ -48,7 +48,9 @@ class TestOTAEnrollment(TestCase):
         self.assertEqual(session.status, "PHASE_2")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "ota", "status": "PHASE_2"}}
+            {"enrollment_session": {"pk": session.pk, "type": "ota", "status": "PHASE_2",
+                                    "ota_enrollment": {"pk": enrollment.pk,
+                                                       "name": enrollment.name}}}
         )
 
     def test_ota_enrollment_session_scep_payload(self):
@@ -87,6 +89,12 @@ class TestOTAEnrollment(TestCase):
         self.assertEqual(reenrollment_session.status, ReEnrollmentSession.STARTED)
         self.assertEqual(reenrollment_session.first_enrolled_at, session.created_at)
         self.assertEqual(reenrollment_session.device_enrolled_at, session.device_enrolled_at)
+        # the enrollment is nested, so it cannot overwrite the session pk
+        self.assertEqual(
+            reenrollment_session.serialize_for_event(),
+            {"enrollment_session": {"pk": reenrollment_session.pk, "type": "re", "status": "STARTED",
+                                    "enrollment": {"pk": enrollment.pk, "name": enrollment.name}}}
+        )
         re_s, ota_s = list(session.enrolled_device.iter_enrollment_session_info())
         self.assertEqual(re_s["session_type"], "RE")
         self.assertEqual(re_s["id"], reenrollment_session.pk)

--- a/tests/mdm/test_user_enrollment.py
+++ b/tests/mdm/test_user_enrollment.py
@@ -38,7 +38,9 @@ class TestUserEnrollment(TestCase):
         self.assertEqual(session.status, "ACCOUNT_DRIVEN_START")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "user", "status": "ACCOUNT_DRIVEN_START"}}
+            {"enrollment_session": {"pk": session.pk, "type": "user", "status": "ACCOUNT_DRIVEN_START",
+                                    "user_enrollment": {"pk": enrollment.pk,
+                                                        "name": enrollment.name}}}
         )
 
     def test_user_enrollment_session_scep_payload(self):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -1560,6 +1560,9 @@ class EnrollmentSession(models.Model):
         d = {"pk": self.pk,
              "type": enrollment_session_type,
              "status": self.status}
+        # the enrollments are referenced by their keys only: these events are posted on every
+        # enrollment attempt, and the full serialization carries the enrollment secret's metadata
+        d.update(extra_dict)
         return {"enrollment_session": d}
 
     # status update methods
@@ -1806,7 +1809,8 @@ class OTAEnrollmentSession(EnrollmentSession):
             raise ValueError("Wrong enrollment sessions status")
 
     def serialize_for_event(self):
-        return super().serialize_for_event("ota", {"ota_enrollment": self.ota_enrollment.serialize_for_event()})
+        return super().serialize_for_event("ota", {"ota_enrollment": self.ota_enrollment.serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.ota_enrollment.blueprint
@@ -2324,7 +2328,8 @@ class DEPEnrollmentSession(EnrollmentSession):
             raise ValueError("Wrong enrollment sessions status")
 
     def serialize_for_event(self):
-        return super().serialize_for_event("dep", {"dep_enrollment": self.dep_enrollment.serialize_for_event()})
+        return super().serialize_for_event("dep", {"dep_enrollment": self.dep_enrollment.serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.dep_enrollment.blueprint
@@ -2466,7 +2471,8 @@ class UserEnrollmentSession(EnrollmentSession):
             raise ValueError("Wrong enrollment sessions status")
 
     def serialize_for_event(self):
-        return super().serialize_for_event("user", {"user_enrollment": self.user_enrollment.serialize_for_event()})
+        return super().serialize_for_event("user", {"user_enrollment": self.user_enrollment.serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.user_enrollment.blueprint
@@ -2591,7 +2597,8 @@ class ReEnrollmentSession(EnrollmentSession):
     def serialize_for_event(self):
         # nested under a key: merged into the session dict, the enrollment's own pk would
         # overwrite the session's
-        return super().serialize_for_event("re", {"enrollment": self.get_enrollment().serialize_for_event()})
+        return super().serialize_for_event("re", {"enrollment": self.get_enrollment().serialize_for_event(
+            keys_only=True)})
 
     def get_blueprint(self):
         return self.get_enrollment().blueprint

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -2589,7 +2589,9 @@ class ReEnrollmentSession(EnrollmentSession):
         return self.first_enrolled_at
 
     def serialize_for_event(self):
-        return super().serialize_for_event("re", self.get_enrollment().serialize_for_event())
+        # nested under a key: merged into the session dict, the enrollment's own pk would
+        # overwrite the session's
+        return super().serialize_for_event("re", {"enrollment": self.get_enrollment().serialize_for_event()})
 
     def get_blueprint(self):
         return self.get_enrollment().blueprint


### PR DESCRIPTION
`EnrollmentSession.serialize_for_event()` takes an `extra_dict` from its four subclasses and drops it:

```python
def serialize_for_event(self, enrollment_session_type, extra_dict):
    d = {"pk": self.pk,
         "type": enrollment_session_type,
         "status": self.status}
    return {"enrollment_session": d}          # extra_dict never used
```

So `dep_enrollment_request`, `ota_enrollment_request`, `user_enrollment_request` and the re-enrollment events never said which enrollment was used, and all four subclasses were building a dict for nothing. The argument was removed from the body in an unrelated commit and the callers were never cleaned up.

## Two commits

**1. Nest the enrollment of a re-enrollment session.** Every other session wraps its enrollment under a key before handing it to the base serializer, which merges the dict into the session dict. The re-enrollment session passed it bare, so the enrollment's own `pk`, `name` and timestamps would land directly on the session and overwrite its `pk`.

Nothing changes in that commit, because the base serializer drops the dict anyway — the mistake is only invisible for that reason. It is fixed first so that the second commit does not turn it into a real bug.

**2. Apply the dict.** The enrollments are referenced **by their keys only**. These events are posted on every enrollment attempt, and the full serialization of an enrollment carries its realm, its timestamps and the metadata of its enrollment secret — the quota, the expiry, the restrictions — which is a lot to repeat for something the enrollment pk already identifies. The secret itself is never serialized either way.

The resulting payload, for a DEP enrollment session:

```json
{"enrollment_session": {"pk": 42, "type": "dep", "status": "STARTED",
                        "dep_enrollment": {"pk": 7, "name": "…", "uuid": "…"}}}
```

OTA, user and re-enrollment sessions get `{pk, name}`; the re-enrollment one nests under a neutral `enrollment` key, since its enrollment can be any of the three types.

## Tests

Three existing assertions were pinning the truncated payload and are updated. A new assertion covers the re-enrollment session and checks that the session `pk` survives, which is the bug the first commit prevents.

Full suite green (7607 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)