### PR TITLE
mdm: pass the enrolled user to the cert issuers in the credential views

### DIFF
--- a/tests/mdm/test_mdm_views.py
+++ b/tests/mdm/test_mdm_views.py
@@ -24,6 +24,7 @@ from realms.models import RealmGroup, RealmUserGroupMembership
 from zentral.contrib.inventory.models import MachineTag, MetaBusinessUnit, Tag
 from zentral.contrib.mdm.apps_books import get_otf_association_cache_key
 from zentral.contrib.mdm.artifacts import Target, update_blueprint_serialized_artifacts
+from zentral.contrib.mdm.cert_issuer_backends.static_challenge import StaticChallenge
 from zentral.contrib.mdm.commands import (
     CustomCommand,
     DeviceLock,
@@ -2960,7 +2961,12 @@ class MDMViewsTestCase(TestCase):
         token = dump_cert_asset_token(
             session, Target(session.enrolled_device, enrolled_user), artifact_version.pk
         )
-        response = self.client.get(reverse("mdm_public:acme_credential", args=(token,)))
+        with patch(
+            "zentral.contrib.mdm.cert_issuer_backends.static_challenge.StaticChallenge.update_acme_payload",
+            autospec=True,
+            side_effect=StaticChallenge.update_acme_payload,
+        ) as update_acme_payload:
+            response = self.client.get(reverse("mdm_public:acme_credential", args=(token,)))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["Content-Type"], "application/json")
         self.assertEqual(
@@ -2980,6 +2986,10 @@ class MDMViewsTestCase(TestCase):
                 "UsageFlags": 1,
             },
         )
+        update_acme_payload.assert_called_once()
+        _, _, _, _, req_enrollment_session, req_enrolled_user = update_acme_payload.call_args.args
+        self.assertEqual(req_enrollment_session, session)
+        self.assertEqual(req_enrolled_user, enrolled_user)
 
     # scep credential download view
 
@@ -3065,7 +3075,12 @@ class MDMViewsTestCase(TestCase):
         token = dump_cert_asset_token(
             session, Target(session.enrolled_device, enrolled_user), artifact_version.pk
         )
-        response = self.client.get(reverse("mdm_public:scep_credential", args=(token,)))
+        with patch(
+            "zentral.contrib.mdm.cert_issuer_backends.static_challenge.StaticChallenge.update_scep_payload",
+            autospec=True,
+            side_effect=StaticChallenge.update_scep_payload,
+        ) as update_scep_payload:
+            response = self.client.get(reverse("mdm_public:scep_credential", args=(token,)))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["Content-Type"], "application/json")
         scep_issuer = artifact_version.cert_asset.scep_issuer
@@ -3087,6 +3102,10 @@ class MDMViewsTestCase(TestCase):
                 "URL": scep_issuer.url,
             },
         )
+        update_scep_payload.assert_called_once()
+        _, _, req_enrollment_session, req_enrolled_user = update_scep_payload.call_args.args
+        self.assertEqual(req_enrollment_session, session)
+        self.assertEqual(req_enrolled_user, enrolled_user)
 
     # data asset download view
 

--- a/zentral/contrib/mdm/public_views/mdm.py
+++ b/zentral/contrib/mdm/public_views/mdm.py
@@ -590,7 +590,7 @@ class ACMECredentialView(CertCredentialView):
         if not acme:
             raise SuspiciousOperation("Device not ACME compatible")
         get_cached_cert_issuer_backend(self.object.acme_issuer).update_acme_payload(
-            cert_payload, hardware_bound, attest, self.enrollment_session
+            cert_payload, hardware_bound, attest, self.enrollment_session, self.enrolled_user
         )
 
 
@@ -601,7 +601,7 @@ class SCEPCredentialView(CertCredentialView):
         if not self.object.scep_issuer:
             raise SuspiciousOperation("Certificate Asset without SCEP issuer")
         get_cached_cert_issuer_backend(self.object.scep_issuer).update_scep_payload(
-            cert_payload, self.enrollment_session
+            cert_payload, self.enrollment_session, self.enrolled_user
         )
 
 


### PR DESCRIPTION
The SCEP and ACME credential download views (`SCEPCredentialView` and `ACMECredentialView` in `zentral/contrib/mdm/public_views/mdm.py`) called the cert issuer backends without forwarding the enrolled user, so user-channel certificate assets never reached the backends with the local user identity. The parent view already resolves the enrolled user from the download token and uses it for `$ENROLLED_USER.*` variable substitution, the backend signatures already accept `enrolled_user`, and the SCEP payloads processed by the `InstallProfile` command already forward it — these two call sites were the gap.

Both views now pass `self.enrolled_user`, which stays `None` on the device channel, i.e. the previous behavior.

The user-channel view tests are extended with a spy on the `StaticChallenge` backend methods (`autospec` with the original method as `side_effect`, so the real backend behavior and the existing response assertions are preserved) asserting that the enrollment session and the enrolled user reach the backends.

Full test suite passes locally (7725 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)