### PR TITLE
fix: bind loop variables in transaction.on_commit callbacks

### DIFF
--- a/server/accounts/management/commands/remove_expired_api_tokens.py
+++ b/server/accounts/management/commands/remove_expired_api_tokens.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
 
                     token.delete()
 
-                    def on_commit_callback():
+                    def on_commit_callback(event=event):
                         event.post()
 
                     transaction.on_commit(on_commit_callback)

--- a/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
+++ b/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
@@ -30,8 +30,8 @@ class Command(BaseCommand):
                 else:
                     self.write("OK")
 
-                    def notify():
-                        notifier.send_notification("monolith.repository", str(db_repository.pk))
+                    def notify(pk=str(db_repository.pk)):
+                        notifier.send_notification("monolith.repository", pk)
 
                     transaction.on_commit(notify)
         queues.stop()


### PR DESCRIPTION
## Summary

Two `transaction.on_commit()` callbacks are defined inside loops and close over the loop variable without binding it (ruff B023). Because Django defers on-commit callbacks until the enclosing atomic block exits, they can all run with the **last** iteration's value:

1. **`zentral/contrib/monolith/management/commands/sync_monolith_repositories.py`** — the `with transaction.atomic():` wraps the *whole* repository loop, so every `notify()` callback fires after the loop with the same late-bound `db_repository` — i.e. syncing N repositories sends N notifications that all carry the **last** repository's pk. Fixed by binding the pk at definition time:

```python
def notify(pk=str(db_repository.pk)):
    notifier.send_notification("monolith.repository", pk)
```

2. **`server/accounts/management/commands/remove_expired_api_tokens.py`** — here the atomic block is per-iteration so standalone runs are correct today, but if this ever executes inside an outer transaction (e.g. from a caller's atomic block or in tests), all deferred `on_commit_callback`s would post the last token's audit event N times. Same one-line binding fix (`event=event`).

## Testing
`python -m py_compile` passes on both files; `ruff check --select B023` goes clean. Standalone command behavior is unchanged — the binding only removes the late-binding hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)