### PR TITLE
Encrypt the realm IdP secrets and remove them from the API

### DIFF
--- a/ee/server/realms/backends/openidc/__init__.py
+++ b/ee/server/realms/backends/openidc/__init__.py
@@ -12,6 +12,15 @@ logger = logging.getLogger("zentral.realms.backends.openidc")
 
 class OpenIDConnectRealmBackend(BaseBackend):
     name = "OpenID Connect"
+    kwargs_keys = (
+        "discovery_url",
+        "client_id",
+        "client_secret",
+        "extra_scopes",
+    )
+    encrypted_kwargs_paths = (
+        ["client_secret"],
+    )
 
     def ac_redirect_uri(self):
         "Authorization code flow redirect URI"
@@ -25,19 +34,16 @@ class OpenIDConnectRealmBackend(BaseBackend):
                              reverse("realms_public:login", args=(self.instance.uuid,)))
 
     def extra_attributes_for_display(self):
-        config = self.instance.config
         return [
-            ("Discovery URL", config.get("discovery_url"), False),
-            ("Client ID", config.get("client_id"), False),
-            ("Client secret", config.get("client_secret"), True),
+            ("Discovery URL", self.discovery_url, False),
+            ("Client ID", self.client_id, False),
+            ("Client secret", self.client_secret, True),
             ("Authorization code flow redirect URI", self.ac_redirect_uri(), False),
             ("IdP-initiated login URI", self.idp_initiated_login_uri(), False),
         ]
 
     def initialize_session(self, request, callback, **callback_kwargs):
-        config = self.instance.config
-
-        if not config.get("client_secret"):
+        if not self.client_secret:
             # PKCE
             code_challenge, code_verifier = generate_pkce_codes()
             backend_state = {"code_verifier": code_verifier}
@@ -59,22 +65,21 @@ class OpenIDConnectRealmBackend(BaseBackend):
         self._add_ras_to_session(request, ras)
 
         return build_authorization_code_flow_url(
-            config["discovery_url"],
-            config["client_id"],
+            self.discovery_url,
+            self.client_id,
             self.ac_redirect_uri(),
-            config["extra_scopes"],
+            self.extra_scopes,
             str(ras.pk),
             code_challenge
         )
 
     def update_or_create_realm_user(self, authorization_code, code_verifier):
-        config = self.instance.config
         claims = get_claims(
-            config["discovery_url"],
-            config["client_id"],
+            self.discovery_url,
+            self.client_id,
             self.ac_redirect_uri(),
             authorization_code,
-            config.get("client_secret"),
+            self.client_secret,
             code_verifier
         )
 

--- a/ee/server/realms/backends/openidc/forms.py
+++ b/ee/server/realms/backends/openidc/forms.py
@@ -24,13 +24,13 @@ class OpenIDConnectRealmForm(RealmForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.instance:
-            for attr in ("discovery_url", "client_id", "client_secret", "extra_scopes"):
-                val = self.instance.config.get(attr)
-                if val:
-                    if attr == "extra_scopes":
-                        val = ", ".join(val)
-                    self.fields[attr].initial = val
+        config = self.instance.get_backend_kwargs() if self.instance.backend else {}
+        for attr in ("discovery_url", "client_id", "client_secret", "extra_scopes"):
+            val = config.get(attr)
+            if val:
+                if attr == "extra_scopes":
+                    val = ", ".join(val)
+                self.fields[attr].initial = val
 
     def clean_extra_scopes(self):
         extra_scopes = self.cleaned_data.get("extra_scopes")

--- a/ee/server/realms/backends/openidc/serializers.py
+++ b/ee/server/realms/backends/openidc/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 class OpenIDCConfigSerializer(serializers.Serializer):
     discovery_url = serializers.URLField()
     client_id = serializers.CharField()
-    client_secret = serializers.CharField(required=False)
+    client_secret = serializers.CharField(required=False, write_only=True)
     extra_scopes = serializers.ListField(
         child=serializers.CharField(min_length=1),
         allow_empty=True,

--- a/ee/server/realms/backends/saml/__init__.py
+++ b/ee/server/realms/backends/saml/__init__.py
@@ -17,18 +17,23 @@ logger = logging.getLogger("zentral.realms.backends.saml")
 
 class SAMLRealmBackend(BaseBackend):
     name = "SAML"
+    # allow_idp_initiated_login and default_relay_state are read via the properties below,
+    # not loaded as attributes, because their values also depend on the realm login flags.
+    kwargs_keys = (
+        "idp_metadata",
+    )
 
     @property
     def allow_idp_initiated_login(self):
         return (self.instance.enabled_for_login or self.instance.user_portal) and (
-            self.instance.config.get("allow_idp_initiated_login") or False
+            self.instance.backend_kwargs.get("allow_idp_initiated_login") or False
         )
 
     @property
     def default_relay_state(self):
         return (
             self.instance.enabled_for_login or self.instance.user_portal
-        ) and self.instance.config.get("default_relay_state")
+        ) and self.instance.backend_kwargs.get("default_relay_state")
 
     def acs_url(self):
         "Assertion Consumer Service URL"
@@ -71,13 +76,10 @@ class SAMLRealmBackend(BaseBackend):
                 },
             },
         }
-        try:
-            settings["metadata"] = {"inline": [self.instance.config["idp_metadata"]]}
-        except KeyError:
-            if missing_idp_metadata_ok:
-                pass
-            else:
-                raise
+        if self.idp_metadata:
+            settings["metadata"] = {"inline": [self.idp_metadata]}
+        elif not missing_idp_metadata_ok:
+            raise KeyError("idp_metadata")
         sp_config = Saml2Config()
         sp_config.allow_unknown_attributes = True
         sp_config.load(settings)

--- a/ee/server/realms/backends/saml/forms.py
+++ b/ee/server/realms/backends/saml/forms.py
@@ -25,7 +25,7 @@ class SAMLRealmForm(RealmForm):
         super().__init__(*args, **kwargs)
         self.fields["metadata_file"].required = self.instance is None
         if self.instance:
-            self.fields["allow_idp_initiated_login"].initial = self.instance.config.get(
+            self.fields["allow_idp_initiated_login"].initial = self.instance.backend_kwargs.get(
                 "allow_idp_initiated_login"
             )
 
@@ -111,7 +111,7 @@ class SAMLRealmForm(RealmForm):
         config = {}
         idp_metadata = self.cleaned_data.get("idp_metadata")
         if not idp_metadata and self.instance:
-            idp_metadata = self.instance.config.get("idp_metadata")
+            idp_metadata = self.instance.backend_kwargs.get("idp_metadata")
         if idp_metadata:
             config["idp_metadata"] = idp_metadata
         if self.cleaned_data.get("allow_idp_initiated_login"):
@@ -120,7 +120,7 @@ class SAMLRealmForm(RealmForm):
             config["allow_idp_initiated_login"] = False
         default_relay_state = None
         if self.instance:
-            default_relay_state = self.instance.config.get("default_relay_state")
+            default_relay_state = self.instance.backend_kwargs.get("default_relay_state")
         if not default_relay_state:
             default_relay_state = str(uuid.uuid4())
         config["default_relay_state"] = default_relay_state

--- a/server/realms/backends/base.py
+++ b/server/realms/backends/base.py
@@ -1,11 +1,12 @@
 from zentral.conf import settings
+from zentral.utils.backend_model import Backend
 
 
-class BaseBackend:
+class BaseBackend(Backend):
     can_get_password = False
 
-    def __init__(self, instance):
-        self.instance = instance
+    def __init__(self, instance, load=True):
+        super().__init__(instance, load)
         self.legacy_public_endpoints_mounted = settings["apps"]["realms"].get("mount_legacy_public_endpoints", False)
 
     @property

--- a/server/realms/backends/ldap/__init__.py
+++ b/server/realms/backends/ldap/__init__.py
@@ -43,27 +43,35 @@ def get_ldap_connection(host):
 class LDAPRealmBackend(BaseBackend):
     name = "LDAP"
     can_get_password = True
+    kwargs_keys = (
+        "host",
+        "bind_dn",
+        "bind_password",
+        "users_base_dn",
+    )
+    encrypted_kwargs_paths = (
+        ["bind_password"],
+    )
 
-    def __init__(self, instance):
-        super().__init__(instance)
+    def __init__(self, instance, load=True):
+        super().__init__(instance, load)
         self._conn = None
 
     def extra_attributes_for_display(self):
-        config = self.instance.config
         return [
-            ("Host", config.get("host"), False),
-            ("Bind DN", config.get("bind_dn"), False),
-            ("Bind password", config.get("bind_password"), True),
-            ("Users base DN", config.get("users_base_dn"), False),
+            ("Host", self.host, False),
+            ("Bind DN", self.bind_dn, False),
+            ("Bind password", self.bind_password, True),
+            ("Users base DN", self.users_base_dn, False),
         ]
 
     def _get_ldap_conn(self):
         if self._conn is None:
-            self._conn = get_ldap_connection(self.instance.config.get("host"))
+            self._conn = get_ldap_connection(self.host)
         return self._conn
 
     def _get_user_dn(self, username):
-        return "uid={},{}".format(ldap.dn.escape_dn_chars(username), self.instance.config.get("users_base_dn"))
+        return "uid={},{}".format(ldap.dn.escape_dn_chars(username), self.users_base_dn)
 
     def authenticate(self, username, password):
         conn = self._get_ldap_conn()
@@ -77,7 +85,7 @@ class LDAPRealmBackend(BaseBackend):
 
     def get_user_info(self, username):
         conn = self._get_ldap_conn()
-        conn.simple_bind_s(self.instance.config.get("bind_dn"), self.instance.config.get("bind_password"))
+        conn.simple_bind_s(self.bind_dn, self.bind_password)
         user_dn = self._get_user_dn(username)
         results = conn.search_s(user_dn, ldap.SCOPE_BASE, attrlist=["*"])
         return cleanup_value(results[0][1])

--- a/server/realms/backends/ldap/forms.py
+++ b/server/realms/backends/ldap/forms.py
@@ -19,8 +19,9 @@ class LDAPRealmForm(RealmForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        config = self.instance.get_backend_kwargs() if self.instance.backend else {}
         for attr in ("host", "bind_dn", "bind_password", "users_base_dn"):
-            self.fields[attr].initial = self.instance.config.get(attr)
+            self.fields[attr].initial = config.get(attr)
 
     def clean(self):
         super().clean()

--- a/server/realms/backends/ldap/serializers.py
+++ b/server/realms/backends/ldap/serializers.py
@@ -4,5 +4,5 @@ from rest_framework import serializers
 class LDAPConfigSerializer(serializers.Serializer):
     host = serializers.CharField()
     bind_dn = serializers.CharField()
-    bind_password = serializers.CharField()
+    bind_password = serializers.CharField(write_only=True)
     users_base_dn = serializers.CharField()

--- a/server/realms/forms.py
+++ b/server/realms/forms.py
@@ -16,7 +16,7 @@ class RealmForm(forms.ModelForm):
         commit = kwargs.pop("commit", True)
         kwargs["commit"] = False
         realm = super().save(*args, **kwargs)
-        realm.config = self.get_config()
+        realm.set_backend_kwargs(self.get_config())
         if commit:
             realm.save()
         return realm

--- a/server/realms/migrations/0016_realm_backend_kwargs.py
+++ b/server/realms/migrations/0016_realm_backend_kwargs.py
@@ -1,0 +1,76 @@
+from django.db import migrations, models
+
+from zentral.core.secret_engines import encrypt_str
+
+
+BACKEND_SECRET_KEYS = {
+    "ldap": "bind_password",
+    "openidc": "client_secret",
+}
+
+
+def dedupe_realm_names(apps, schema_editor):
+    Realm = apps.get_model("realms", "Realm")
+    seen_names = set()
+    for realm in Realm.objects.all().order_by("created_at", "uuid"):
+        name = realm.name
+        suffix = 1
+        while name in seen_names:
+            suffix += 1
+            # truncated to fit in the varchar(255) column, widened only in the next operation
+            name = f"{realm.name[:240]} ({suffix})"
+        if name != realm.name:
+            realm.name = name
+            realm.save()
+        seen_names.add(name)
+
+
+def encrypt_realm_secrets(apps, schema_editor):
+    Realm = apps.get_model("realms", "Realm")
+    for realm in Realm.objects.all():
+        secret_key = BACKEND_SECRET_KEYS.get(realm.backend)
+        if not secret_key:
+            continue
+        secret = realm.backend_kwargs.get(secret_key)
+        if not secret:
+            continue
+        realm.backend_kwargs[secret_key] = encrypt_str(
+            secret, field=secret_key, model="realms.realm", pk=str(realm.pk)
+        )
+        realm.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('realms', '0015_realmgroup_scim_managed'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='realm',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+        migrations.RunPython(dedupe_realm_names),
+        migrations.AlterField(
+            model_name='realm',
+            name='name',
+            field=models.CharField(unique=True),
+        ),
+        migrations.AlterField(
+            model_name='realm',
+            name='backend',
+            field=models.CharField(
+                choices=[('ldap', 'LDAP'), ('openidc', 'OpenID Connect'), ('saml', 'SAML')],
+                editable=False,
+                max_length=255,
+            ),
+        ),
+        migrations.RenameField(
+            model_name='realm',
+            old_name='config',
+            new_name='backend_kwargs',
+        ),
+        migrations.RunPython(encrypt_realm_secrets),
+    ]

--- a/server/realms/models.py
+++ b/server/realms/models.py
@@ -1,6 +1,5 @@
 import logging
 import uuid
-from functools import partial
 from importlib import import_module
 
 import django.dispatch
@@ -11,6 +10,7 @@ from django.db.models import Q
 from django.urls import reverse
 from django.utils.functional import cached_property
 
+from zentral.utils.backend_model import BackendInstance
 from zentral.utils.time import naive_utcnow
 
 from .backends.registry import backend_classes
@@ -18,9 +18,14 @@ from .backends.registry import backend_classes
 logger = logging.getLogger('zentral.realms.models')
 
 
-class Realm(models.Model):
+class RealmBackend(models.TextChoices):
+    LDAP = "ldap", "LDAP"
+    OPENIDC = "openidc", "OpenID Connect"
+    SAML = "saml", "SAML"
+
+
+class Realm(BackendInstance):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    name = models.CharField(max_length=255)
     enabled_for_login = models.BooleanField(
         default=False,
         help_text="If True, users will be able to sign in to the Zentral admin console"
@@ -32,8 +37,9 @@ class Realm(models.Model):
     login_session_expiry = models.PositiveIntegerField(null=True, default=0)
 
     # backend + backend config
-    backend = models.CharField(max_length=255, editable=False)
-    config = models.JSONField(default=dict, editable=False)
+    backend = models.CharField(max_length=255, editable=False, choices=RealmBackend.choices)
+    backend_enum = RealmBackend
+    backend_kwargs = models.JSONField(default=dict, editable=False)
 
     # user claims mapping
     username_claim = models.CharField(max_length=255)
@@ -47,30 +53,17 @@ class Realm(models.Model):
     # SCIM
     scim_enabled = models.BooleanField(verbose_name="SCIM enabled", default=False)
 
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
     class Meta:
         ordering = ("name", "-created_at")
 
-    def __str__(self):
-        return self.name
+    def get_backend(self, load=False):
+        return backend_classes[self.backend](self, load)
 
     @cached_property
     def backend_instance(self):
         backend_class = backend_classes.get(self.backend)
         if backend_class:
             return backend_class(self)
-
-    def _get_BACKEND_config(self, backend):
-        if self.backend == backend:
-            return self.config
-
-    def __getattr__(self, name):
-        for backend in backend_classes:
-            if name == f"get_{backend}_config":
-                return partial(self._get_BACKEND_config, backend)
-        raise AttributeError
 
     def get_absolute_url(self):
         return reverse("realms:view", args=(self.uuid,))
@@ -82,15 +75,12 @@ class Realm(models.Model):
             yield user_claim, getattr(self, "{}_claim".format(user_claim))
 
     def serialize_for_event(self, keys_only=False):
-        d = {"pk": str(self.pk),
-             "name": self.name}
+        d = super().serialize_for_event(keys_only=keys_only)
         if keys_only:
             return d
         d.update({
             "enabled_for_login": self.enabled_for_login,
             "login_session_expiry": self.login_session_expiry,
-            "backend": self.backend,
-            "config": self.config,
             "username_claim": self.username_claim,
             "email_claim": self.email_claim,
             "first_name_claim": self.first_name_claim,
@@ -99,8 +89,6 @@ class Realm(models.Model):
             "custom_attr_1_claim": self.custom_attr_1_claim,
             "custom_attr_2_claim": self.custom_attr_2_claim,
             "scim_enabled": self.scim_enabled,
-            "created_at": self.created_at.isoformat(),
-            "updated_at": self.updated_at.isoformat(),
         })
         return d
 

--- a/server/realms/serializers.py
+++ b/server/realms/serializers.py
@@ -7,18 +7,18 @@ from .backends.saml.serializers import SAMLConfigSerializer
 
 class RealmSerializer(serializers.ModelSerializer):
     ldap_config = LDAPConfigSerializer(
-        source="get_ldap_config",
+        source="get_ldap_kwargs",
         required=False,
     )
     openidc_config = OpenIDCConfigSerializer(
-        source="get_openidc_config",
+        source="get_openidc_kwargs",
         required=False,
     )
     saml_config = SAMLConfigSerializer(
-        source="get_saml_config",
+        source="get_saml_kwargs",
         required=False,
     )
 
     class Meta:
         model = Realm
-        exclude = ("config",)
+        exclude = ("backend_kwargs",)

--- a/server/realms/views.py
+++ b/server/realms/views.py
@@ -80,9 +80,9 @@ class CreateRealmView(LocalUserRequiredMixin, PermissionRequiredMixin, CreateVie
         return backend_classes.get(self.backend).get_form_class()
 
     def form_valid(self, form):
-        self.object = form.save(commit=False)
-        self.object.backend = self.backend
-        self.object.save()
+        # the backend is required to encrypt the backend kwargs secrets during form save
+        form.instance.backend = self.backend
+        self.object = form.save()
         return redirect(self.object)
 
 

--- a/tests/jamf/test_jamf_models.py
+++ b/tests/jamf/test_jamf_models.py
@@ -31,6 +31,7 @@ class JamfModelsTestCase(TestCase):
         jamf_instance.rewrap_secrets()
         self.assertEqual(jamf_instance.get_password(), password)
         # upgrade to fernet secret engine
+        self.addCleanup(secret_engines.load_config, {})
         secret_engines.load_config({
             "fernet": {"backend": "zentral.core.secret_engines.backends.fernet",
                        "passwords": ["undeuxtrois"]}

--- a/tests/server_realms/test_api_views.py
+++ b/tests/server_realms/test_api_views.py
@@ -63,9 +63,9 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
               'description': '',
               'backend': 'ldap',
               'ldap_config': {
+                  # no bind_password, it is write only
                   "host": "ldap.example.com",
                   "bind_dn": "uid=zentral,ou=Users,o=yolo,dc=example,dc=com",
-                  "bind_password": "yolo",
                   "users_base_dn": 'ou=Users,o=yolo,dc=example,dc=com',
               },
               'openidc_config': None,
@@ -143,8 +143,8 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
              'backend': 'openidc',
              'ldap_config': None,
              'openidc_config': {
+                 # no client_secret, it is write only
                  "client_id": "yolo",
-                 "client_secret": "fomo",
                  "discovery_url": "https://zentral.example.com/.well-known/openid-configuration",
                  "extra_scopes": ["profile"],
              },

--- a/tests/server_realms/test_api_views.py
+++ b/tests/server_realms/test_api_views.py
@@ -60,6 +60,7 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             response.json(),
             [{'uuid': str(realm.pk),
               'name': realm.name,
+              'description': '',
               'backend': 'ldap',
               'ldap_config': {
                   "host": "ldap.example.com",
@@ -94,6 +95,7 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             response.json(),
             [{'uuid': str(realm.pk),
               'name': realm.name,
+              'description': '',
               'backend': 'saml',
               'ldap_config': None,
               'openidc_config': None,
@@ -137,6 +139,7 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             response.json(),
             {'uuid': str(realm.pk),
              'name': realm.name,
+             'description': '',
              'backend': 'openidc',
              'ldap_config': None,
              'openidc_config': {

--- a/tests/server_realms/test_public_views.py
+++ b/tests/server_realms/test_public_views.py
@@ -20,7 +20,7 @@ class SamlPublicViewsTestCase(TestCase):
             name=get_random_string(12),
             backend="saml",
             username_claim="username",
-            config={"idp_metadata": SAML2_IDP_METADATA_TEST_STRING},
+            backend_kwargs={"idp_metadata": SAML2_IDP_METADATA_TEST_STRING},
             enabled_for_login=True,
             user_portal=True,
         )

--- a/tests/server_realms/test_realm_backends.py
+++ b/tests/server_realms/test_realm_backends.py
@@ -1,15 +1,16 @@
 import uuid
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
+from ldap import LDAPError
 from realms.models import Realm, RealmAuthenticationSession
 
 from zentral.conf import settings
 
-from .utils import SAML2_IDP_METADATA_TEST_STRING
+from .utils import SAML2_IDP_METADATA_TEST_STRING, force_realm
 
 
 class RealmBackendsTestCase(TestCase):
@@ -31,22 +32,51 @@ class RealmBackendsTestCase(TestCase):
             backend="openidc",
             username_claim="username",
             email_claim="email",
-            config={"discovery_url": "https://issuer.example.com/.well-knowm/openid-configuration",
-                    "client_id": str(uuid.uuid4()),
-                    "extra_scopes": []},
+            backend_kwargs={"discovery_url": "https://issuer.example.com/.well-knowm/openid-configuration",
+                            "client_id": str(uuid.uuid4()),
+                            "extra_scopes": []},
             enabled_for_login=True
         )
         cls.saml_realm = Realm.objects.create(
             name=get_random_string(12),
             backend="saml",
             username_claim="username",
-            config={"idp_metadata": SAML2_IDP_METADATA_TEST_STRING},
+            backend_kwargs={"idp_metadata": SAML2_IDP_METADATA_TEST_STRING},
             enabled_for_login=True
         )
 
     def test_ldap_no_login(self):
         response = self.client.post(reverse("realms_public:login", args=(self.ldap_realm_no_login.pk,)))
         self.assertEqual(response.status_code, 404)
+
+    @patch("realms.backends.ldap.get_ldap_connection")
+    def test_ldap_authenticate(self, get_ldap_connection):
+        conn = Mock()
+        get_ldap_connection.return_value = conn
+        backend = force_realm().backend_instance
+        self.assertTrue(backend.authenticate("jane", "fomo"))
+        get_ldap_connection.assert_called_once_with("ldap.example.com")
+        conn.simple_bind_s.assert_called_once_with("uid=jane,ou=Users,o=yolo,dc=example,dc=com", "fomo")
+
+    @patch("realms.backends.ldap.get_ldap_connection")
+    def test_ldap_authenticate_error(self, get_ldap_connection):
+        conn = Mock()
+        conn.simple_bind_s.side_effect = LDAPError({"desc": "Yolo"})
+        get_ldap_connection.return_value = conn
+        backend = force_realm().backend_instance
+        self.assertFalse(backend.authenticate("jane", "fomo"))
+
+    @patch("realms.backends.ldap.get_ldap_connection")
+    def test_ldap_get_user_info(self, get_ldap_connection):
+        conn = Mock()
+        conn.search_s.return_value = [
+            ("uid=jane,ou=Users,o=yolo,dc=example,dc=com", {"uid": [b"jane"]})
+        ]
+        get_ldap_connection.return_value = conn
+        backend = force_realm().backend_instance
+        self.assertEqual(backend.get_user_info("jane"), {"uid": ["jane"]})
+        # the decrypted bind password is used
+        conn.simple_bind_s.assert_called_once_with("uid=zentral,ou=Users,o=yolo,dc=example,dc=com", "yolo")
 
     def test_ldap_login(self):
         next_url = "/{}".format(get_random_string(12))
@@ -79,14 +109,14 @@ class RealmBackendsTestCase(TestCase):
         self.assertEqual(url.netloc, auth_url.netloc)
         self.assertEqual(url.path, auth_url.path)
         query = parse_qs(url.query)
-        self.assertEqual(query["client_id"], [self.openidc_realm.config["client_id"]])
+        self.assertEqual(query["client_id"], [self.openidc_realm.backend_kwargs["client_id"]])
         self.assertEqual(
             query["redirect_uri"],
             ["https://{}{}".format(settings["api"]["fqdn"],
                                    reverse("realms_public:openidc_ac_redirect", args=(self.openidc_realm.pk,)))]
         )
         self.assertEqual(query["state"], [str(ras.pk)])
-        get_openid_configuration.assert_called_once_with(self.openidc_realm.config["discovery_url"])
+        get_openid_configuration.assert_called_once_with(self.openidc_realm.backend_kwargs["discovery_url"])
 
     @patch("realms.backends.openidc.lib.get_openid_configuration")
     @patch("realms.backends.openidc.lib.requests.post")
@@ -100,7 +130,7 @@ class RealmBackendsTestCase(TestCase):
         }
         verify_jws.return_value = {
             "iss": "https://issuer.example.com",
-            "aud": self.openidc_realm.config["client_id"],
+            "aud": self.openidc_realm.backend_kwargs["client_id"],
             "sub": username,
         }
         token_request.return_value.json.return_value = {
@@ -131,6 +161,17 @@ class RealmBackendsTestCase(TestCase):
         self.assertEqual(response.context["user"].username, username)
         self.assertEqual(response.context["user"].email, f"{username}@example.com")
         self.assertTemplateUsed(response, "base/index.html")
+
+    def test_saml_missing_idp_metadata(self):
+        realm = Realm.objects.create(
+            name=get_random_string(12),
+            backend="saml",
+            username_claim="username",
+        )
+        backend = realm.backend_instance
+        with self.assertRaises(KeyError):
+            backend.get_saml2_config()
+        self.assertIsNotNone(backend.get_saml2_config(missing_idp_metadata_ok=True))
 
     def test_saml_login(self):
         next_url = "/{}".format(get_random_string(12))

--- a/tests/server_realms/test_realm_models.py
+++ b/tests/server_realms/test_realm_models.py
@@ -1,10 +1,16 @@
 from django.test import TestCase
 from tests.zentral_test_utils.assertions.serialization_assertions import SerializeForEventAssertions
+from zentral.core.secret_engines import secret_engines
 from .utils import force_realm, force_realm_group, force_realm_user
 
 
 class RealmModelsTestCase(TestCase, SerializeForEventAssertions):
     maxDiff = None
+
+    def setUp(self):
+        # reset the secret engines to the default noop engine,
+        # to be able to assert the tokens stored at rest
+        secret_engines.load_config({})
 
     def test_serialize_for_event_is_json_native(self):
         realm = force_realm()
@@ -30,15 +36,16 @@ class RealmModelsTestCase(TestCase, SerializeForEventAssertions):
         self.assertEqual(
             realm.serialize_for_event(),
             {'backend': 'ldap',
-             'config': {
+             'backend_kwargs': {
                  'bind_dn': 'uid=zentral,ou=Users,o=yolo,dc=example,dc=com',
-                 'bind_password': 'yolo',
+                 'bind_password_hash': '311fe3feed16b9cd8df0f8b1517be5cb86048707df4889ba8dc37d4d68866d02',
                  'host': 'ldap.example.com',
                  'users_base_dn': 'ou=Users,o=yolo,dc=example,dc=com'
              },
              'created_at': realm.created_at.isoformat(),
              'custom_attr_1_claim': '',
              'custom_attr_2_claim': '',
+             'description': '',
              'email_claim': 'email',
              'enabled_for_login': False,
              'first_name_claim': '',
@@ -51,6 +58,36 @@ class RealmModelsTestCase(TestCase, SerializeForEventAssertions):
              'updated_at': realm.updated_at.isoformat(),
              'username_claim': 'username'}
         )
+
+    def test_realm_ldap_secrets_encrypted_at_rest(self):
+        realm = force_realm()
+        self.assertEqual(realm.backend_kwargs["bind_password"], "noop$eW9sbw==")
+        self.assertEqual(
+            realm.get_backend_kwargs(),
+            {"host": "ldap.example.com",
+             "bind_dn": "uid=zentral,ou=Users,o=yolo,dc=example,dc=com",
+             "bind_password": "yolo",
+             "users_base_dn": "ou=Users,o=yolo,dc=example,dc=com"}
+        )
+
+    def test_realm_openidc_secrets_encrypted_at_rest(self):
+        realm = force_realm(backend="openidc")
+        self.assertEqual(realm.backend_kwargs["client_secret"], "noop$Zm9tbw==")
+        self.assertEqual(realm.get_backend_kwargs()["client_secret"], "fomo")
+
+    def test_realm_saml_backend_kwargs_not_encrypted(self):
+        realm = force_realm(backend="saml")
+        self.assertEqual(
+            realm.backend_kwargs,
+            {"default_relay_state": "29eb0205-3572-4901-b773-fc82bef847ef",
+             "idp_metadata": "<md></md>"}
+        )
+
+    def test_realm_rewrap_secrets(self):
+        realm = force_realm()
+        realm.rewrap_secrets()
+        self.assertEqual(realm.backend_kwargs["bind_password"], "noop$eW9sbw==")
+        self.assertEqual(realm.get_backend_kwargs()["bind_password"], "yolo")
 
     def test_realm_group_serialize_for_event(self):
         parent_realm_group = force_realm_group()

--- a/tests/server_realms/test_realm_views.py
+++ b/tests/server_realms/test_realm_views.py
@@ -179,11 +179,30 @@ class RealmViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, payload["name"])
         realm = Realm.objects.get(name=payload["name"])
         self.assertEqual(realm.username_claim, payload["username_claim"])
+        # the bind password is not stored in cleartext
+        self.assertNotEqual(realm.backend_kwargs["bind_password"], payload["bind_password"])
+        config = realm.get_backend_kwargs()
         for k in ("host", "bind_dn", "bind_password", "users_base_dn"):
-            self.assertEqual(realm.config[k], payload[k])
+            self.assertEqual(config[k], payload[k])
             self.assertContains(response, payload[k])
         get_ldap_connection.assert_called_once_with(payload["host"])
         conn.simple_bind_s.assert_called_once_with(payload["bind_dn"], payload["bind_password"])
+
+    @patch("realms.backends.ldap.forms.get_ldap_connection")
+    def test_create_ldap_realm_post_duplicate_name(self, get_ldap_connection):
+        conn = Mock()
+        get_ldap_connection.return_value = conn
+        realm = force_realm()
+        self.login("realms.add_realm")
+        payload = {
+            k: get_random_string(12)
+            for k in ("username_claim", "host", "bind_dn", "bind_password", "users_base_dn")
+        }
+        payload["name"] = realm.name
+        response = self.client.post(reverse("realms:create", args=("ldap",)), payload, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "realms/realm_form.html")
+        self.assertFormError(response.context["form"], "name", "Realm with this Name already exists.")
 
     def test_create_openidc_realm_post(self):
         self.login("realms.change_realm", "realms.view_realm")
@@ -204,10 +223,13 @@ class RealmViewsTestCase(TestCase, LoginCase):
         realm = Realm.objects.get(name=payload["name"])
         self.assertEqual(realm.login_session_expiry, payload["login_session_expiry"])
         self.assertEqual(realm.username_claim, payload["username_claim"])
+        # the client secret is not stored in cleartext
+        self.assertNotEqual(realm.backend_kwargs["client_secret"], payload["client_secret"])
+        config = realm.get_backend_kwargs()
         for k in ("discovery_url", "client_id", "client_secret"):
-            self.assertEqual(realm.config[k], payload[k])
+            self.assertEqual(config[k], payload[k])
             self.assertContains(response, payload[k])
-        self.assertEqual(realm.config["extra_scopes"], ["un", "deux"])
+        self.assertEqual(config["extra_scopes"], ["un", "deux"])
 
     def test_create_saml_realm_post_could_not_read_saml_metadata_file(self):
         self.login("realms.change_realm", "realms.view_realm")
@@ -249,8 +271,8 @@ class RealmViewsTestCase(TestCase, LoginCase):
         realm = Realm.objects.get(name=payload["name"])
         self.assertEqual(realm.login_session_expiry, payload["login_session_expiry"])
         self.assertEqual(realm.username_claim, payload["username_claim"])
-        self.assertEqual(realm.config["idp_metadata"], "yolo")
-        self.assertEqual(realm.config["allow_idp_initiated_login"], True)
+        self.assertEqual(realm.backend_kwargs["idp_metadata"], "yolo")
+        self.assertEqual(realm.backend_kwargs["allow_idp_initiated_login"], True)
 
     @patch("realms.backends.saml.forms.Saml2Client.prepare_for_authenticate")
     @patch("realms.backends.saml.forms.Saml2Config.load")
@@ -341,6 +363,43 @@ class RealmViewsTestCase(TestCase, LoginCase):
         response = self.client.get(reverse("realms:update", args=(realm.pk,)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "realms/realm_form.html")
+        # the decrypted bind password is used as initial value
+        self.assertEqual(response.context["form"].fields["bind_password"].initial, "yolo")
+
+    def test_update_openidc_realm_get(self):
+        realm = force_realm(backend="openidc")
+        self.login("realms.change_realm")
+        response = self.client.get(reverse("realms:update", args=(realm.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "realms/realm_form.html")
+        form = response.context["form"]
+        # the decrypted client secret is used as initial value
+        self.assertEqual(form.fields["client_secret"].initial, "fomo")
+        self.assertEqual(form.fields["extra_scopes"].initial, "profile")
+
+    def test_update_saml_realm_get(self):
+        realm = force_realm(backend="saml")
+        self.login("realms.change_realm")
+        response = self.client.get(reverse("realms:update", args=(realm.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "realms/realm_form.html")
+        self.assertIsNone(response.context["form"].fields["allow_idp_initiated_login"].initial)
+
+    def test_update_saml_realm_post_no_metadata_file(self):
+        realm = force_realm(backend="saml")
+        self.login("realms.change_realm", "realms.view_realm")
+        payload = {
+            "name": get_random_string(12),
+            "username_claim": realm.username_claim,
+        }
+        response = self.client.post(reverse("realms:update", args=(realm.pk,)), payload, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "realms/realm_detail.html")
+        realm.refresh_from_db()
+        self.assertEqual(realm.name, payload["name"])
+        # the existing IdP metadata and relay state are preserved
+        self.assertEqual(realm.backend_kwargs["idp_metadata"], "<md></md>")
+        self.assertEqual(realm.backend_kwargs["default_relay_state"], "29eb0205-3572-4901-b773-fc82bef847ef")
 
     @patch("realms.backends.ldap.forms.get_ldap_connection")
     def test_update_realm_post(self, get_ldap_connection):
@@ -359,8 +418,11 @@ class RealmViewsTestCase(TestCase, LoginCase):
         realm.refresh_from_db()
         self.assertEqual(realm.name, payload["name"])
         self.assertContains(response, payload["name"])
+        # the bind password is not stored in cleartext
+        self.assertNotEqual(realm.backend_kwargs["bind_password"], payload["bind_password"])
+        config = realm.get_backend_kwargs()
         for k in ("host", "bind_dn", "bind_password", "users_base_dn"):
-            self.assertEqual(realm.config[k], payload[k])
+            self.assertEqual(config[k], payload[k])
             self.assertContains(response, payload[k])
         get_ldap_connection.assert_called_once_with(payload["host"])
         conn.simple_bind_s.assert_called_once_with(payload["bind_dn"], payload["bind_password"])

--- a/tests/server_realms/test_secrets_migration.py
+++ b/tests/server_realms/test_secrets_migration.py
@@ -1,0 +1,82 @@
+from datetime import timedelta
+from importlib import import_module
+
+from django.apps import apps
+from django.db import connection
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from realms.models import Realm
+from zentral.core.secret_engines import secret_engines
+from zentral.utils.time import naive_utcnow
+
+migration_module = import_module("realms.migrations.0016_realm_backend_kwargs")
+
+
+class RealmBackendKwargsMigrationTestCase(TestCase):
+    def setUp(self):
+        # reset the secret engines to the default noop engine,
+        # to be able to assert the tokens stored at rest
+        secret_engines.load_config({})
+
+    def _force_realm(self, backend, backend_kwargs):
+        return Realm.objects.create(
+            name=get_random_string(12),
+            backend=backend,
+            backend_kwargs=backend_kwargs,
+            username_claim="username",
+        )
+
+    def test_encrypt_realm_secrets(self):
+        ldap_realm = self._force_realm(
+            "ldap",
+            {"host": "ldap.example.com",
+             "bind_dn": "uid=zentral,ou=Users,o=yolo,dc=example,dc=com",
+             "bind_password": "yolo",
+             "users_base_dn": "ou=Users,o=yolo,dc=example,dc=com"},
+        )
+        openidc_realm = self._force_realm(
+            "openidc",
+            {"discovery_url": "https://zentral.example.com/.well-known/openid-configuration",
+             "client_id": "yolo",
+             "client_secret": "fomo",
+             "extra_scopes": []},
+        )
+        openidc_pkce_realm = self._force_realm(
+            "openidc",
+            {"discovery_url": "https://zentral.example.com/.well-known/openid-configuration",
+             "client_id": "yolo",
+             "extra_scopes": []},
+        )
+        saml_realm = self._force_realm("saml", {"idp_metadata": "<md></md>"})
+        migration_module.encrypt_realm_secrets(apps, None)
+        for realm in (ldap_realm, openidc_realm, openidc_pkce_realm, saml_realm):
+            realm.refresh_from_db()
+        self.assertEqual(ldap_realm.backend_kwargs["bind_password"], "noop$eW9sbw==")
+        self.assertEqual(ldap_realm.get_backend_kwargs()["bind_password"], "yolo")
+        self.assertEqual(openidc_realm.backend_kwargs["client_secret"], "noop$Zm9tbw==")
+        self.assertEqual(openidc_realm.get_backend_kwargs()["client_secret"], "fomo")
+        self.assertNotIn("client_secret", openidc_pkce_realm.backend_kwargs)
+        self.assertEqual(saml_realm.backend_kwargs, {"idp_metadata": "<md></md>"})
+
+    def _drop_name_unique_constraint(self):
+        # simulate the pre-migration schema, where realm names were not unique.
+        # rolled back with the test transaction.
+        table = Realm._meta.db_table
+        with connection.cursor() as cursor:
+            constraints = connection.introspection.get_constraints(cursor, table)
+            for constraint_name, constraint in constraints.items():
+                if constraint["columns"] == ["name"] and constraint["unique"]:
+                    cursor.execute(f'ALTER TABLE "{table}" DROP CONSTRAINT "{constraint_name}"')
+
+    def test_dedupe_realm_names(self):
+        self._drop_name_unique_constraint()
+        realms = [self._force_realm("ldap", {}) for _ in range(3)]
+        for realm, name, age in zip(realms, ("Yolo", "Yolo (2)", "Yolo"), (2, 1, 0)):
+            Realm.objects.filter(pk=realm.pk).update(name=name, created_at=naive_utcnow() - timedelta(days=age))
+        migration_module.dedupe_realm_names(apps, None)
+        for realm in realms:
+            realm.refresh_from_db()
+        self.assertEqual(realms[0].name, "Yolo")
+        self.assertEqual(realms[1].name, "Yolo (2)")
+        self.assertEqual(realms[2].name, "Yolo (3)")

--- a/tests/server_realms/utils.py
+++ b/tests/server_realms/utils.py
@@ -94,15 +94,17 @@ def force_realm(backend="ldap", enabled_for_login=False, user_portal=False):
         }
     else:
         raise ValueError("Unknown backend")
-    return Realm.objects.create(
+    realm = Realm(
         name=get_random_string(12),
         backend=backend,
-        config=config,
         username_claim="username",
         email_claim="email",
         enabled_for_login=enabled_for_login,
         user_portal=user_portal,
     )
+    realm.set_backend_kwargs(config)
+    realm.save()
+    return realm
 
 
 def force_realm_user(


### PR DESCRIPTION
`Realm.config` stored the IdP secrets — the LDAP `bind_password` and the OpenID Connect `client_secret` — in cleartext, and the read-only realms API returned them to any API token with the `realms.view_realm` permission.

First commit — test suite hygiene, found while fixing the CI for this PR:

* the jamf rewrap test loads a fernet secret engine into the process-global registry and never restores it, so every test after `tests/jamf` in a full suite run uses fernet instead of the default noop engine.

Second commit — `Realm` becomes a `zentral.utils.backend_model.BackendInstance`:

* `config` is renamed to `backend_kwargs`, and the two secrets are encrypted with the secret engines (`encrypted_kwargs_paths`), with a data migration for the existing realms.
* the realm backends read decrypted attributes like the other `Backend` subclasses, and the `rewrap_secrets` command picks realms up automatically.
* the realm events embed hashes of the secrets instead of the cleartext values.
* realm names are unique, like the other backend instances — the data migration renames existing duplicates (`name (2)`, …, the oldest realm keeps its name).
* realms gain a `description` field, and the forms/UI behave as before (secrets are decrypted for the form initial values and the detail page).

Third commit — the API redaction:

* `bind_password` and `client_secret` become `write_only` in the config serializers, so `GET /api/realms/` no longer returns them, and the serializers can later be reused as inputs for a realm write API.

API changes: `ldap_config.bind_password` and `openidc_config.client_secret` are no longer returned; `name` is unique; `description` is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)