### PR TITLE
santa: send a stable non matching path regex in the preflight response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,8 @@ A Santa sync incident is updated when the severity is raised on the configuratio
 
 Santa ballot events link every configuration their votes name, and not only the last one.
 
+The Santa preflight response falls back to a stable non matching path regex when a configuration has none. A fresh random one was sent on every full sync, and the clients flush all their decision caches whenever a path regex changes, twice per sync in this case.
+
 `santactl doctor` does not report a broken sync connection on a healthy server anymore.
 
 

--- a/tests/santa/test_configuration.py
+++ b/tests/santa/test_configuration.py
@@ -1,3 +1,4 @@
+import re
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.santa.models import Configuration
@@ -37,7 +38,7 @@ class SantaConfigurationTestCase(TestCase):
         self.assertTrue("AllowedPathRegex" not in local_config)
         sync_server_config = config.get_sync_server_config(get_random_string(12), (1, 14))
         self.assertEqual(sync_server_config["blocked_path_regex"], blocked_path_regex)
-        self.assertTrue(sync_server_config["allowed_path_regex"].startswith("NON_MATCHING_PLACEHOLDER_"))
+        self.assertEqual(sync_server_config["allowed_path_regex"], Configuration.NON_MATCHING_PATH_REGEX)
 
     def test_allowed_path_regex_default_blocked_path_regex(self):
         allowed_path_regex = get_random_string(34)
@@ -48,7 +49,24 @@ class SantaConfigurationTestCase(TestCase):
         self.assertTrue("BlockedPathRegex" not in local_config)
         sync_server_config = config.get_sync_server_config(get_random_string(12), (1, 14))
         self.assertEqual(sync_server_config["allowed_path_regex"], allowed_path_regex)
-        self.assertTrue(sync_server_config["blocked_path_regex"].startswith("NON_MATCHING_PLACEHOLDER_"))
+        self.assertEqual(sync_server_config["blocked_path_regex"], Configuration.NON_MATCHING_PATH_REGEX)
+
+    def test_non_matching_path_regex_stable_across_preflights(self):
+        # a value that changed on every preflight made the client flush all its decision
+        # caches twice per full sync
+        config = Configuration.objects.create(name=get_random_string(256))
+        serial_number = get_random_string(12)
+        first = config.get_sync_server_config(serial_number, (1, 14))
+        second = config.get_sync_server_config(serial_number, (1, 14))
+        for attr in ("allowed_path_regex", "blocked_path_regex"):
+            self.assertEqual(first[attr], Configuration.NON_MATCHING_PATH_REGEX)
+            self.assertEqual(first[attr], second[attr])
+
+    def test_non_matching_path_regex_matches_no_path(self):
+        # the client compiles the pattern with ICU, re only guards against the constant being
+        # replaced by something a path could match
+        for path in ("/", "/usr/local/bin/santactl", Configuration.NON_MATCHING_PATH_REGEX, ""):
+            self.assertIsNone(re.search(Configuration.NON_MATCHING_PATH_REGEX, path))
 
     def test_enable_all_event_upload_local_config(self):
         config = Configuration.objects.create(name=get_random_string(256))

--- a/tests/santa/test_santa_api_views.py
+++ b/tests/santa/test_santa_api_views.py
@@ -172,8 +172,8 @@ class SantaAPIViewsTestCase(TestCase):
         self.assertEqual(json_response["client_mode"], Configuration.PREFLIGHT_MONITOR_MODE)
         self.assertEqual(json_response["full_sync_interval"], Configuration.DEFAULT_FULL_SYNC_INTERVAL)
         self.assertEqual(json_response["sync_type"], "CLEAN")
-        self.assertTrue(json_response["blocked_path_regex"].startswith("NON_MATCHING_PLACEHOLDER_"))
-        self.assertTrue(json_response["allowed_path_regex"].startswith("NON_MATCHING_PLACEHOLDER_"))
+        self.assertEqual(json_response["blocked_path_regex"], Configuration.NON_MATCHING_PATH_REGEX)
+        self.assertEqual(json_response["allowed_path_regex"], Configuration.NON_MATCHING_PATH_REGEX)
 
         # enrollment event
         events = list(call_args.args[0] for call_args in post_event.call_args_list)
@@ -218,8 +218,8 @@ class SantaAPIViewsTestCase(TestCase):
         self.assertEqual(json_response["client_mode"], Configuration.PREFLIGHT_MONITOR_MODE)
         self.assertEqual(json_response["full_sync_interval"], Configuration.DEFAULT_FULL_SYNC_INTERVAL)
         self.assertEqual(json_response["sync_type"], "CLEAN")
-        self.assertTrue(json_response["blocked_path_regex"].startswith("NON_MATCHING_PLACEHOLDER_"))
-        self.assertTrue(json_response["allowed_path_regex"].startswith("NON_MATCHING_PLACEHOLDER_"))
+        self.assertEqual(json_response["blocked_path_regex"], Configuration.NON_MATCHING_PATH_REGEX)
+        self.assertEqual(json_response["allowed_path_regex"], Configuration.NON_MATCHING_PATH_REGEX)
 
     def test_deprecated_preflight(self):
         data, serial_number, hardware_uuid = self._get_preflight_data()

--- a/zentral/contrib/santa/models.py
+++ b/zentral/contrib/santa/models.py
@@ -509,6 +509,13 @@ class Configuration(models.Model):
     PREFLIGHT_LOCKDOWN_MODE = "LOCKDOWN"
     DEFAULT_BATCH_SIZE = 50
     DEFAULT_FULL_SYNC_INTERVAL = 600
+    # The preflight path regex fields have explicit presence: omitting one leaves the pattern the
+    # client already persisted in place, so an emptied regex has to be overwritten with a pattern
+    # that cannot match. Not an empty string: ICU rejects it, which clears the sync state key and
+    # lets a regex still set in the configuration profile take over again. Not a placeholder path
+    # either, which would be the same known allow rule in every deployment. A failing lookahead
+    # matches nothing, anchored or not, and stays byte for byte the same between preflights.
+    NON_MATCHING_PATH_REGEX = "(?!)"
     SYNC_SERVER_CONFIGURATION_ATTRIBUTES = {
         # 'client_mode', has to be translated to a string value
         # 'clean_sync' managed dynamically
@@ -684,7 +691,7 @@ class Configuration(models.Model):
         for attr in ("allowed_path_regex",
                      "blocked_path_regex"):
             if not config.get(attr):
-                config[attr] = "NON_MATCHING_PLACEHOLDER_{}".format(get_random_string(8))
+                config[attr] = self.NON_MATCHING_PATH_REGEX
 
         # enable_all_event_upload
         config["enable_all_event_upload"] = (


### PR DESCRIPTION
## The bug

When a configuration has no allowed or blocked path regex, the preflight response falls back to a placeholder that cannot match. That placeholder was regenerated on every request:

```python
config[attr] = "NON_MATCHING_PLACEHOLDER_{}".format(get_random_string(8))
```

The client watches both patterns and flushes **all** of its decision caches whenever one changes, comparing them as strings:

```objc
if ((!newValue && !oldValue) || ([newValue.pattern isEqualToString:oldValue.pattern])) {
  return;
}
LOGI(@"AllowedPathRegex changed. Flushing caches.");
auth_result_cache->FlushCache(FlushCacheMode::kAllCaches, FlushCacheReason::kPathRegexChanged);
```

Both regexes default to empty, so a machine with neither set threw away its entire authorization cache twice per full sync — every 600s by default — and re-evaluated every executing binary from scratch.

## The fix

The fallback is a failing lookahead, `(?!)`, held in `Configuration.NON_MATCHING_PATH_REGEX`. It is unmatchable by construction rather than by luck of anchoring, and it is byte for byte identical between preflights, so the client's comparison short-circuits and no flush happens.

Two alternatives were rejected, both checked against `NSRegularExpression` rather than Python's `re`:

- **Omitting the key.** The field has explicit presence (`resp.has_allowed_path_regex()`), so a client that does not receive it keeps the pattern it already persisted. An emptied regex would never be cleared.
- **Sending an empty string.** ICU refuses to compile an empty pattern, so the client stores nil, which *removes* the sync state key. `allowedPathRegex` then falls through to the profile, and a regex still set there would take over. `(?!)` keeps the override semantics the placeholder already had.

A literal placeholder path was avoided on purpose: it would be the same known string in every deployment, and this is an open source project.

Worth noting for anyone reading the pattern later: ICU rejects a bare empty pattern but happily compiles `(?:)`, which matches everything. The two are not interchangeable.

## Expected effect on upgrade

Each machine sees the pattern change once, from its old random placeholder to `(?!)`, and flushes once. After that the fallback is stable and the periodic flushing stops.

## Tests

`tests.santa.test_configuration` and `tests.santa.test_santa_api_views` pass (75 tests). Two tests added: one asserts the fallback is identical across two preflights for the same machine, one that it matches no path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)