### PR TITLE
mdm: fix the UserAuthenticate check-in message type

### DIFF
--- a/tests/mdm/test_mdm_views.py
+++ b/tests/mdm/test_mdm_views.py
@@ -271,6 +271,13 @@ class MDMViewsTestCase(TestCase):
         for k, v in kwargs.items():
             self.assertEqual(last_event.payload.get(k), v)
 
+    def _assertWarning(self, post_event, **kwargs):
+        last_event = post_event.call_args.args[0]
+        self.assertIsInstance(last_event, MDMRequestEvent)
+        self.assertEqual(last_event.payload["status"], "warning")
+        for k, v in kwargs.items():
+            self.assertEqual(last_event.payload.get(k), v)
+
     def _assert_sync_tokens(self, actual, expected):
         iso_8601 = "%Y-%m-%dT%H:%M:%SZ"
         actual_datetime = datetime.strptime(actual["SyncTokens"]["Timestamp"], iso_8601)
@@ -723,10 +730,26 @@ class MDMViewsTestCase(TestCase):
         self.assertEqual(session.status, DEPEnrollmentSession.AUTHENTICATED)
         payload = {
             "UDID": udid,
-            "MessageType": "UserAutenticate",
+            "MessageType": "UserAuthenticate",
         }
         response = self._put(reverse("mdm_public:checkin"), payload, session)
         self.assertEqual(response.status_code, 410)
+        self._assertWarning(post_event, user_id=None)
+
+    def test_user_channel_user_authenticate(self, post_event):
+        session, udid, serial_number = force_dep_enrollment_session(
+            self.mbu, authenticated=True, completed=True
+        )
+        self.assertEqual(session.status, DEPEnrollmentSession.COMPLETED)
+        user_id = str(uuid.uuid4())
+        payload = {
+            "UDID": udid,
+            "UserID": user_id,  # → User channel
+            "MessageType": "UserAuthenticate",
+        }
+        response = self._put(reverse("mdm_public:checkin"), payload, session)
+        self.assertEqual(response.status_code, 410)
+        self._assertWarning(post_event, user_id=user_id)
 
     # checkin - token update
 

--- a/zentral/contrib/mdm/public_views/mdm.py
+++ b/zentral/contrib/mdm/public_views/mdm.py
@@ -465,8 +465,9 @@ class CheckinView(MDMView):
         # route the payload
         if self.message_type == "Authenticate":
             self.do_authenticate()
-        elif self.message_type == "UserAutenticate":
+        elif self.message_type == "UserAuthenticate":
             # TODO: network / mobile user management
+            # 410 tells the client we will not manage this user for the duration of the login session
             self.post_event("warning", user_id=self.enrolled_user_id)
             return HttpResponse(status=410)
         elif self.message_type == "TokenUpdate":


### PR DESCRIPTION
## Problem

`CheckinView.do_put()` routed on `"UserAutenticate"` — missing the `h`. Apple's check-in protocol sends `UserAuthenticate`, so that branch was unreachable: a real request fell through to `self.abort("unknown message type")`, which posts a failure event and raises `SuspiciousOperation`, answering **400**.

## Why it matters

Apple's check-in specification allows two answers to `UserAuthenticate`: `200` with a `DigestChallenge`, or `410` to say the server will not manage this user — after which the client makes no further requests on that user's behalf for the rest of the login session.

So the `410` this branch already intended to return was correct all along; it simply never ran. `400` is not a defined response, and leaves the handshake unresolved.

Cross-checked against Apple's published schema: `mdm/checkin/userauthenticate.yaml` in [apple/device-management](https://github.com/apple/device-management) requires `MessageType` to be `UserAuthenticate`.

## Change

- Match Apple's spelling, so the existing `410` branch runs.
- Record *why* `410` is the right answer — the branch reads like an unfinished stub otherwise.

## Tests

- `test_device_channel_user_authenticate` — corrected to the real message type, and now asserts the `warning` event payload rather than only the status code.
- `test_user_channel_user_authenticate` — added. The handshake happens per user login, so the user channel is the realistic path; this also pins `user_id` propagation into the event.
- `_assertWarning` helper added, mirroring the existing `_assertSuccess` / `_assertAbort`.

Full suite run locally: 7726 tests, OK. Patch coverage 100% on the measurable changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
