### PR TITLE
incidents: make the status constraint conditions deterministic

### DIFF
--- a/tests/core_incidents/test_models.py
+++ b/tests/core_incidents/test_models.py
@@ -1,0 +1,10 @@
+from django.test import SimpleTestCase
+from zentral.core.incidents.models import Status
+
+
+class IncidentStatusTestCase(SimpleTestCase):
+    def test_open_values_deterministic_sorted_tuple(self):
+        self.assertEqual(Status.open_values(), ("IN_PROGRESS", "OPEN", "REOPENED"))
+
+    def test_closed_values_deterministic_sorted_tuple(self):
+        self.assertEqual(Status.closed_values(), ("CLOSED", "RESOLVED"))

--- a/zentral/core/incidents/migrations/0001_initial.py
+++ b/zentral/core/incidents/migrations/0001_initial.py
@@ -47,10 +47,10 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='machineincident',
-            constraint=models.UniqueConstraint(condition=models.Q(status__in={'OPEN', 'IN_PROGRESS', 'REOPENED'}), fields=('incident', 'serial_number'), name='one_open_machine_incident_per_incident'),
+            constraint=models.UniqueConstraint(condition=models.Q(status__in=('IN_PROGRESS', 'OPEN', 'REOPENED')), fields=('incident', 'serial_number'), name='one_open_machine_incident_per_incident'),
         ),
         migrations.AddConstraint(
             model_name='incident',
-            constraint=models.UniqueConstraint(condition=models.Q(status__in={'OPEN', 'IN_PROGRESS', 'REOPENED'}), fields=('probe_source',), name='one_open_incident_per_probe'),
+            constraint=models.UniqueConstraint(condition=models.Q(status__in=('IN_PROGRESS', 'OPEN', 'REOPENED')), fields=('probe_source',), name='one_open_incident_per_probe'),
         ),
     ]

--- a/zentral/core/incidents/migrations/0002_auto_20211201_1224.py
+++ b/zentral/core/incidents/migrations/0002_auto_20211201_1224.py
@@ -106,7 +106,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='incident',
             constraint=models.UniqueConstraint(
-                condition=models.Q(status__in={'REOPENED', 'OPEN', 'IN_PROGRESS'}),
+                condition=models.Q(status__in=('IN_PROGRESS', 'OPEN', 'REOPENED')),
                 fields=('incident_type', 'key'),
                 name='one_open_incident_per_incident_type_and_key'),
         ),

--- a/zentral/core/incidents/models.py
+++ b/zentral/core/incidents/models.py
@@ -41,11 +41,13 @@ class Status(Enum):
 
     @classmethod
     def open_values(cls):
-        return {cls.OPEN.value, cls.IN_PROGRESS.value, cls.REOPENED.value}
+        # sorted tuple, not a set: used in migration-serialized constraint conditions,
+        # where the iteration order must not depend on the process hash seed
+        return (cls.IN_PROGRESS.value, cls.OPEN.value, cls.REOPENED.value)
 
     @classmethod
     def closed_values(cls):
-        return {cls.CLOSED.value, cls.RESOLVED.value}
+        return (cls.CLOSED.value, cls.RESOLVED.value)
 
     def next_statuses(self):
         if self == Status.OPEN or self == Status.REOPENED:


### PR DESCRIPTION
`manage.py makemigrations --check` non-deterministically (roughly 1 run in 2–3) reports `- Remove constraint / + Create constraint` drift for the `Incident` and `MachineIncident` unique constraints.

### Cause

`Status.open_values()` returns a `set`, used in the `Q(status__in=...)` conditions of `one_open_incident_per_incident_type_and_key` and `one_open_machine_incident_per_incident`. Set iteration order depends on the process hash seed, and since Django 5.2 `Q.__eq__` compares `Q.identity`, which runs values through `make_hashable()` — an unhashable `set` becomes a tuple **in iteration order**. Two sets with the same elements can therefore compare unequal depending on the seed, and the autodetector flags the constraints as changed. Deterministic repro: with `PYTHONHASHSEED=0`, the check always fails on `machineincident`.

### Fix

- `Status.open_values()` / `closed_values()` now return sorted tuples. All other call sites are `status__in` lookups, membership tests, or a `tuple()` conversion, so the type change is transparent.
- The set literals frozen in the existing `0001` / `0002` migrations are updated in place to the same sorted tuples, so the projected migration state matches the models. No new migration and no DDL: applied migrations are recorded by name and never re-run, and on a fresh install the resulting schema is identical (the order inside the `IN` clause is irrelevant). The legacy `one_open_incident_per_probe` literal in `0001` (removed again in `0002`) gets the same treatment for consistency.
- A small test locks the deterministic values.

### Verification

`makemigrations --check --dry-run` run 13× (`PYTHONHASHSEED` pinned 0–9, plus 3 random seeds): 13/13 `No changes detected`. Before the fix, seed 0 reliably reproduced the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
