### PR TITLE
Harden the macOS package builder, stop using defusedxml

### DIFF
--- a/ee/zentral/core/stores/backends/splunk.py
+++ b/ee/zentral/core/stores/backends/splunk.py
@@ -3,10 +3,10 @@ import time
 import uuid
 from datetime import datetime, timedelta
 from urllib.parse import urlencode, urljoin
+from xml.etree.ElementTree import ParseError, fromstring
 
 import requests
 from base.utils import deployment_info
-from defusedxml.ElementTree import ParseError, fromstring
 from django.utils.functional import cached_property
 from django.utils.timezone import is_aware, make_naive
 from kombu.utils import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ celery<6
 clickhouse-connect
 django-celery-results==2.6.0
 cryptography                    # MDM, monolith (cloudfront), munki
-defusedxml
 django<6
 djangorestframework
 djangorestframework-yaml

--- a/tests/jamf/test_api_client.py
+++ b/tests/jamf/test_api_client.py
@@ -459,3 +459,39 @@ class JamfAPIClientTestCase(SimpleTestCase):
         self.assertEqual(machine_d["os_version"]["major"], 15)
         self.assertEqual(machine_d["os_version"]["minor"], 5)
         self.assertEqual(machine_d["os_version"]["patch"], 0)
+
+    # computer extension attributes
+
+    @patch("zentral.contrib.jamf.api_client.requests.Session.post")
+    @patch("zentral.contrib.jamf.api_client.requests.Session.get")
+    def test_create_text_computer_extension_attribute(self, session_get, session_post):
+        get_response = Mock()
+        get_response.status_code = 404
+        session_get.return_value = get_response
+        post_response = Mock()
+        post_response.status_code = 201
+        post_response.content = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<computer_extension_attribute><id>42</id></computer_extension_attribute>'
+        )
+        session_post.return_value = post_response
+        api_client = APIClient("host", 443, "/JSSResource", "user", "pwd", "sec")
+        self.assertEqual(
+            api_client.get_or_create_text_computer_extension_attribute("YOLO", "General"),
+            42
+        )
+
+    @patch("zentral.contrib.jamf.api_client.requests.Session.post")
+    @patch("zentral.contrib.jamf.api_client.requests.Session.get")
+    def test_create_text_computer_extension_attribute_no_id(self, session_get, session_post):
+        get_response = Mock()
+        get_response.status_code = 404
+        session_get.return_value = get_response
+        post_response = Mock()
+        post_response.status_code = 201
+        post_response.content = b"<computer_extension_attribute><name>YOLO</name></computer_extension_attribute>"
+        session_post.return_value = post_response
+        api_client = APIClient("host", 443, "/JSSResource", "user", "pwd", "sec")
+        with self.assertRaises(APIClientError) as cm:
+            api_client.get_or_create_text_computer_extension_attribute("YOLO", "General")
+        self.assertEqual(cm.exception.args[0], "Could not get created text computer extension attribute ID")

--- a/tests/utils/test_osx_package.py
+++ b/tests/utils/test_osx_package.py
@@ -1,0 +1,21 @@
+import os
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.test import SimpleTestCase
+from zentral.utils.osx_package import BasePackageBuilder
+
+
+class OSXPackageBuilderTestCase(SimpleTestCase):
+    def test_get_signature_size(self):
+        builder = BasePackageBuilder()
+        self.addCleanup(builder._clean)
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_path = os.path.join(builder.tempdir, "signing.key")
+        with open(key_path, "wb") as f:
+            f.write(private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            ))
+        # a RSA-2048 signature is the size of the modulus, 256 bytes
+        self.assertEqual(builder._get_signature_size(key_path), 256)

--- a/zentral/contrib/mdm/app_manifest.py
+++ b/zentral/contrib/mdm/app_manifest.py
@@ -5,8 +5,8 @@ import subprocess
 import tempfile
 import zipfile
 from hashlib import md5, sha256
+from xml.etree.ElementTree import ParseError, fromstring
 
-from defusedxml.ElementTree import ParseError, fromstring
 from django.core.files.uploadedfile import TemporaryUploadedFile, UploadedFile
 
 from .models import Platform

--- a/zentral/utils/osx_package.py
+++ b/zentral/utils/osx_package.py
@@ -91,27 +91,14 @@ class BasePackageBuilder(object):
 
 
 class ProductArchiveBuilder(BasePackageBuilder):
-    def __init__(self, title, product_archive=None):
+    def __init__(self, title):
         super().__init__()
         self.title = title
         self.package_name = "{}.pkg".format("_".join(s.lower() for s in self.title.split()))
         self.distribution = os.path.join(self.builddir, "Distribution")
         os.makedirs(self.builddir)
-        if product_archive:
-            self._extract_xar_archive(product_archive, self.builddir)
-            self._init_distribution()
-        else:
-            self._build_empty_distribution()
+        self._build_empty_distribution()
         self.package_dir = self.builddir
-
-    def _init_distribution(self):
-        tree = ET.parse(self.distribution)
-        title = tree.find("title")
-        title.text = self.title
-        tree.write(self.distribution, encoding="utf-8", xml_declaration=True)
-        for pkg_ref in tree.findall(".//pkg-ref[@version]"):
-            self.pkg_refs.append({"id": pkg_ref.get("id"),
-                                  "version": pkg_ref.get("version")})
 
     def get_host_architectures(self):
         # default to universal packages
@@ -222,13 +209,6 @@ class ProductArchiveBuilder(BasePackageBuilder):
         # Update pkg-refs
         self.pkg_refs.append({"id": pkg_identifier, "version": pkg_version})
 
-    def remove_pkg_ref_on_conclusion(self, pkg_ref_id):
-        tree = ET.parse(self.distribution)
-        root = tree.getroot()
-        for pkg_ref in root.findall('.//pkg-ref[@id="{}"]'.format(pkg_ref_id)):
-            pkg_ref.attrib.pop("onConclusion", None)
-        tree.write(self.distribution, encoding='utf-8', xml_declaration=True)
-
 
 def get_tls_hostname(for_client_cert_auth=False):
     if for_client_cert_auth:
@@ -329,9 +309,6 @@ class PackageBuilder(BasePackageBuilder, APIConfigToolsMixin):
     def extra_build_steps(self):
         pass
 
-    def get_product_archive(self):
-        return None
-
     def get_product_archive_title(self):
         return None
 
@@ -353,12 +330,11 @@ class PackageBuilder(BasePackageBuilder, APIConfigToolsMixin):
         self._build_bom()
 
         product_archive_title = self.get_product_archive_title()
-        product_archive = self.get_product_archive()
         extra_packages = self.get_extra_packages()
 
-        if product_archive_title or product_archive or extra_packages:
+        if product_archive_title or extra_packages:
             # build a product archive
-            builder = ProductArchiveBuilder(product_archive_title, product_archive)
+            builder = ProductArchiveBuilder(product_archive_title)
             for extra_package in extra_packages:
                 builder.add_package(extra_package)
             builder.add_package(self.package_dir)

--- a/zentral/utils/osx_package.py
+++ b/zentral/utils/osx_package.py
@@ -6,7 +6,7 @@ import os
 import plistlib
 import shutil
 import stat
-from subprocess import check_call, check_output
+from subprocess import DEVNULL, PIPE, Popen, check_call, check_output
 import tempfile
 import xml.etree.ElementTree as ET
 from django.http import HttpResponse, HttpResponseNotModified
@@ -30,7 +30,7 @@ class BasePackageBuilder(object):
         check_call(["/usr/local/bin/xar", "-x", "-C", destination, "-f", xar_archive])
 
     def _get_signature_size(self, private_key):
-        return len(check_output(": | openssl dgst -sign '{}' -binary".format(private_key), shell=True))
+        return len(check_output(["openssl", "dgst", "-sign", private_key, "-binary"], stdin=DEVNULL))
 
     def _add_cert_and_get_digest_info(self, pkg_path, certificate, signature_size):
         digest_info_file = os.path.join(self.tempdir, "digestinfo.dat")
@@ -79,9 +79,7 @@ class BasePackageBuilder(object):
 
     def _build_pkg(self):
         package_path = os.path.join(self.tempdir, self.package_name)
-        check_call('cd "{}" && '
-                   'xar --compression none -cf "{}" .'.format(self.package_dir, package_path),
-                   shell=True)
+        check_call(["xar", "--compression", "none", "-cf", package_path, "."], cwd=self.package_dir)
         certificate, private_key = self._get_certificate_and_private_key()
         if certificate and private_key:
             self._sign_pkg(package_path, certificate, private_key)
@@ -300,9 +298,16 @@ class PackageBuilder(BasePackageBuilder, APIConfigToolsMixin):
     def _build_gziped_cpio_arch(self, dirname, arch_name):
         input_path = self.get_build_path(dirname)
         output_path = self.get_build_path("base.pkg", arch_name)
-        check_call('(cd "{}" && find . | '
-                   'bsdcpio -o --quiet --format odc --owner 0:0 | '
-                   'gzip -c) > "{}"'.format(input_path, output_path), shell=True)
+        # equivalent to `find . | bsdcpio -o … | gzip -c > output_path`, run in input_path, without a shell
+        with open(output_path, "wb") as output_file:
+            find = Popen(["find", "."], cwd=input_path, stdout=PIPE)
+            cpio = Popen(["bsdcpio", "-o", "--quiet", "--format", "odc", "--owner", "0:0"],
+                         cwd=input_path, stdin=find.stdout, stdout=PIPE)
+            find.stdout.close()
+            check_call(["gzip", "-c"], stdin=cpio.stdout, stdout=output_file)
+            cpio.stdout.close()
+            find.wait()
+            cpio.wait()
 
     def _build_payload(self):
         self._build_gziped_cpio_arch("root", "Payload")


### PR DESCRIPTION
Hardening and cleanup around the macOS package builder, plus a follow-up that drops `defusedxml`. Each is a separate commit.

### 1. `utils/osx_package`: build packages without a shell
The builder shelled out to `/bin/sh` for three steps — the signature-size probe, the component-package `xar` archive, and the gzipped-cpio payload/scripts archives — interpolating paths into the command string. The path fed to the `xar` step derives from `ProductArchiveBuilder`'s title, whose whitespace stripping does **not** neutralise `$(...)`, backticks or `${IFS}`, so a caller passing an attacker-influenced product-archive title would turn that step into command injection. No production caller does today (the only one returns a constant), but the shell buys nothing here — rebuilt the three calls with argument lists (`cwd=` instead of `cd &&`, and a `find | bsdcpio | gzip` pipeline through `Popen`). `gzip` stays under `check_call` so a failing archive still raises. Behaviour is otherwise unchanged. Adds a unit test for `_get_signature_size`, which had none.

### 2. `utils/osx_package`: remove the dead product-archive-from-file path
`ProductArchiveBuilder` could be constructed from an existing product archive (extract it, seed the Distribution via `_init_distribution`). Nothing ever did — `get_product_archive()` returns `None` and no builder overrides it — so `build()` only ever passed `product_archive=None`. Dropped the parameter, the branch, `_init_distribution` and the `get_product_archive` hook. `remove_pkg_ref_on_conclusion` had no callers either; dropped it too.

### 3. `jamf`: cover the text computer extension attribute creation
`get_or_create_text_computer_extension_attribute` had no test. Covers the creation, which parses the ID out of the API response, and the response without an ID.

### 4. Stop using defusedxml
libexpat has handled these attacks for a while: the billion laughs / quadratic blowup amplification limit landed in **2.4.1**, and the large-token denial of service was fixed in **2.6.0**. `ElementTree` never expanded external entities. Our images ship expat 2.8, so `defusedxml` only buys a slightly earlier failure on entity declarations.

It even gets in the way in the app-manifest reader: expat reports the amplification breach as a `ParseError`, which the reader already turns into a clean "Invalid Distribution file", where `defusedxml` raised an `EntitiesForbidden` that nothing catches.

Drops the direct requirement. `pysaml2` still depends on `defusedxml`, so it stays installed and keeps its pin in the constraints file.

### Testing
- `ruff` + `flake8` clean
- 4138 tests pass (`tests.mdm`, `tests.core_stores`, `tests.monolith`, `tests.jamf`, `tests.osquery`, `tests.utils.test_osx_package`)
- 100% patch coverage on the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
