### PR TITLE
Bump Django to 5.2.17

### DIFF
--- a/requirements_constraints.txt
+++ b/requirements_constraints.txt
@@ -35,7 +35,7 @@ coverage==7.14.0
 cryptography==50.0.0
 decorator==5.1.1
 defusedxml==0.7.1
-Django==5.2.16
+Django==5.2.17
 django-filter==25.2
 django-redis==6.0.0
 django-storages==1.14.6


### PR DESCRIPTION
Django 5.2.17 is a security release. It fixes four issues in 5.2.16:

| CVE | Severity | Issue |
| --- | --- | --- |
| CVE-2026-15307 | high | Server-side file-write and request forgery via spatial lookups |
| CVE-2026-15830 | moderate | DoS via nested geometry collections |
| CVE-2026-15920 | moderate | XSS via `URLField` values in the admin |
| CVE-2026-15337 | low | DoS in `check_for_language()` |

None of them are reachable from Zentral:

- the two spatial ones need GeoDjango — `django.contrib.gis` is not installed and there are no geometry fields,
- the `URLField` one is an admin rendering bug — `django.contrib.admin` is not in `INSTALLED_APPS` and nothing is registered with it,
- `check_for_language()` is reached through `django.views.i18n.set_language()`, which is not wired into the URLconf.

So this is hygiene rather than a fix for an exposure, but worth taking since it is an LTS patch release.

The backward incompatible change in CVE-2026-15307 (spatial lookups no longer accept `dict`, or a `str` that is not a valid `GEOSGeometry`) does not affect us for the same reason.

Only `requirements_constraints.txt` changes: `requirements.txt` carries the loose `django<6` since 0f6dd8cc, and the exact version lives in the constraints file.

## Testing

Full suite, run in its own stack against an image built from this branch, so the pin is what gets installed:

```
docker compose -p bump-django-5217 -f docker-compose.yml -f docker-compose.tests.yml build web
docker compose -p bump-django-5217 -f docker-compose.yml -f docker-compose.tests.yml run --rm web tests --noinput
```

```
Ran 7799 tests in 107.139s

OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
