### PR TITLE
Fix the wrong permission names in the templates

### DIFF
--- a/server/realms/templates/realms/realmgroup_list.html
+++ b/server/realms/templates/realms/realmgroup_list.html
@@ -59,7 +59,7 @@
           {% url 'realms:update_group' obj.pk as url %}
           {% button 'UPDATE' url "Edit group" %}
         {% endif %}
-        {% if perms.realms.delete_realmgroupmapping and obj.can_be_deleted %}
+        {% if perms.realms.delete_realmgroup and obj.can_be_deleted %}
           {% url 'realms:delete_group' obj.pk as url %}
           {% button 'DELETE' url "Delete group" %}
         {% endif %}

--- a/server/templates/user_menu.html
+++ b/server/templates/user_menu.html
@@ -45,7 +45,7 @@
             {% if perms.accounts.view_user %}
             <li><a class="dropdown-item" href="{% url 'accounts:users' %}">Users</a></li>
             {% endif %}
-            {% if perms.accounts.view_group %}
+            {% if perms.auth.view_group %}
             <li><a class="dropdown-item" href="{% url 'accounts:groups' %}">Roles</a></li>
             {% endif %}
             {% if perms.accounts.view_policy %}

--- a/tests/core_stores/test_store_views.py
+++ b/tests/core_stores/test_store_views.py
@@ -79,6 +79,25 @@ class StoreViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, '<span class="store-backend">HTTP</span>')
         self.assertContains(response, "endpoint_url")
 
+    def test_store_authorized_role_link(self):
+        store = force_store()
+        store.instance.events_url_authorized_roles.add(self.group)
+        self.login("stores.view_store", "auth.view_group")
+        response = self.client.get(reverse("stores:store", args=(store.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "stores/store_detail.html")
+        self.assertContains(response, reverse("accounts:group", args=(self.group.pk,)))
+
+    def test_store_authorized_role_no_link(self):
+        store = force_store()
+        store.instance.events_url_authorized_roles.add(self.group)
+        self.login("stores.view_store")
+        response = self.client.get(reverse("stores:store", args=(store.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "stores/store_detail.html")
+        self.assertNotContains(response, reverse("accounts:group", args=(self.group.pk,)))
+        self.assertContains(response, self.group.name)
+
     def test_store_provisioned(self):
         store = force_store(provisioned=True)
         self.login("stores.view_store")

--- a/tests/inventory/test_compliance_checks_views.py
+++ b/tests/inventory/test_compliance_checks_views.py
@@ -211,6 +211,22 @@ class InventoryComplianceChecksViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, cc.compliance_check.name)
         self.assertContains(response, f"/inventory/compliance_checks/{cc.pk}/events/store_redirect/")
 
+    def test_compliance_check_update_link(self):
+        cc = self._force_jmespath_check()
+        self.login("inventory.view_jmespathcheck", "inventory.change_jmespathcheck")
+        response = self.client.get(cc.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "inventory/compliancecheck_detail.html")
+        self.assertContains(response, reverse("inventory:update_compliance_check", args=(cc.pk,)))
+
+    def test_compliance_check_no_update_link(self):
+        cc = self._force_jmespath_check()
+        self.login("inventory.view_jmespathcheck")
+        response = self.client.get(cc.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "inventory/compliancecheck_detail.html")
+        self.assertNotContains(response, reverse("inventory:update_compliance_check", args=(cc.pk,)))
+
     # events
 
     def test_cc_events_redirect(self):

--- a/tests/inventory/test_setup_views.py
+++ b/tests/inventory/test_setup_views.py
@@ -50,6 +50,20 @@ class InventorySetupViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "inventory/mbu_list.html")
         self.assertContains(response, self.mbu.name)
 
+    def test_meta_business_units_update_link(self):
+        self.login("inventory.view_metabusinessunit", "inventory.change_metabusinessunit")
+        response = self.client.get(reverse("inventory:mbu"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "inventory/mbu_list.html")
+        self.assertContains(response, reverse("inventory:update_mbu", args=(self.mbu.pk,)))
+
+    def test_meta_business_units_no_update_link(self):
+        self.login("inventory.view_metabusinessunit")
+        response = self.client.get(reverse("inventory:mbu"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "inventory/mbu_list.html")
+        self.assertNotContains(response, reverse("inventory:update_mbu", args=(self.mbu.pk,)))
+
     # create meta business unit
 
     def test_create_meta_business_unit_redirect(self):

--- a/tests/mdm/test_management_enrolled_device.py
+++ b/tests/mdm/test_management_enrolled_device.py
@@ -84,6 +84,31 @@ class EnrolledDeviceManagementViewsTestCase(TestCase, LoginCase):
                 self.assertContains(response, udid)
                 self.assertContains(response, serial_number)
 
+    def test_enrolled_devices_machine_link(self):
+        session, _, _ = force_dep_enrollment_session(self.mbu, completed=True)
+        enrolled_device = session.enrolled_device
+        self.login("mdm.view_enrolleddevice", "inventory.view_machinesnapshot")
+        response = self.client.get(reverse("mdm:enrolled_devices"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mdm/enrolleddevice_list.html")
+        self.assertContains(
+            response,
+            reverse("inventory:machine", args=(enrolled_device.get_urlsafe_serial_number(),))
+        )
+
+    def test_enrolled_devices_no_machine_link(self):
+        session, _, serial_number = force_dep_enrollment_session(self.mbu, completed=True)
+        enrolled_device = session.enrolled_device
+        self.login("mdm.view_enrolleddevice")
+        response = self.client.get(reverse("mdm:enrolled_devices"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mdm/enrolleddevice_list.html")
+        self.assertNotContains(
+            response,
+            reverse("inventory:machine", args=(enrolled_device.get_urlsafe_serial_number(),))
+        )
+        self.assertContains(response, serial_number)
+
     def test_enrolled_devices_search(self):
         self.login("mdm.view_enrolleddevice")
         response = self.client.get(reverse("mdm:enrolled_devices"),)

--- a/tests/mdm/test_management_realm_group_tag_mapping.py
+++ b/tests/mdm/test_management_realm_group_tag_mapping.py
@@ -63,6 +63,43 @@ class RealmGroupTagMappingManagementViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, "Group → Tag mappings (3)")
         self.assertContains(response, "page 2 of 3")
 
+    def test_realm_group_tag_mappings_links(self):
+        rgtm = force_realm_group_tag_mapping()
+        self.login("mdm.view_realmgrouptagmapping", "mdm.add_realmgrouptagmapping",
+                   "mdm.change_realmgrouptagmapping", "mdm.delete_realmgrouptagmapping")
+        response = self.client.get(reverse("mdm:realm_group_tag_mappings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mdm/realmgrouptagmapping_list.html")
+        self.assertContains(response, reverse("mdm:create_realm_group_tag_mapping"))
+        self.assertContains(response, reverse("mdm:update_realm_group_tag_mapping", args=(rgtm.pk,)))
+        self.assertContains(response, reverse("mdm:delete_realm_group_tag_mapping", args=(rgtm.pk,)))
+
+    def test_realm_group_tag_mappings_no_links(self):
+        rgtm = force_realm_group_tag_mapping()
+        self.login("mdm.view_realmgrouptagmapping")
+        response = self.client.get(reverse("mdm:realm_group_tag_mappings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mdm/realmgrouptagmapping_list.html")
+        self.assertNotContains(response, reverse("mdm:create_realm_group_tag_mapping"))
+        self.assertNotContains(response, reverse("mdm:update_realm_group_tag_mapping", args=(rgtm.pk,)))
+        self.assertNotContains(response, reverse("mdm:delete_realm_group_tag_mapping", args=(rgtm.pk,)))
+
+    def test_realm_group_tag_mappings_none_create_link(self):
+        self.login("mdm.view_realmgrouptagmapping", "mdm.add_realmgrouptagmapping")
+        response = self.client.get(reverse("mdm:realm_group_tag_mappings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mdm/realmgrouptagmapping_list.html")
+        self.assertContains(response, "There are no Group → Tag mappings created.")
+        self.assertContains(response, reverse("mdm:create_realm_group_tag_mapping"))
+
+    def test_realm_group_tag_mappings_none_no_create_link(self):
+        self.login("mdm.view_realmgrouptagmapping")
+        response = self.client.get(reverse("mdm:realm_group_tag_mappings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mdm/realmgrouptagmapping_list.html")
+        self.assertContains(response, "There are no Group → Tag mappings created.")
+        self.assertNotContains(response, reverse("mdm:create_realm_group_tag_mapping"))
+
     # create
 
     def test_create_realm_group_tag_mapping_redirect(self):

--- a/tests/monolith/test_setup_views.py
+++ b/tests/monolith/test_setup_views.py
@@ -744,6 +744,22 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "monolith/pkginfo_list.html")
         self.assertContains(response, self.pkginfo_name_1.name)
 
+    def test_pkg_infos_create_links(self):
+        self.login("monolith.view_pkginfo", "monolith.add_pkginfo", "monolith.add_pkginfoname")
+        response = self.client.get(reverse("monolith:pkg_infos"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "monolith/pkginfo_list.html")
+        self.assertContains(response, reverse("monolith:create_pkg_info_name"))
+        self.assertContains(response, reverse("monolith:upload_package"))
+
+    def test_pkg_infos_no_create_links(self):
+        self.login("monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_infos"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "monolith/pkginfo_list.html")
+        self.assertNotContains(response, reverse("monolith:create_pkg_info_name"))
+        self.assertNotContains(response, reverse("monolith:upload_package"))
+
     def test_pkg_infos_search(self):
         self.login("monolith.view_pkginfo")
         response = self.client.get(reverse("monolith:pkg_infos"))

--- a/tests/munki/test_script_check_views.py
+++ b/tests/munki/test_script_check_views.py
@@ -75,6 +75,15 @@ class MunkiScriptCheckViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, reverse("munki:delete_script_check", args=(sc_one.pk,)))
         self.assertContains(response, reverse("munki:update_script_check", args=(sc_one.pk,)))
 
+    def test_script_checks_delete_link_only(self):
+        sc = force_script_check()
+        self.login("munki.view_scriptcheck", "munki.delete_scriptcheck")
+        response = self.client.get(reverse("munki:script_checks"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "munki/scriptcheck_list.html")
+        self.assertContains(response, reverse("munki:delete_script_check", args=(sc.pk,)))
+        self.assertNotContains(response, reverse("munki:update_script_check", args=(sc.pk,)))
+
     def test_script_check_no_search_no_script_checks(self):
         self.login("munki.view_scriptcheck")
         response = self.client.get(reverse("munki:script_checks"))

--- a/tests/munki/test_setup_views.py
+++ b/tests/munki/test_setup_views.py
@@ -68,6 +68,18 @@ class MunkiSetupViewsTestCase(TestCase, LoginCase):
         self.assertNotContains(response, reverse("munki:configurations"))
         self.assertContains(response, reverse("munki:script_checks"))
 
+    def test_index_terraform_export_link(self):
+        self.login("munki.view_configuration", "munki.view_enrollment", "munki.view_scriptcheck")
+        response = self.client.get(reverse("munki:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("munki:terraform_export"))
+
+    def test_index_no_terraform_export_link(self):
+        self.login("munki.view_configuration", "munki.view_enrollment")
+        response = self.client.get(reverse("munki:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, reverse("munki:terraform_export"))
+
     # configurations
 
     def test_configurations_redirect(self):

--- a/tests/osquery/test_setup_atcs.py
+++ b/tests/osquery/test_setup_atcs.py
@@ -145,6 +145,22 @@ class OsquerySetupATCViewsTestCase(TestCase, LoginCase):
         response = self.client.get(reverse("osquery:atcs"))
         self.assertEqual(response.status_code, 403)
 
+    def test_atc_list_update_link(self):
+        atc, _ = self._force_atc()
+        self.login("osquery.view_automatictableconstruction", "osquery.change_automatictableconstruction")
+        response = self.client.get(reverse("osquery:atcs"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/automatictableconstruction_list.html")
+        self.assertContains(response, reverse("osquery:update_atc", args=(atc.pk,)))
+
+    def test_atc_list_no_update_link(self):
+        atc, _ = self._force_atc()
+        self.login("osquery.view_automatictableconstruction")
+        response = self.client.get(reverse("osquery:atcs"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/automatictableconstruction_list.html")
+        self.assertNotContains(response, reverse("osquery:update_atc", args=(atc.pk,)))
+
     def test_atc_list(self):
         atc, _ = self._force_atc()
         self.login("osquery.view_automatictableconstruction")

--- a/tests/osquery/test_setup_configurations.py
+++ b/tests/osquery/test_setup_configurations.py
@@ -135,6 +135,26 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertIn(configuration, response.context["object_list"])
         self.assertContains(response, configuration.name)
 
+    # configuration
+
+    def test_configuration_add_pack_link(self):
+        configuration = self._force_configuration()
+        self._force_pack()
+        self.login("osquery.view_configuration", "osquery.change_configuration")
+        response = self.client.get(reverse("osquery:configuration", args=(configuration.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/configuration_detail.html")
+        self.assertContains(response, reverse("osquery:add_configuration_pack", args=(configuration.pk,)))
+
+    def test_configuration_no_add_pack_link(self):
+        configuration = self._force_configuration()
+        self._force_pack()
+        self.login("osquery.view_configuration")
+        response = self.client.get(reverse("osquery:configuration", args=(configuration.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/configuration_detail.html")
+        self.assertNotContains(response, reverse("osquery:add_configuration_pack", args=(configuration.pk,)))
+
     # add configuration pack
 
     def test_add_configuration_pack_redirect(self):

--- a/tests/server_base/test_index.py
+++ b/tests/server_base/test_index.py
@@ -62,6 +62,20 @@ class BaseViewsTestCase(TestCase, LoginCase):
         self.assertIn(";script-src 'self' 'nonce-", response["Content-Security-Policy"])
         self.assertNotIn("unsafe-eval", response["Content-Security-Policy"])
 
+    # user menu
+
+    def test_index_roles_link(self):
+        self.login("auth.view_group")
+        response = self.client.get(reverse("base:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("accounts:groups"))
+
+    def test_index_no_roles_link(self):
+        self.login()
+        response = self.client.get(reverse("base:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, reverse("accounts:groups"))
+
     # app histograms
 
     def test_index_no_perms(self):

--- a/tests/server_base/test_template_perms.py
+++ b/tests/server_base/test_template_perms.py
@@ -1,0 +1,47 @@
+import os
+import re
+
+from django.apps import apps
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from pbac.engine import engine
+
+
+# perms.<app_label>.<codename>, or perms.<app_label> for a module wide check
+PERMS_RE = re.compile(r"\bperms\.(?P<app_label>\w+)(?:\.(?P<codename>\w+))?")
+
+# BASE_DIR is the server/ directory, the templates are spread over the whole repository
+REPO_DIR = os.path.dirname(settings.BASE_DIR)
+
+
+class TemplatePermissionsTestCase(SimpleTestCase):
+    maxDiff = None
+
+    def iter_template_paths(self):
+        roots = list(settings.TEMPLATES[0]["DIRS"])
+        roots.extend(app_config.path for app_config in apps.get_app_configs())
+        for root in roots:
+            for dirpath, _, filenames in os.walk(root):
+                for filename in filenames:
+                    if filename.endswith(".html"):
+                        yield os.path.join(dirpath, filename)
+
+    def test_template_permissions_are_registered(self):
+        checked = 0
+        unknown = []
+        for path in sorted(set(self.iter_template_paths())):
+            with open(path) as f:
+                for line_number, line in enumerate(f, 1):
+                    for match in PERMS_RE.finditer(line):
+                        app_label, codename = match.group("app_label"), match.group("codename")
+                        checked += 1
+                        if codename:
+                            if f"{app_label}.{codename}" in engine.legacy_perm_actions:
+                                continue
+                        elif app_label in engine.module_legacy_perm_actions:
+                            continue
+                        unknown.append(f"{os.path.relpath(path, REPO_DIR)}:{line_number} {match.group()}")
+        self.assertEqual(unknown, [])
+        # a scan that finds nothing would pass without checking anything
+        self.assertGreater(checked, 100)

--- a/tests/server_realms/test_realm_views.py
+++ b/tests/server_realms/test_realm_views.py
@@ -889,6 +889,24 @@ class RealmViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, "Group (1)")
         self.assertNotContains(response, "We didn't find any item related to your search")
 
+    def test_realm_groups_update_delete_links(self):
+        self.login("realms.view_realmgroup", "realms.change_realmgroup", "realms.delete_realmgroup")
+        group = force_realm_group()
+        response = self.client.get(reverse("realms:groups"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "realms/realmgroup_list.html")
+        self.assertContains(response, reverse("realms:update_group", args=(group.pk,)))
+        self.assertContains(response, reverse("realms:delete_group", args=(group.pk,)))
+
+    def test_realm_groups_no_update_delete_links(self):
+        self.login("realms.view_realmgroup")
+        group = force_realm_group()
+        response = self.client.get(reverse("realms:groups"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "realms/realmgroup_list.html")
+        self.assertNotContains(response, reverse("realms:update_group", args=(group.pk,)))
+        self.assertNotContains(response, reverse("realms:delete_group", args=(group.pk,)))
+
     # realm group
 
     def test_realm_group_redirect(self):

--- a/zentral/contrib/inventory/templates/inventory/compliancecheck_detail.html
+++ b/zentral/contrib/inventory/templates/inventory/compliancecheck_detail.html
@@ -27,7 +27,7 @@
     <div class="d-flex align-items-center mb-3">
         <h3 class="m-0 fs-5 text-secondary">Compliance check</h3>
         <div class="ms-auto">
-            {% if perms.inventory.update_jmespathcheck %}
+            {% if perms.inventory.change_jmespathcheck %}
                 {% url 'inventory:update_compliance_check' object.pk as url %}
                 {% button 'UPDATE' url "Edit Compliance Check" %}
             {% endif %}

--- a/zentral/contrib/inventory/templates/inventory/mbu_list.html
+++ b/zentral/contrib/inventory/templates/inventory/mbu_list.html
@@ -76,7 +76,7 @@
                     {% endif %}
                 </td>
                 <td class="text-end py-0">
-                    {% if perms.mbu.change_metabusinessunit %}
+                    {% if perms.inventory.change_metabusinessunit %}
                         {% url 'inventory:update_mbu' mbu.pk as url %}
                         {% button 'UPDATE' url "Edit Business Unit" %}
                     {% endif %}

--- a/zentral/contrib/mdm/templates/mdm/enrolleddevice_list.html
+++ b/zentral/contrib/mdm/templates/mdm/enrolleddevice_list.html
@@ -50,7 +50,7 @@
         <td>
             {% with enrolled_device.get_urlsafe_serial_number as urlsafe_serial_number %}
             {% if urlsafe_serial_number %}
-            {% if perms.inventory.view_machinsnapshot %}
+            {% if perms.inventory.view_machinesnapshot %}
             <a href="{% url 'inventory:machine' urlsafe_serial_number %}">{{ enrolled_device.serial_number|default:"-"|privacywrapper }}</a>
             {% else %}
             {{ enrolled_device.serial_number|default:"-"|privacywrapper }}

--- a/zentral/contrib/mdm/templates/mdm/realmgrouptagmapping_list.html
+++ b/zentral/contrib/mdm/templates/mdm/realmgrouptagmapping_list.html
@@ -12,10 +12,10 @@
 <div class="d-flex align-items-center mb-1">
     <h2 class="m-0">Group → Tag mapping{{ page_obj.paginator.count|pluralize }} ({{ page_obj.paginator.count }})</h2>
     <div class="ms-auto">
-        {% if perms.mdm.add_scepconfig %}
+        {% if perms.mdm.add_realmgrouptagmapping %}
             {% url 'mdm:create_realm_group_tag_mapping' as url %}
             {% button 'CREATE' url "Create new group → tag mapping" %}
-        {% endif %}  
+        {% endif %}
     </div>
 </div>
 
@@ -60,7 +60,7 @@
         {% url 'mdm:update_realm_group_tag_mapping' realm_group_tag_mapping.pk as url %}
         {% button 'UPDATE' url "Edit group → tag mapping" %}
         {% endif %}
-        {% if perms.mdm.delete_realmgroupmapping %}
+        {% if perms.mdm.delete_realmgrouptagmapping %}
         {% url 'mdm:delete_realm_group_tag_mapping' realm_group_tag_mapping.pk as url %}
         {% button 'DELETE' url "Delete group → tag mapping" %}
         {% endif %}
@@ -77,11 +77,11 @@
 
 {% else %}
 
-{% if perms.mdm.add_scepconfig %}
+{% if perms.mdm.add_realmgrouptagmapping %}
   {% url 'mdm:create_realm_group_tag_mapping' as link %}
   {% no_entities 'Group → Tag mappings' link %}
 {% else %}
-  {% no_entities 'Group → Tags' %}
+  {% no_entities 'Group → Tag mappings' %}
 {% endif %}
 
 {% endif %}

--- a/zentral/contrib/monolith/templates/monolith/pkginfo_list.html
+++ b/zentral/contrib/monolith/templates/monolith/pkginfo_list.html
@@ -28,17 +28,17 @@
         </button>
     </form>
     <div class="ms-auto">
-        {% if perms.add_pkginfoname or perms.add_pkginfo %}
+        {% if perms.monolith.add_pkginfoname or perms.monolith.add_pkginfo %}
         <div class="dropdown">
             <button class="btn btn-link dropdown-toggle" type="button" id="pkgInfoAdd"
                     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <i class="bi bi-plus-circle"></i>
             </button>
             <ul class="dropdown-menu" aria-labelledby="pkgInfoAdd">
-            {% if perms.add_pkginfoname %}
+            {% if perms.monolith.add_pkginfoname %}
                 <li><a class="dropdown-item" href="{% url 'monolith:create_pkg_info_name' %}">Package info name</a></li>
             {% endif %}
-            {% if perms.add_pkginfo %}
+            {% if perms.monolith.add_pkginfo %}
                 <li><a class="dropdown-item" href="{% url 'monolith:upload_package' %}">Package</a></li>
             {% endif %}
             </ul>

--- a/zentral/contrib/munki/templates/munki/index.html
+++ b/zentral/contrib/munki/templates/munki/index.html
@@ -12,7 +12,7 @@
     <div class="d-flex align-items-center mb-1">
         <h2 class="m-0">Munki</h2>
         <div class="me-auto">
-            {% if perms.view_configuration and perms.munki.view_enrollment and perms.view_scriptcheck %}
+            {% if perms.munki.view_configuration and perms.munki.view_enrollment and perms.munki.view_scriptcheck %}
                 {% url 'munki:terraform_export' as url %}
                 {% button 'DOWNLOAD' url "Download Terraform Config" %}
             {% endif %}

--- a/zentral/contrib/munki/templates/munki/scriptcheck_list.html
+++ b/zentral/contrib/munki/templates/munki/scriptcheck_list.html
@@ -69,7 +69,7 @@
             {% endfor %}
         </td>
         {% endwith %}
-        {% if perms.munki.change_scriptcheck or perms.munki.delete_script_check %}
+        {% if perms.munki.change_scriptcheck or perms.munki.delete_scriptcheck %}
         <td class="text-end">
             {% if perms.munki.change_scriptcheck %}
             {% url 'munki:update_script_check' obj.pk as url %}

--- a/zentral/contrib/osquery/templates/osquery/automatictableconstruction_list.html
+++ b/zentral/contrib/osquery/templates/osquery/automatictableconstruction_list.html
@@ -24,7 +24,7 @@
         <thead>
         <tr>
             <th>Name</th>
-            {% if perms.osquery.change_automatictableconstrucion %}
+            {% if perms.osquery.change_automatictableconstruction %}
             <th></th>
             {% endif %}
         </tr>
@@ -35,7 +35,7 @@
             <td>
             <a href="{{ atc.get_absolute_url }}">{{ atc }}</a>
             </td>
-            {% if perms.osquery.change_automatictableconstrucion %}
+            {% if perms.osquery.change_automatictableconstruction %}
             <td class="text-end py-0">
                 {% url 'osquery:update_atc' atc.id as url %}
                 {% button 'UPDATE' url "Edit ATC" %}

--- a/zentral/contrib/osquery/templates/osquery/configuration_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/configuration_detail.html
@@ -101,7 +101,7 @@
 <div class="d-flex justify-content-between mb-3">
     <h3 class="m-0" id="packs">Pack{{ configuration_pack_count|pluralize }} ({{configuration_pack_count }})</h3>
     <div class="ms-auto">
-    {% if perms.can_add_configuration_pack %}
+    {% if can_add_configuration_pack %}
         {% url 'osquery:add_configuration_pack' object.id as url %}
         {% button 'CREATE' url "Create new Pack" %}
     {% endif %}

--- a/zentral/core/stores/templates/stores/index.html
+++ b/zentral/core/stores/templates/stores/index.html
@@ -11,10 +11,6 @@
 
 <div class="d-flex align-items-center mb-1">
     <h3 class="mb-3">Store{{ store_count|pluralize }} ({{ store_count }})</h3>
-    <div class="ms-auto">
-        {% if perms.accounts.add_store %}
-        {% endif %}
-    </div>
 </div>
 
 <div class="table-responsive mb-3">

--- a/zentral/core/stores/templates/stores/store_detail.html
+++ b/zentral/core/stores/templates/stores/store_detail.html
@@ -18,12 +18,6 @@
     </div>
     <div class="d-flex align-items-center mb-3">
         <h3 class="m-0 fs-5 text-secondary">Store</h3>
-        <div class="ms-auto">
-            {% if perms.accounts.change_store and object.can_be_updated %}
-            {% endif %}
-            {% if perms.accounts.delete_store and object.can_be_deleted %}
-            {% endif %}
-        </div>
     </div>
 
     <div class="table-responsive mb-3">
@@ -57,7 +51,7 @@
                 <th>Authorized roles for store links</th>
                 <td>
                   {% for role in object.events_url_authorized_roles.all %}
-                  {% if perms.accounts.view_group %}<a href="{% url 'accounts:group' role.pk %}">{{ role }}</a>{% else %}{{ role }}{% endif %}{% if not forloop.last %}, {% endif %}
+                  {% if perms.auth.view_group %}<a href="{% url 'accounts:group' role.pk %}">{{ role }}</a>{% else %}{{ role }}{% endif %}{% if not forloop.last %}, {% endif %}
                   {% empty %}
                   -
                   {% endfor %}


### PR DESCRIPTION
13 templates referenced permissions that no role can hold: 22 `perms.…` references, three of them
in dead code.

These fail silently, and only for the users who are supposed to see the button:
`ZentralBackend.has_perm` returns `True` for any string when the user is a superuser, and
`engine.has_legacy_perm` returns `False` for anything that is not registered in
`legacy_perm_actions`. The buttons were therefore there when testing as an admin, and missing for
every role scoped user.

Three flavours, all present:

* **another model** — `realms.delete_realmgroupmapping` guarding the realm group DELETE,
  `mdm.add_scepconfig` guarding the group → tag mapping CREATE (`scepconfig` is not even in the
  `permission_models` of the mdm app, so it cannot be granted at all)
* **typo, or the wrong app label** — `view_machinsnapshot`, `automatictableconstrucion`,
  `delete_script_check`, `update_jmespathcheck`, `perms.mbu.…`, and `perms.accounts.view_group`
  where the roles are `auth` groups
* **no app label at all** — `perms.add_pkginfo`, `perms.view_scriptcheck`, … which Django resolves
  as module checks (`has_module_perms("add_pkginfo")`), always false

## Fixed

| template | was | is | hidden button |
|---|---|---|---|
| `templates/user_menu.html` | `accounts.view_group` | `auth.view_group` | Roles menu entry |
| `realms/realmgroup_list.html` | `realms.delete_realmgroupmapping` | `realms.delete_realmgroup` | DELETE |
| `inventory/compliancecheck_detail.html` | `inventory.update_jmespathcheck` | `inventory.change_jmespathcheck` | UPDATE |
| `inventory/mbu_list.html` | `mbu.change_metabusinessunit` | `inventory.change_metabusinessunit` | UPDATE |
| `mdm/enrolleddevice_list.html` | `inventory.view_machinsnapshot` | `inventory.view_machinesnapshot` | machine link |
| `mdm/realmgrouptagmapping_list.html` | `mdm.add_scepconfig` | `mdm.add_realmgrouptagmapping` | CREATE |
| `mdm/realmgrouptagmapping_list.html` | `mdm.delete_realmgroupmapping` | `mdm.delete_realmgrouptagmapping` | DELETE |
| `monolith/pkginfo_list.html` | `add_pkginfo`, `add_pkginfoname` | `monolith.` prefixed | package info creation menu |
| `munki/index.html` | `view_configuration`, `view_scriptcheck` | `munki.` prefixed | Terraform export |
| `munki/scriptcheck_list.html` | `munki.delete_script_check` | `munki.delete_scriptcheck` | DELETE, for a delete only role |
| `osquery/automatictableconstruction_list.html` | `osquery.change_automatictableconstrucion` | `osquery.change_automatictableconstruction` | UPDATE column |
| `osquery/configuration_detail.html` | `perms.can_add_configuration_pack` | `can_add_configuration_pack` | CREATE pack |
| `stores/store_detail.html` | `accounts.view_group` | `auth.view_group` | role links |

`can_add_configuration_pack` is a context variable set by `ConfigurationView`, and it already
checks `osquery.change_configuration`, so it only lost its `perms.` prefix.

Two extras:

* `stores/index.html` and `stores/store_detail.html` had three empty `{% if %}` blocks left over
  from buttons that no longer exist — there is no store creation, update or deletion view in the
  UI — so they are gone.
* the empty group → tag mapping list called itself "Group → Tags".

## Tests

Every fix comes with a shown-with-permission / hidden-without pair in the app's existing test
module, and each of them fails without its template change.

The last commit adds `tests/server_base/test_template_perms.py`: it walks the templates of every
installed app plus the `TEMPLATES` dirs and asserts that each `perms.…` reference is registered in
the pbac engine, `legacy_perm_actions` for `perms.<app>.<codename>` and
`module_legacy_perm_actions` for the module wide `perms.<app>` form. Run against the tree before
this branch it reports all 21 bad references with their file and line. It cannot catch a
permission that exists but belongs to the wrong model — the first flavour above — so it is a net,
not a proof.
