### PR TITLE
mdm: report the enrollment in the enrollment session events

### DIFF
--- a/tests/mdm/test_dep_enrollment.py
+++ b/tests/mdm/test_dep_enrollment.py
@@ -61,7 +61,10 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(session.status, "STARTED")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "dep", "status": "STARTED"}}
+            {"enrollment_session": {"pk": session.pk, "type": "dep", "status": "STARTED"},
+             "dep_enrollment": {"pk": enrollment.pk,
+                                "name": enrollment.name,
+                                "uuid": str(enrollment.uuid)}}
         )
 
     def test_dep_enrollment_session_no_acme_payload(self):
@@ -127,6 +130,14 @@ class TestDEPEnrollment(TestCase):
         self.assertEqual(reenrollment_session.realm_user, realm_user)
         self.assertEqual(reenrollment_session.first_enrolled_at, session.created_at)
         self.assertEqual(reenrollment_session.device_enrolled_at, session.device_enrolled_at)
+        # same key as the first session, even though the session type is different
+        self.assertEqual(
+            reenrollment_session.serialize_for_event(),
+            {"enrollment_session": {"pk": reenrollment_session.pk, "type": "re", "status": "STARTED"},
+             "dep_enrollment": {"pk": enrollment.pk,
+                                "name": enrollment.name,
+                                "uuid": str(enrollment.uuid)}}
+        )
         re_s, dep_s = list(session.enrolled_device.iter_enrollment_session_info())
         self.assertEqual(re_s["session_type"], "RE")
         self.assertEqual(re_s["id"], reenrollment_session.pk)

--- a/tests/mdm/test_dep_enrollment_public_views.py
+++ b/tests/mdm/test_dep_enrollment_public_views.py
@@ -11,6 +11,7 @@ from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.crypto import verify_signed_payload
 from zentral.contrib.mdm.events import DEPEnrollmentRequestEvent
+from zentral.contrib.mdm.models import DEPEnrollmentSession
 from zentral.contrib.mdm.public_views.dep import DEP_ENROLLMENT_SESSION_KEY, dep_web_enroll_callback
 
 from .utils import (
@@ -248,7 +249,12 @@ class MDMDEPEnrollmentPublicViewsTestCase(TestCase):
                                                          "UDID": str(uuid.uuid4()).upper()}),
                                     content_type="application/octet-stream")
         self.assertEqual(response.status_code, 200)
-        self.assertSuccess(post_event)
+        session = DEPEnrollmentSession.objects.get(dep_enrollment=enrollment)
+        self.assertSuccess(
+            post_event,
+            enrollment_session={"pk": session.pk, "type": "dep", "status": "STARTED"},
+            dep_enrollment={"pk": enrollment.pk, "name": enrollment.name, "uuid": str(enrollment.uuid)},
+        )
         _, data = verify_signed_payload(response.content)
         payload = plistlib.loads(data)
         self.assertEqual(payload["PayloadIdentifier"], "zentral.mdm")

--- a/tests/mdm/test_enrollment_request_events.py
+++ b/tests/mdm/test_enrollment_request_events.py
@@ -1,0 +1,48 @@
+import uuid
+from django.test import SimpleTestCase
+from zentral.contrib.mdm.events import (DEPEnrollmentRequestEvent,
+                                        OTAEnrollmentRequestEvent,
+                                        UserEnrollmentRequestEvent)
+from zentral.core.events.base import EventMetadata
+
+
+class TestEnrollmentRequestEvents(SimpleTestCase):
+    def test_dep_enrollment_request_linked_objects(self):
+        enrollment_uuid = str(uuid.uuid4())
+        event = DEPEnrollmentRequestEvent(
+            EventMetadata(),
+            {"status": "success",
+             "enrollment_session": {"pk": 1, "type": "dep", "status": "STARTED"},
+             "dep_enrollment": {"pk": 17, "name": "yolo", "uuid": enrollment_uuid}}
+        )
+        self.assertEqual(event.get_linked_objects_keys(), {"mdm_dep_enrollment": [(17,)]})
+        self.assertEqual(event.metadata.serialize()["objects"], {"mdm_dep_enrollment": ["17"]})
+
+    def test_ota_enrollment_request_linked_objects(self):
+        event = OTAEnrollmentRequestEvent(
+            EventMetadata(),
+            {"status": "success",
+             "phase": 2,
+             "enrollment_session": {"pk": 2, "type": "ota", "status": "PHASE_2"},
+             "ota_enrollment": {"pk": 18, "name": "fomo"}}
+        )
+        self.assertEqual(event.get_linked_objects_keys(), {"mdm_ota_enrollment": [(18,)]})
+        self.assertEqual(event.metadata.serialize()["objects"], {"mdm_ota_enrollment": ["18"]})
+
+    def test_user_enrollment_request_linked_objects(self):
+        event = UserEnrollmentRequestEvent(
+            EventMetadata(),
+            {"status": "success",
+             "enrollment_session": {"pk": 3, "type": "user", "status": "ACCOUNT_DRIVEN_START"},
+             "user_enrollment": {"pk": 19, "name": "godzilla"}}
+        )
+        self.assertEqual(event.get_linked_objects_keys(), {"mdm_user_enrollment": [(19,)]})
+        self.assertEqual(event.metadata.serialize()["objects"], {"mdm_user_enrollment": ["19"]})
+
+    def test_aborted_request_no_linked_objects(self):
+        event = DEPEnrollmentRequestEvent(
+            EventMetadata(),
+            {"status": "failure", "reason": "Device blocked"}
+        )
+        self.assertEqual(event.get_linked_objects_keys(), {})
+        self.assertNotIn("objects", event.metadata.serialize())

--- a/tests/mdm/test_ota_enrollment.py
+++ b/tests/mdm/test_ota_enrollment.py
@@ -48,7 +48,9 @@ class TestOTAEnrollment(TestCase):
         self.assertEqual(session.status, "PHASE_2")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "ota", "status": "PHASE_2"}}
+            {"enrollment_session": {"pk": session.pk, "type": "ota", "status": "PHASE_2"},
+             "ota_enrollment": {"pk": enrollment.pk,
+                                "name": enrollment.name}}
         )
 
     def test_ota_enrollment_session_scep_payload(self):
@@ -87,6 +89,12 @@ class TestOTAEnrollment(TestCase):
         self.assertEqual(reenrollment_session.status, ReEnrollmentSession.STARTED)
         self.assertEqual(reenrollment_session.first_enrolled_at, session.created_at)
         self.assertEqual(reenrollment_session.device_enrolled_at, session.device_enrolled_at)
+        # same key as the first session, even though the session type is different
+        self.assertEqual(
+            reenrollment_session.serialize_for_event(),
+            {"enrollment_session": {"pk": reenrollment_session.pk, "type": "re", "status": "STARTED"},
+             "ota_enrollment": {"pk": enrollment.pk, "name": enrollment.name}}
+        )
         re_s, ota_s = list(session.enrolled_device.iter_enrollment_session_info())
         self.assertEqual(re_s["session_type"], "RE")
         self.assertEqual(re_s["id"], reenrollment_session.pk)

--- a/tests/mdm/test_ota_enrollment_public_views.py
+++ b/tests/mdm/test_ota_enrollment_public_views.py
@@ -8,6 +8,7 @@ from realms.models import RealmAuthenticationSession
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.crypto import verify_signed_payload
 from zentral.contrib.mdm.events import OTAEnrollmentRequestEvent
+from zentral.contrib.mdm.models import OTAEnrollmentSession
 from zentral.contrib.mdm.public_views.ota import ota_enroll_callback
 from .utils import force_ota_enrollment, force_ota_enrollment_session, force_realm, force_realm_user
 
@@ -110,4 +111,9 @@ class MDMOTAEnrollmentPublicViewsTestCase(TestCase):
         self.assertEqual(data["PayloadIdentifier"], "zentral.scep")
         self.assertEqual(len(data["PayloadContent"]), 1)
         self.assertEqual(data["PayloadContent"][0]["PayloadType"], "com.apple.security.scep")
-        self.assertSuccess(post_event, phase=2)
+        session = OTAEnrollmentSession.objects.get(ota_enrollment=enrollment)
+        self.assertSuccess(
+            post_event, phase=2,
+            enrollment_session={"pk": session.pk, "type": "ota", "status": "PHASE_2"},
+            ota_enrollment={"pk": enrollment.pk, "name": enrollment.name},
+        )

--- a/tests/mdm/test_user_enrollment.py
+++ b/tests/mdm/test_user_enrollment.py
@@ -38,7 +38,9 @@ class TestUserEnrollment(TestCase):
         self.assertEqual(session.status, "ACCOUNT_DRIVEN_START")
         self.assertEqual(
             session.serialize_for_event(),
-            {"enrollment_session": {"pk": session.pk, "type": "user", "status": "ACCOUNT_DRIVEN_START"}}
+            {"enrollment_session": {"pk": session.pk, "type": "user", "status": "ACCOUNT_DRIVEN_START"},
+             "user_enrollment": {"pk": enrollment.pk,
+                                 "name": enrollment.name}}
         )
 
     def test_user_enrollment_session_scep_payload(self):
@@ -74,6 +76,13 @@ class TestUserEnrollment(TestCase):
         self.assertEqual(reenrollment_session.status, ReEnrollmentSession.STARTED)
         self.assertEqual(reenrollment_session.first_enrolled_at, session.created_at)
         self.assertEqual(reenrollment_session.device_enrolled_at, session.device_enrolled_at)
+        # same key as the first session, even though the session type is different
+        self.assertEqual(
+            reenrollment_session.serialize_for_event(),
+            {"enrollment_session": {"pk": reenrollment_session.pk, "type": "re", "status": "STARTED"},
+             "user_enrollment": {"pk": enrollment.pk,
+                                 "name": enrollment.name}}
+        )
         re_s, user_s = list(session.enrolled_device.iter_enrollment_session_info())
         self.assertEqual(re_s["session_type"], "RE")
         self.assertEqual(re_s["id"], reenrollment_session.pk)

--- a/zentral/contrib/mdm/events/mdm.py
+++ b/zentral/contrib/mdm/events/mdm.py
@@ -6,24 +6,39 @@ from zentral.core.events.base import BaseEvent, EventMetadata, EventRequest
 logger = logging.getLogger('zentral.contrib.mdm.events.mdm')
 
 
-class DEPEnrollmentRequestEvent(BaseEvent):
+class EnrollmentRequestEvent(BaseEvent):
+    enrollment_payload_key = None
+
+    def get_linked_objects_keys(self):
+        enrollment = self.payload.get(self.enrollment_payload_key)
+        if not enrollment:
+            # the aborted requests do not always have an enrollment session
+            return {}
+        # same object key as the audit events of the enrollment
+        return {f"mdm_{self.enrollment_payload_key}": [(enrollment["pk"],)]}
+
+
+class DEPEnrollmentRequestEvent(EnrollmentRequestEvent):
     event_type = "dep_enrollment_request"
+    enrollment_payload_key = "dep_enrollment"
     tags = ["mdm", "dep", "heartbeat"]
 
 
 register_event_type(DEPEnrollmentRequestEvent)
 
 
-class OTAEnrollmentRequestEvent(BaseEvent):
+class OTAEnrollmentRequestEvent(EnrollmentRequestEvent):
     event_type = "ota_enrollment_request"
+    enrollment_payload_key = "ota_enrollment"
     tags = ["mdm", "ota", "heartbeat"]
 
 
 register_event_type(OTAEnrollmentRequestEvent)
 
 
-class UserEnrollmentRequestEvent(BaseEvent):
+class UserEnrollmentRequestEvent(EnrollmentRequestEvent):
     event_type = "user_enrollment_request"
+    enrollment_payload_key = "user_enrollment"
     tags = ["mdm"]
 
 

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -1527,6 +1527,9 @@ class EnrolledUser(models.Model):
 
 
 class EnrollmentSession(models.Model):
+    # value of the enrollment_session.type event payload attribute, set by the subclasses
+    session_type = None
+
     realm_user = models.ForeignKey(RealmUser, on_delete=models.PROTECT, blank=True, null=True)
     enrolled_device = models.ForeignKey(EnrolledDevice, on_delete=models.CASCADE, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -1556,11 +1559,17 @@ class EnrollmentSession(models.Model):
     def is_completed(self):
         return self.status == self.COMPLETED
 
-    def serialize_for_event(self, enrollment_session_type, extra_dict):
-        d = {"pk": self.pk,
-             "type": enrollment_session_type,
-             "status": self.status}
-        return {"enrollment_session": d}
+    def serialize_for_event(self):
+        enrollment = self.get_enrollment()
+        # dep_enrollment, ota_enrollment or user_enrollment, whatever the session type: a
+        # re-enrollment session reports its enrollment under the same key as a first enrollment
+        enrollment_key = enrollment._meta.verbose_name.replace(" ", "_")
+        return {"enrollment_session": {"pk": self.pk,
+                                       "type": self.session_type,
+                                       "status": self.status},
+                # keys only: these events are posted on every enrollment attempt, and the full
+                # serialization carries the realm and the enrollment secret's metadata
+                enrollment_key: enrollment.serialize_for_event(keys_only=True)}
 
     # status update methods
 
@@ -1769,6 +1778,8 @@ class OTAEnrollmentSessionManager(models.Manager):
 
 
 class OTAEnrollmentSession(EnrollmentSession):
+    session_type = "ota"
+
     PHASE_1 = "PHASE_1"
     PHASE_2 = "PHASE_2"
     PHASE_3 = "PHASE_3"
@@ -1804,9 +1815,6 @@ class OTAEnrollmentSession(EnrollmentSession):
             return "MDM$OTA"
         else:
             raise ValueError("Wrong enrollment sessions status")
-
-    def serialize_for_event(self):
-        return super().serialize_for_event("ota", {"ota_enrollment": self.ota_enrollment.serialize_for_event()})
 
     def get_blueprint(self):
         return self.ota_enrollment.blueprint
@@ -2305,6 +2313,8 @@ class DEPEnrollmentSessionManager(models.Manager):
 
 
 class DEPEnrollmentSession(EnrollmentSession):
+    session_type = "dep"
+
     STARTED = "STARTED"
     AUTHENTICATED = "AUTHENTICATED"
     COMPLETED = "COMPLETED"
@@ -2329,9 +2339,6 @@ class DEPEnrollmentSession(EnrollmentSession):
             return "MDM$DEP"
         else:
             raise ValueError("Wrong enrollment sessions status")
-
-    def serialize_for_event(self):
-        return super().serialize_for_event("dep", {"dep_enrollment": self.dep_enrollment.serialize_for_event()})
 
     def get_blueprint(self):
         return self.dep_enrollment.blueprint
@@ -2440,6 +2447,8 @@ class UserEnrollmentSessionManager(models.Manager):
 
 
 class UserEnrollmentSession(EnrollmentSession):
+    session_type = "user"
+
     ACCOUNT_DRIVEN_START = "ACCOUNT_DRIVEN_START"
     ACCOUNT_DRIVEN_AUTHENTICATED = "ACCOUNT_DRIVEN_AUTHENTICATED"
     STARTED = "STARTED"
@@ -2471,9 +2480,6 @@ class UserEnrollmentSession(EnrollmentSession):
             return "MDM$USER"
         else:
             raise ValueError("Wrong enrollment sessions status")
-
-    def serialize_for_event(self):
-        return super().serialize_for_event("user", {"user_enrollment": self.user_enrollment.serialize_for_event()})
 
     def get_blueprint(self):
         return self.user_enrollment.blueprint
@@ -2558,6 +2564,8 @@ class ReEnrollmentSessionManager(models.Manager):
 
 
 class ReEnrollmentSession(EnrollmentSession):
+    session_type = "re"
+
     STARTED = "STARTED"
     AUTHENTICATED = "AUTHENTICATED"
     COMPLETED = "COMPLETED"
@@ -2594,9 +2602,6 @@ class ReEnrollmentSession(EnrollmentSession):
     @property
     def device_enrolled_at(self):
         return self.first_enrolled_at
-
-    def serialize_for_event(self):
-        return super().serialize_for_event("re", self.get_enrollment().serialize_for_event())
 
     def get_blueprint(self):
         return self.get_enrollment().blueprint

--- a/zentral/contrib/mdm/public_views/mdm.py
+++ b/zentral/contrib/mdm/public_views/mdm.py
@@ -161,6 +161,7 @@ class MDMView(PostEventMixin, View):
             try:
                 self.enrollment_session = (
                     ReEnrollmentSession.objects
+                    .select_related("dep_enrollment", "ota_enrollment", "user_enrollment")
                     .get(enrollment_secret__secret=enrollment_secret_secret)
                 )
             except ReEnrollmentSession.DoesNotExist:

--- a/zentral/contrib/mdm/public_views/ota.py
+++ b/zentral/contrib/mdm/public_views/ota.py
@@ -190,6 +190,6 @@ class OTAEnrollView(PostEventMixin, View):
             )
             configuration_profile_filename = "zentral_mdm"
 
-        self.post_event("success", phase=phase)
+        self.post_event("success", phase=phase, **ota_enrollment_session.serialize_for_event())
 
         return build_configuration_profile_response(configuration_profile, configuration_profile_filename)


### PR DESCRIPTION
Supersedes #1600, which reported the enrollment nested in the session. This reports it at the top level, under a key derived from the enrollment model.

`EnrollmentSession.serialize_for_event()` took an `extra_dict` from its four subclasses and dropped it:

```python
def serialize_for_event(self, enrollment_session_type, extra_dict):
    d = {"pk": self.pk,
         "type": enrollment_session_type,
         "status": self.status}
    return {"enrollment_session": d}          # extra_dict never used
```

So the enrollment session events never said which enrollment was used, and all four subclasses were building a dict for nothing. The argument was removed from the body in an unrelated commit and the callers were never cleaned up.

## Report the enrollment

At the top level of the payload, next to the session, like the munki, osquery and inventory enrollment events already do — and under a key derived from the enrollment model: `dep_enrollment`, `ota_enrollment` or `user_enrollment`. For a DEP enrollment session:

```json
{"enrollment_session": {"pk": 42, "type": "dep", "status": "COMPLETED"},
 "dep_enrollment": {"pk": 7, "name": "…", "uuid": "…"}}
```

and for a re-enrollment session of that same enrollment, where only the session type differs:

```json
{"enrollment_session": {"pk": 51, "type": "re", "status": "COMPLETED"},
 "dep_enrollment": {"pk": 7, "name": "…", "uuid": "…"}}
```

Deriving the key gets three things at once. It is the same key as the object key of the enrollment's audit events, so both kinds of events answer to the same name. It is the same key whatever the session type, so one payload attribute per enrollment model instead of one per model *and* a bare `enrollment` key that only a re-enrollment session uses. And it removes the `extra_dict` argument, and with it the merge into the session dict, where a key could silently overwrite the session's own `pk`.

The session keeps its own dict: its `status` is the status of the session, not the outcome of the request that the top-level `status` reports.

The enrollments are referenced **by their keys only**. These events are posted on every enrollment attempt, and the full serialization carries the realm, the timestamps and the metadata of the enrollment secret — the quota, the expiry, the restrictions — which is a lot to repeat, and a couple of extra queries, for something the enrollment pk already identifies. The secret itself is never serialized either way.

The re-enrollment sessions were the only ones fetched without their enrollment in the MDM view, so they get the `select_related` the other three already had. Without it, reporting the enrollment would have cost one query per MDM request of every re-enrolled device, on the checkin and the command result paths.

## Two things that came with it

**The OTA enrollment events report their session.** The OTA view was the only one not doing so — it posted the phase alone, so an `ota_enrollment_request` event never said which enrollment the device was enrolling with. Both phases have the session in hand where the event is posted.

**The enrollment request events are linked to their enrollment.** They carried no linked object, so nothing pointed at the enrollment they now report and the events of an enrollment could not be fetched from a store. They are linked under `mdm_dep_enrollment`, `mdm_ota_enrollment` and `mdm_user_enrollment`, the object keys the audit events of the enrollments already use, so both kinds of events answer to the same key.

The `mdm_request` events are left out for now: they are posted on every checkin and every command result, and no view fetches the events of an enrollment yet.

## Tests

Three existing assertions were pinning the truncated payload and are updated. Added: a re-enrollment assertion for each of the three enrollment types, which is what pins the derived key; an assertion on the payload of a real `dep_enrollment_request` event and of a real `ota_enrollment_request` event; and the linked objects of the three event classes, with and without an enrollment in the payload.

Patch coverage is 100% (23 of 23 changed lines). The 3 "coverage regressions" Coveralls reports are an artifact of comparing line numbers across the diff: this branch deletes four small `serialize_for_event` overrides, so the lines below each deletion shift up by three, and `OTAEnrollmentSession.get_blueprint` — untouched here, and uncovered on main too — lands on a line number that used to hold a covered one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
