### PR TITLE
Rename constraints.txt to requirements_constraints.txt so the dependency graph sees the pins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
 RUN python -m venv /opt/venv && /opt/venv/bin/pip install -U pip setuptools wheel
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY constraints.txt requirements*.txt ./
+COPY requirements*.txt ./
 RUN pip install -r requirements.txt -r requirements_dev.txt -r requirements_aws.txt -r requirements_gcp.txt
 
 # Build the CSS and JS dist files

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -28,11 +28,11 @@ jobs:
     with:
       scan-args: |-
         --lockfile ./package-lock.json
-        --lockfile requirements.txt:./constraints.txt
+        --lockfile requirements.txt:./requirements_constraints.txt
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1" # v2.5.0
     with:
       scan-args: |-
         --lockfile ./package-lock.json
-        --lockfile requirements.txt:./constraints.txt
+        --lockfile requirements.txt:./requirements_constraints.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN set -eux ; \
 RUN python -m venv /opt/venv && /opt/venv/bin/pip install -U pip setuptools wheel
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY constraints.txt requirements.txt ./
+COPY requirements_constraints.txt requirements.txt ./
 RUN pip install -r requirements.txt
 
 # Build the CSS and JS dist files
@@ -88,19 +88,19 @@ RUN npm install && npm run build
 
 # Installing the extra requirements for dev
 FROM base-builder AS dev-builder
-COPY constraints.txt requirements_*.txt ./
+COPY requirements_*.txt ./
 RUN pip install -r requirements_dev.txt -r requirements_aws.txt -r requirements_gcp.txt
 
 
 # Installing the extra requirements for aws
 FROM base-builder AS aws-builder
-COPY constraints.txt requirements_aws.txt ./
+COPY requirements_constraints.txt requirements_aws.txt ./
 RUN pip install -r requirements_aws.txt
 
 
 # Installing the extra requirements for gcp
 FROM base-builder AS gcp-builder
-COPY constraints.txt requirements_gcp.txt ./
+COPY requirements_constraints.txt requirements_gcp.txt ./
 RUN pip install -r requirements_gcp.txt
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--c constraints.txt
+-c requirements_constraints.txt
 
 asn1crypto                      # MDM, mTLS, SCEP
 azure-storage-blob

--- a/requirements_aws.txt
+++ b/requirements_aws.txt
@@ -1,4 +1,4 @@
--c constraints.txt
+-c requirements_constraints.txt
 
 # Django file storgae
 django-storages[boto3]

--- a/requirements_constraints.txt
+++ b/requirements_constraints.txt
@@ -1,3 +1,9 @@
+# Do not rename this back to constraints.txt: GitHub's dependency graph only
+# parses requirements*.txt files, and only refreshes a manifest when that file
+# itself changes. Under the old name the pins were invisible, and the Dependabot
+# alerts kept matching whatever versions were current the last time
+# requirements.txt happened to be edited.
+
 aiohappyeyeballs==2.6.1
 aiohttp==3.14.3
 aiosignal==1.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
--c constraints.txt
+-c requirements_constraints.txt
 
 coverage

--- a/requirements_gcp.txt
+++ b/requirements_gcp.txt
@@ -1,4 +1,4 @@
--c constraints.txt
+-c requirements_constraints.txt
 
 # Django file storage
 django-storages[google]


### PR DESCRIPTION
## Problem

The Dependabot alert list has been reporting vulnerabilities that our pins already fix. All of the currently open pip alerts — for `django`, `cryptography`, `aiohttp`, `h2` and `pyasn1` — are satisfied on `main`:

| package | dependency graph | pinned on `main` | first patched |
|---|---|---|---|
| django | 5.2.14 | **5.2.16** | 5.2.16 |
| cryptography | 46.0.7 | **50.0.0** | 50.0.0 |
| aiohttp | 3.14.0 | **3.14.3** | 3.14.3 |
| h2 | 4.3.0 | **4.4.1** | 4.4.1 |
| pyasn1 | 0.6.3 | **0.6.4** | 0.6.4 |

Those "dependency graph" versions are not arbitrary: they are the exact contents of `constraints.txt` at commit 0d007fcc (2026-06-05), which is the last commit that touched `requirements.txt` itself.

## Cause

`requirements.txt` carries no versions and delegates them to `-c constraints.txt`. GitHub parses `requirements.txt` as a manifest and follows the `-c` include to resolve versions, but:

1. `constraints.txt` is not a manifest in its own right. The repository's dependency graph lists 15 manifests — `requirements.txt`, `requirements_aws.txt`, `requirements_dev.txt`, `requirements_gcp.txt`, `pyproject.toml`, `package-lock.json`, … — and `constraints.txt` is not among them, because the name does not match the patterns recognised for pip.
2. A manifest is only re-parsed when that file itself changes. `requirements.txt` has not changed since 2026-06-05, while `constraints.txt` has changed 11 times since — including every security bump (Django 5.2.16, pyasn1 0.6.4, aiohttp 3.14.3, cryptography 50.0.0). None of them dirtied `requirements.txt`, so the graph never re-read it.

This is specific to the pip side: `package-lock.json` was updated on 2026-08-07 and all 182 npm packages in the SBOM match the lockfile exactly.

It is also the same blind spot the OSV workflow already works around explicitly, by telling the scanner to treat the file as a requirements lockfile (`--lockfile requirements.txt:./constraints.txt`). OSV offers that override; the dependency graph does not.

## Fix

Rename `constraints.txt` to `requirements_constraints.txt`, so the pin file lands in the set the dependency graph already parses — `requirements_aws.txt`, `requirements_dev.txt` and `requirements_gcp.txt` are all picked up under the same pattern. From then on a pin bump touches a watched manifest and refreshes the graph on its own.

Included:

- the four `-c` lines in `requirements*.txt`
- the `COPY` lines in `Dockerfile` and `.devcontainer/Dockerfile`. The `dev-builder` and devcontainer stages used a glob that now covers the new name, so they no longer name the constraints file separately; the `aws-builder` and `gcp-builder` stages still name it explicitly
- the two `--lockfile` arguments in `.github/workflows/osv-scanner.yml`, keeping the explicit parser prefix
- a comment at the top of the file recording why it is not simply called `constraints.txt`

No pins change.

## Verification

`docker build --target dev-builder` passes locally, which exercises the reworked `COPY` lines. `pip freeze` in the resulting image confirms the constraints are applied under the new name, across all four requirements files:

```
aiohttp==3.14.3           cryptography==50.0.0     Django==5.2.16    h2==4.4.1
pyasn1==0.6.4             coverage==7.14.0         django-storages==1.14.6
google-cloud-pubsub==2.35.0
```

(`coverage` comes from `requirements_dev.txt`, `django-storages` from `requirements_aws.txt`, `google-cloud-pubsub` from `requirements_gcp.txt`.) The Tests workflow builds the same stages via docker compose, and the Docker workflow builds all three `APP_ENV` variants (`dev`, `aws`, `gcp`) on the pull request, so every reworked `COPY` line is covered by CI.

After merge, the dependency graph re-parse should show `requirements_constraints.txt` as a manifest with current versions, and the open alerts for the five packages above should close on their own.

One expected side effect: the graph will now record all pins in the file as direct dependencies, including the dev-only ones such as `coverage`. That is a more accurate picture of what actually gets installed, but it may surface alerts for transitive packages that the stale resolution was hiding.
