### PR TITLE
docs: centralize the API token documentation

### DIFF
--- a/docs/apps/core.md
+++ b/docs/apps/core.md
@@ -2,6 +2,110 @@
 
 The Zentral core app supports common functionalities for other apps.
 
+## API authentication
+
+Every Zentral HTTP API request is authenticated with an API token, passed in the `Authorization` HTTP header:
+
+```
+Authorization: Token the_token_string
+```
+
+A token belongs to a **user** or to a **service account**, and carries that account's privileges — what a token may do is decided by the [PBAC policies](../configuration/pbac.md) that apply to its account, never by the token itself. Tokens are prefixed accordingly: `ztlu_` for a user token, `ztls_` for a service account token.
+
+Zentral only stores a hash of the token, so a token that has been lost cannot be recovered — only replaced. An unknown, malformed or expired token is rejected with a `401`.
+
+### Service accounts
+
+A service account is a Zentral account that cannot sign in to the web console — it exists to hold API credentials. Use one per integration, so that a leaked token can be revoked without disturbing anything else.
+
+To create one, open the **Platform settings** menu (the ⋮ icon in the top right corner), go to *Users*, and click on the [+] button in the *Service accounts* section.
+
+|Field|Description|
+|---|---|
+|Name|Required. Up to 150 characters: letters, digits and `.`, `+`, `-`, `_`.|
+|Description|Optional, free text.|
+|Roles|The [roles](../configuration/pbac.md) the account belongs to. You can only grant roles you hold yourself.|
+
+The account's email address is derived from its name and the deployment's `api.fqdn` — you do not set it.
+
+A brand new service account has **no token and no privileges**. Add a token (see below), then write a [PBAC policy](../configuration/pbac.md) granting it the actions it needs. Its detail page shows the principal to reference in that policy, `ServiceAccount::"<pk>"`.
+
+### API tokens
+
+An account can hold several tokens, each with its own name and its own optional expiry. They are listed in a table, with their creation date, expiration date, and an *Active* or *Expired* badge.
+
+* **your own tokens** are managed from *User settings > Profile* (the person icon in the top right corner);
+* **a service account's tokens** are managed from its detail page, under *Platform settings > Users*.
+
+To add one, click on the [+] (*Add Token*) button above the token list.
+
+|Field|Description|
+|---|---|
+|Token name|A descriptive name. It is how you will recognise the token in the list later, and it is recorded in the audit events.|
+|Expiry|Optional. Must be a date in the future. Leave it empty for a token that never expires.|
+
+The token is displayed **once**, on the page that follows. Click the eye icon to reveal it, and the clipboard icon to copy it. Once you have stored it — in a password manager, a CI secret, a configuration variable, … — click [Close]. It cannot be retrieved afterwards, but you can always create another one.
+
+Each row in the token list carries a pencil (*Update API Token*) button, which changes the token's name and expiry **without re-issuing it**, and a trash (*Delete API Token*) button, which revokes it immediately.
+
+#### Who can issue a token for whom
+
+Issuing a token means handing out a credential, so Zentral is deliberately restrictive:
+
+* anyone can create a token for **themselves**, from their own profile page;
+* **nobody can create a token for another user** — not even a superuser. A user who needs a token creates their own;
+* creating a token for a **service account** additionally requires the `Accounts::Action::"createAPIToken"` action *and* holding every role that service account holds. This stops an operator from minting a credential more privileged than themselves. A service account named directly by a PBAC policy can only be issued tokens by a superuser, since its privileges no longer follow from its roles.
+
+The same rule guards the pencil button on a service account's token: pushing an expiry date out keeps a credential alive, so it needs `Accounts::Action::"updateAPIToken"` and the same role check.
+
+Revocation is intentionally easier than issuance: `Accounts::Action::"deleteAPIToken"` is enough to delete any token, with no role check, and you can always delete your own.
+
+### Expiring tokens
+
+A token with an expiration date stops authenticating the moment it passes — requests get a `401` — but the row stays in the list, badged *Expired*, so it is visible rather than silently gone. Rotating a token is therefore: create the new one, deploy it, then delete the old one.
+
+Expired tokens can be purged with a management command:
+
+```bash
+python server/manage.py remove_expired_api_tokens
+```
+
+|Option|Description|
+|---|---|
+|`--after-days`|Only purge tokens that expired more than this many days ago. `15` by default.|
+|`--user`|Restrict to a username or email address. Repeat the option for several accounts. Every account by default.|
+|`--dry-run`|List what would be deleted, and delete nothing.|
+|`--json`|JSON output.|
+
+Each deletion emits a `zentral_audit` event, so a purge leaves a trail.
+
+### OIDC API token issuers
+
+A long-lived token in a CI system is a standing liability. As an alternative, a service account can carry one or more **OIDC API token issuers**: a workload that already has an OIDC identity token — a GitHub Actions job, a GitLab pipeline, a cloud workload — exchanges it for a short-lived Zentral API token, and no Zentral secret is stored anywhere.
+
+Issuers are managed from the service account's detail page, under *Platform settings > Users*. They can only be attached to a service account, never to a user.
+
+|Field|Description|
+|---|---|
+|Name|Required, unique across the deployment.|
+|Description|Optional, free text.|
+|Issuer URI|The OIDC issuer, `https` only. Zentral derives the discovery URI from it, and uses it to fetch the keys the identity tokens are verified against.|
+|Audience|The audience the identity tokens must be issued for.|
+|CEL condition|Required. A [CEL](https://cel.dev) expression over the identity token's claims. Only the tokens whose claims satisfy it are accepted.|
+|Max API token validity|The longest lifetime, in seconds, of a token this issuer may mint. Between 30 and 604800 (7 days). `3600` by default.|
+
+The CEL condition is evaluated with the verified claims bound to `claims`, and must return a boolean. It is what pins an issuer to the workload you intend — the signature and the audience only prove *a* workload from that provider, so without a claim condition any job on the same provider could mint your token. For a GitHub Actions workflow on a single repository and branch, for example:
+
+```
+claims.repository == "acme/infra" && claims.ref == "refs/heads/main"
+```
+
+An issuer that does not accept a token — bad signature, wrong audience, or a condition that evaluates to false — returns a `400`.
+
+Once the issuer exists, the workload exchanges its identity token at [`/api/accounts/token_issuers/oidc/<uuid:issuer_id>/auth/`](#apiaccountstoken_issuersoidcuuidissuer_idauth). The tokens it mints are ordinary API tokens with an expiry, and appear in the service account's token list like any other.
+
+Issuers can also be managed over the API, at `/api/accounts/token_issuers/oidc/`.
+
 ## HTTP API
 
 ### `/api/task_result/<uuid:task_id>/`
@@ -56,7 +160,9 @@ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 * method: POST
 * PBAC action: none
 
-Use this endpoint to exchange an OIDC identity token (Signed JWT) for a short-lived API token.
+Use this endpoint to exchange an OIDC identity token (Signed JWT) for a short-lived API token. The issuer must be set up first — see [OIDC API token issuers](#oidc-api-token-issuers).
+
+The `jwt` attribute is required. `name` is optional, and names the minted token in the service account's token list. `validity` is optional, in seconds, and must be between 30 and the issuer's *Max API token validity*, which is also the value used when it is omitted.
 
 Example:
 

--- a/docs/apps/inventory.md
+++ b/docs/apps/inventory.md
@@ -252,6 +252,18 @@ This boolean is used to toggle the inclusion of the principal user in the event 
 
 ## HTTP API
 
+### Requests
+
+#### Authentication
+
+API requests are authenticated using a token in the `Authorization` HTTP header:
+
+```
+Authorization: Token the_token_string
+```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
+
 ### `/api/inventory/machines/<url_safe_serial_number>/meta/`
 
 * method: GET

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -661,6 +661,18 @@ For Automated Device Enrollment, the enrollment only exists once Apple has accep
 
 ## HTTP API
 
+### Requests
+
+#### Authentication
+
+API requests are authenticated using a token in the `Authorization` HTTP header:
+
+```
+Authorization: Token the_token_string
+```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
+
 ### `/api/mdm/dep/devices/`
 
  * method: `GET`

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -136,7 +136,7 @@ Example:
 ```
 curl -X POST \
      -H "Authorization: Token $TOKEN" \
-     https://$FQDN/api/monolith/repositories/1/sync/
+     https://$ZTL_FQDN/api/monolith/repositories/1/sync/
 ```
 
 Response:
@@ -192,19 +192,19 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifests/" \
+  "https://$ZTL_FQDN/api/monolith/manifests/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifests/?name=default" \
+  "https://$ZTL_FQDN/api/monolith/manifests/?name=default" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifests/?meta_business_unit_id=1" \
+  "https://$ZTL_FQDN/api/monolith/manifests/?meta_business_unit_id=1" \
   |python3 -m json.tool
 ```
 
@@ -242,7 +242,7 @@ manifest.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/manifests/" \
+  "https://$ZTL_FQDN/api/monolith/manifests/" \
   -d @manifest.json \
   |python3 -m json.tool
 ```
@@ -272,7 +272,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifests/1/" \
+  "https://$ZTL_FQDN/api/monolith/manifests/1/" \
   |python3 -m json.tool
 ```
 
@@ -311,7 +311,7 @@ manifest.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/manifests/1/" \
+  "https://$ZTL_FQDN/api/monolith/manifests/1/" \
   -d @manifest.json \
   |python3 -m json.tool
 ```
@@ -340,7 +340,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifests/1/"
+  "https://$ZTL_FQDN/api/monolith/manifests/1/"
 ```
 
 Response (204 No Content)
@@ -358,13 +358,13 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/catalogs/" \
+  "https://$ZTL_FQDN/api/monolith/catalogs/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/catalogs/?name=production" \
+  "https://$ZTL_FQDN/api/monolith/catalogs/?name=production" \
   |python3 -m json.tool
 ```
 
@@ -403,7 +403,7 @@ catalog.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/catalogs/" \
+  "https://$ZTL_FQDN/api/monolith/catalogs/" \
   -d @catalog.json \
   |python3 -m json.tool
 ```
@@ -433,7 +433,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/catalogs/1/" \
+  "https://$ZTL_FQDN/api/monolith/catalogs/1/" \
   |python3 -m json.tool
 ```
 
@@ -472,7 +472,7 @@ catalog.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/catalogs/1/" \
+  "https://$ZTL_FQDN/api/monolith/catalogs/1/" \
   -d @catalog.json \
   |python3 -m json.tool
 ```
@@ -501,7 +501,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/catalogs/1/"
+  "https://$ZTL_FQDN/api/monolith/catalogs/1/"
 ```
 
 Response (204 No Content)
@@ -519,13 +519,13 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/conditions/" \
+  "https://$ZTL_FQDN/api/monolith/conditions/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/conditions/?name=desktop" \
+  "https://$ZTL_FQDN/api/monolith/conditions/?name=desktop" \
   |python3 -m json.tool
 ```
 
@@ -562,7 +562,7 @@ condition.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/conditions/" \
+  "https://$ZTL_FQDN/api/monolith/conditions/" \
   -d @condition.json \
   |python3 -m json.tool
 ```
@@ -591,7 +591,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/conditions/1/" \
+  "https://$ZTL_FQDN/api/monolith/conditions/1/" \
   |python3 -m json.tool
 ```
 
@@ -629,7 +629,7 @@ condition.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/conditions/1/" \
+  "https://$ZTL_FQDN/api/monolith/conditions/1/" \
   -d @condition.json \
   |python3 -m json.tool
 ```
@@ -657,7 +657,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/conditions/1/"
+  "https://$ZTL_FQDN/api/monolith/conditions/1/"
 ```
 
 Response (204 No Content)
@@ -675,13 +675,13 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/enrollments/" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/enrollments/?manifest_id=2" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/?manifest_id=2" \
   |python3 -m json.tool
 ```
 
@@ -736,7 +736,7 @@ enrollment.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/enrollments/" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/" \
   -d @enrollment.json \
   |python3 -m json.tool
 ```
@@ -778,7 +778,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/enrollments/1/" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/1/" \
   |python3 -m json.tool
 ```
 
@@ -833,7 +833,7 @@ enrollment.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/enrollments/1/" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/1/" \
   -d @enrollment.json \
   |python3 -m json.tool
 ```
@@ -874,7 +874,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/enrollments/1/"
+  "https://$ZTL_FQDN/api/monolith/enrollments/1/"
 ```
 
 Response (204 No Content)
@@ -893,19 +893,19 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/?manifest_id=1" \
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/?manifest_id=1" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/?catalog_id=2" \
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/?catalog_id=2" \
   |python3 -m json.tool
 ```
 
@@ -942,7 +942,7 @@ manifest\_catalog.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/" \
   -d @manifest_catalog.json \
   |python3 -m json.tool
 ```
@@ -970,7 +970,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/1/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/1/" \
   |python3 -m json.tool
 ```
 
@@ -1008,7 +1008,7 @@ manifest\_catalog.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/1/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/1/" \
   -d @manifest_catalog.json \
   |python3 -m json.tool
 ```
@@ -1035,7 +1035,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_catalogs/1/"
+  "https://$ZTL_FQDN/api/monolith/manifest_catalogs/1/"
 ```
 
 Response (204 No Content)
@@ -1054,19 +1054,19 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/?manifest_id=1" \
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/?manifest_id=1" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/?sub_manifest_id=2" \
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/?sub_manifest_id=2" \
   |python3 -m json.tool
 ```
 
@@ -1103,7 +1103,7 @@ manifest\_sub_manifest.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/" \
   -d @manifest_sub_manifest.json \
   |python3 -m json.tool
 ```
@@ -1131,7 +1131,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/1/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/1/" \
   |python3 -m json.tool
 ```
 
@@ -1169,7 +1169,7 @@ manifest\_sub_manifest.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/1/" \
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/1/" \
   -d @manifest_sub_manifest.json \
   |python3 -m json.tool
 ```
@@ -1196,7 +1196,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/manifest_sub_manifests/1/"
+  "https://$ZTL_FQDN/api/monolith/manifest_sub_manifests/1/"
 ```
 
 Response (204 No Content)
@@ -1214,13 +1214,13 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifests/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifests/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifests/?name=Browsers" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifests/?name=Browsers" \
   |python3 -m json.tool
 ```
 
@@ -1258,7 +1258,7 @@ sub\_manifest.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/sub_manifests/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifests/" \
   -d @sub_manifest.json \
   |python3 -m json.tool
 ```
@@ -1288,7 +1288,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifests/1/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifests/1/" \
   |python3 -m json.tool
 ```
 
@@ -1328,7 +1328,7 @@ sub\_manifest.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/sub_manifests/1/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifests/1/" \
   -d @sub_manifest.json \
   |python3 -m json.tool
 ```
@@ -1357,7 +1357,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifests/1/"
+  "https://$ZTL_FQDN/api/monolith/sub_manifests/1/"
 ```
 
 Response (204 No Content)
@@ -1375,13 +1375,13 @@ Examples:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifest_pkg_infos/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifest_pkg_infos/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifest_pkg_infos/?sub_manifest_id=1" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifest_pkg_infos/?sub_manifest_id=1" \
   |python3 -m json.tool
 ```
 
@@ -1438,7 +1438,7 @@ sub\_manifest_pkg_info.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/sub_manifest_pkg_infos/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifest_pkg_infos/" \
   -d @sub_manifest_pkg_info.json \
   |python3 -m json.tool
 ```
@@ -1476,7 +1476,7 @@ Example:
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifest_pkg_infos/2/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifest_pkg_infos/2/" \
   |python3 -m json.tool
 ```
 
@@ -1532,7 +1532,7 @@ sub\_manifest.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/monolith/sub_manifest_pkg_infos/2/" \
+  "https://$ZTL_FQDN/api/monolith/sub_manifest_pkg_infos/2/" \
   -d @sub_manifest_pkg_info.json \
   |python3 -m json.tool
 ```
@@ -1572,7 +1572,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/monolith/sub_manifest_pkg_infos/2/"
+  "https://$ZTL_FQDN/api/monolith/sub_manifest_pkg_infos/2/"
 ```
 
 Response (204 No Content)

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -104,19 +104,13 @@ First Zentral checks the `excluded_tags`. If a machine has any one of the tags l
 
 #### Authentication
 
-API requests are authenticated using a token in the `Authorization` HTTP header.
-
-To get a token, you can create a service account. As a superuser, go to Setup > Manage users, and in the "Service accounts" subsection, click on the [Create] button. Pick a name for your service account and [Save]. You will be redirected to a token view. The token is only displayed once. To reveal it, click on the eye icon. Once you have saved it (in a password manager, in a configuration variable, …), you can click on the [OK] button.
-
-You can also add an API token to a normal user, although it is not recommended. To do so, click on the user in the User list, and click on the [+] button next to the API token boolean.
-
-If you have lost or leaked a token, you can delete it by clicking on the user or service account name, and then click on the 🗑 next to the API token boolean.
-
-The format for the `Authorization` header is the following:
+API requests are authenticated using a token in the `Authorization` HTTP header:
 
 ```
 Authorization: Token the_token_string
 ```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
 #### Content type
 

--- a/docs/apps/munki.md
+++ b/docs/apps/munki.md
@@ -21,6 +21,18 @@ Number of failed installs for each package.
 
 ## HTTP API
 
+### Requests
+
+#### Authentication
+
+API requests are authenticated using a token in the `Authorization` HTTP header:
+
+```
+Authorization: Token the_token_string
+```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
+
 ### /api/munki/configurations/
 
 

--- a/docs/apps/munki.md
+++ b/docs/apps/munki.md
@@ -48,14 +48,14 @@ Examples:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/munki/configurations/ \
+  https://$ZTL_FQDN/api/munki/configurations/ \
   |python3 -m json.tool
 ```
 
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://$ZTL_HOST/api/munki/configurations/?name=Default" \
+  "https://$ZTL_FQDN/api/munki/configurations/?name=Default" \
   |python3 -m json.tool
 ```
 
@@ -127,7 +127,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @configuration.json \
-  https://$ZTL_HOST/api/munki/configurations/ \
+  https://$ZTL_FQDN/api/munki/configurations/ \
   |python3 -m json.tool
 ```
 
@@ -173,7 +173,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/munki/configurations/2/ \
+  https://$ZTL_FQDN/api/munki/configurations/2/ \
   |python3 -m json.tool
 ```
 
@@ -245,7 +245,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @configuration.json \
-  https://$ZTL_HOST/api/munki/configurations/2/ \
+  https://$ZTL_FQDN/api/munki/configurations/2/ \
   |python3 -m json.tool
 ```
 
@@ -288,7 +288,7 @@ Response:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/munki/configurations/6/
+  https://$ZTL_FQDN/api/munki/configurations/6/
 ```
 
 Response (204 No Content)
@@ -307,14 +307,14 @@ Examples:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/munki/enrollments/ \
+  https://$ZTL_FQDN/api/munki/enrollments/ \
   |python3 -m json.tool
 ```
 
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/munki/enrollments/?configuration_id=1 \
+  https://$ZTL_FQDN/api/munki/enrollments/?configuration_id=1 \
   |python3 -m json.tool
 ```
 
@@ -327,7 +327,7 @@ Response:
         "created_at": "2020-06-16T14:10:32.322536",
         "enrolled_machines_count": 5,
         "id": 1,
-        "package_download_url": "https://$ZTL_HOST/api/munki/enrollments/1/package/",
+        "package_download_url": "https://$ZTL_FQDN/api/munki/enrollments/1/package/",
         "secret": {
             "id": 11,
             "meta_business_unit": 1,
@@ -368,7 +368,7 @@ enrollment.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://$ZTL_HOST/api/munki/enrollments/" \
+  "https://$ZTL_FQDN/api/munki/enrollments/" \
   -d @enrollment.json \
   |python3 -m json.tool
 ```
@@ -391,7 +391,7 @@ Response:
     "udids": []
   },
   "version": 1,
-  "package_download_url": "https://$ZTL_HOST/api/munki/enrollments/1/package/",
+  "package_download_url": "https://$ZTL_FQDN/api/munki/enrollments/1/package/",
   "created_at": "2023-01-10T11:02:51.831544",
   "updated_at": "2023-01-10T11:02:51.831553"
 }
@@ -408,7 +408,7 @@ Response:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/munki/enrollments/1/ \
+  https://$ZTL_FQDN/api/munki/enrollments/1/ \
   |python3 -m json.tool
 ```
 
@@ -420,7 +420,7 @@ Response:
     "created_at": "2020-06-16T14:10:32.322536",
     "enrolled_machines_count": 5,
     "id": 1,
-    "package_download_url": "https://$ZTL_HOST/api/munki/enrollments/1/package/",
+    "package_download_url": "https://$ZTL_FQDN/api/munki/enrollments/1/package/",
     "secret": {
         "id": 11,
         "meta_business_unit": 1,
@@ -461,7 +461,7 @@ enrollment.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://$ZTL_HOST/api/munki/enrollments/1/" \
+  "https://$ZTL_FQDN/api/munki/enrollments/1/" \
   -d @enrollment.json \
   |python3 -m json.tool
 ```
@@ -484,7 +484,7 @@ Response:
     "udids": []
   },
   "version": 2,
-  "package_download_url": "https://$ZTL_HOST/api/munki/enrollments/1/package/",
+  "package_download_url": "https://$ZTL_FQDN/api/munki/enrollments/1/package/",
   "created_at": "2023-01-10T11:02:51.831544",
   "updated_at": "2023-01-10T11:02:51.831553"
 }
@@ -501,7 +501,7 @@ Example:
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://$ZTL_HOST/api/munki/enrollments/1/"
+  "https://$ZTL_FQDN/api/munki/enrollments/1/"
 ```
 
 Response (204 No Content)
@@ -519,5 +519,5 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -o zentral_munki_enrollment_package.pkg \
-  https://$ZTL_HOST/api/munki/enrollments/1/package/
+  https://$ZTL_FQDN/api/munki/enrollments/1/package/
 ```

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -44,14 +44,14 @@ Examples:
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/atcs/" \
+  "https://$ZTL_FQDN/api/osquery/atcs/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/atcs/?name=Santa+rules" \
+  "https://$ZTL_FQDN/api/osquery/atcs/?name=Santa+rules" \
   |python3 -m json.tool
 ```
 
@@ -115,7 +115,7 @@ atc.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/atcs/" \
+  "https://$ZTL_FQDN/api/osquery/atcs/" \
   -d @atc.json \
   |python3 -m json.tool
 ```
@@ -158,7 +158,7 @@ Example
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/atcs/2/" \
+  "https://$ZTL_FQDN/api/osquery/atcs/2/" \
   |python3 -m json.tool
 ```
 
@@ -223,7 +223,7 @@ atc_update.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/atcs/2/" \
+  "https://$ZTL_FQDN/api/osquery/atcs/2/" \
   -d @atc_update.json \
   |python3 -m json.tool
 ```
@@ -266,7 +266,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/atcs/2/" 
+  "https://$ZTL_FQDN/api/osquery/atcs/2/" 
 ```
 
 Response (204 No Content)
@@ -286,14 +286,14 @@ Examples:
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configurations/" \
+  "https://$ZTL_FQDN/api/osquery/configurations/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configurations/?name=example" \
+  "https://$ZTL_FQDN/api/osquery/configurations/?name=example" \
   |python3 -m json.tool
 ```
 
@@ -358,7 +358,7 @@ configuration.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configurations/" \
+  "https://$ZTL_FQDN/api/osquery/configurations/" \
   -d @configuration.json \
   |python3 -m json.tool
 ```
@@ -402,7 +402,7 @@ Example
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configurations/2/" \
+  "https://$ZTL_FQDN/api/osquery/configurations/2/" \
   |python3 -m json.tool
 ```
 
@@ -464,7 +464,7 @@ configuration_update.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configurations/2/" \
+  "https://$ZTL_FQDN/api/osquery/configurations/2/" \
   -d @configuration_update.json \
   |python3 -m json.tool
 ```
@@ -501,7 +501,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/configurations/2/" 
+  "https://$ZTL_FQDN/api/osquery/configurations/2/" 
 ```
 
 Response (204 No Content)
@@ -522,14 +522,14 @@ Examples:
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configuration_packs/" \
+  "https://$ZTL_FQDN/api/osquery/configuration_packs/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configuration_packs/?pack_id=2" \
+  "https://$ZTL_FQDN/api/osquery/configuration_packs/?pack_id=2" \
   |python3 -m json.tool
 ```
 
@@ -577,7 +577,7 @@ configurationpack.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configuration_packs/" \
+  "https://$ZTL_FQDN/api/osquery/configuration_packs/" \
   -d @configurationpack.json \
   |python3 -m json.tool
 ```
@@ -609,7 +609,7 @@ Example
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configuration_packs/2/" \
+  "https://$ZTL_FQDN/api/osquery/configuration_packs/2/" \
   |python3 -m json.tool
 ```
 
@@ -656,7 +656,7 @@ configurationpack_update.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/configuration_packs/2/" \
+  "https://$ZTL_FQDN/api/osquery/configuration_packs/2/" \
   -d @configurationpack_update.json \
   |python3 -m json.tool
 ```
@@ -685,7 +685,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/configuration_packs/2/" 
+  "https://$ZTL_FQDN/api/osquery/configuration_packs/2/" 
 ```
 
 Response (204 No Content)
@@ -706,14 +706,14 @@ Examples:
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/file_categories/" \
+  "https://$ZTL_FQDN/api/osquery/file_categories/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/file_categories/?name=example" \
+  "https://$ZTL_FQDN/api/osquery/file_categories/?name=example" \
   |python3 -m json.tool
 ```
 
@@ -762,7 +762,7 @@ file_category.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/file_categories/" \
+  "https://$ZTL_FQDN/api/osquery/file_categories/" \
   -d @file_category.json \
   |python3 -m json.tool
 ```
@@ -803,7 +803,7 @@ Example
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/file_categories/2/" \
+  "https://$ZTL_FQDN/api/osquery/file_categories/2/" \
   |python3 -m json.tool
 ```
 
@@ -859,7 +859,7 @@ file_category_update.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/file_categories/2/" \
+  "https://$ZTL_FQDN/api/osquery/file_categories/2/" \
   -d @file_categories_update.json \
   |python3 -m json.tool
 ```
@@ -896,7 +896,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/file_categories/2/" 
+  "https://$ZTL_FQDN/api/osquery/file_categories/2/" 
 ```
 
 Response (204 No Content)
@@ -917,14 +917,14 @@ Examples:
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/packs/" \
+  "https://$ZTL_FQDN/api/osquery/packs/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/packs/?name=Default" \
+  "https://$ZTL_FQDN/api/osquery/packs/?name=Default" \
   |python3 -m json.tool
 ```
 
@@ -971,7 +971,7 @@ pack.json
 $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/packs/" \
+  "https://$ZTL_FQDN/api/osquery/packs/" \
   -d @pack.json \
   |python3 -m json.tool
 ```
@@ -1008,7 +1008,7 @@ Example
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/packs/2/" \
+  "https://$ZTL_FQDN/api/osquery/packs/2/" \
   |python3 -m json.tool
 ```
 
@@ -1056,7 +1056,7 @@ pack_update.json
 $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/osquery/packs/2/" \
+  "https://$ZTL_FQDN/api/osquery/packs/2/" \
   -d @pack_update.json \
   |python3 -m json.tool
 ```
@@ -1090,7 +1090,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/packs/2/" 
+  "https://$ZTL_FQDN/api/osquery/packs/2/" 
 ```
 
 Response (204 No Content)
@@ -1137,7 +1137,7 @@ $ curl -XPUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @pack.json \
-  "https://zentral.example.com/api/osquery/packs/first-pack-slug/" \
+  "https://$ZTL_FQDN/api/osquery/packs/first-pack-slug/" \
   |python3 -m json.tool
 ```
 
@@ -1184,7 +1184,7 @@ If you make a `DELETE` request on the same URL, the pack and all its rules will 
 $ curl -XDELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
-  "https://zentral.example.com/api/osquery/packs/first-pack-slug/" \
+  "https://$ZTL_FQDN/api/osquery/packs/first-pack-slug/" \
   |python3 -m json.tool
 ```
 
@@ -1233,7 +1233,7 @@ $ curl -XPUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/x-osquery-conf' \
   --data-binary @pack.conf \
-  "https://zentral.example.com/api/osquery/packs/second-pack-slug/" \
+  "https://$ZTL_FQDN/api/osquery/packs/second-pack-slug/" \
   |python3 -m json.tool
 ```
 
@@ -1280,7 +1280,7 @@ $ curl -XPUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/yaml' \
   --data-binary @pack.yml \
-  "https://zentral.example.com/api/osquery/packs/second-pack-slug/" \
+  "https://$ZTL_FQDN/api/osquery/packs/second-pack-slug/" \
   |python3 -m json.tool
 ```
 
@@ -1316,13 +1316,13 @@ Examples
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/queries/" \
+  "https://$ZTL_FQDN/api/osquery/queries/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/queries/?name=GetApps" \
+  "https://$ZTL_FQDN/api/osquery/queries/?name=GetApps" \
   |python3 -m json.tool
 ```
 
@@ -1377,7 +1377,7 @@ $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @query.json \
-  "https://zentral.example.com/api/osquery/queries/" \
+  "https://$ZTL_FQDN/api/osquery/queries/" \
   |python3 -m json.tool
 ```
 
@@ -1421,7 +1421,7 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/queries/1/" \
+  "https://$ZTL_FQDN/api/osquery/queries/1/" \
   |python3 -m json.tool
 ```
 
@@ -1468,7 +1468,7 @@ $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @query_update.json \
-  "https://zentral.example.com/api/osquery/queries/1/" \
+  "https://$ZTL_FQDN/api/osquery/queries/1/" \
   |python3 -m json.tool
 ```
 
@@ -1503,7 +1503,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/queries/1/"
+  "https://$ZTL_FQDN/api/osquery/queries/1/"
 ```
 
 Response (204 No Content)
@@ -1525,7 +1525,7 @@ Example
 ```bash
 curl -XPOST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/osquery/runs/1/results/export/" \
+  "https://$ZTL_FQDN/api/osquery/runs/1/results/export/" \
   |python3 -m json.tool
 ```
 

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -12,19 +12,13 @@ To activate the osquery module, you need to add a `zentral.contrib.osquery` sect
 
 #### Authentication
 
-API requests are authenticated using a token in the `Authorization` HTTP header.
-
-To get a token, you can create a service account. As a superuser, go to Setup > Manage users, and in the "Service accounts" subsection, click on the [Create] button. Pick a name for your service account and [Save]. You will be redirected to a token view. The token is only displayed once. To reveal it, click on the eye icon. Once you have saved it (in a password manager, in a configuration variable, …), you can click on the [OK] button.
-
-You can also add an API token to a normal user, although it is not recommended. To do so, click on the user in the User list, and click on the [+] button next to the API token boolean.
-
-If you have lost or leaked a token, you can delete it by clicking on the user or service account name, and then click on the 🗑 next to the API token boolean.
-
-The format for the `Authorization` header is the following:
+API requests are authenticated using a token in the `Authorization` HTTP header:
 
 ```
 Authorization: Token the_token_string
 ```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
 #### Content type
 

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -246,14 +246,14 @@ Example:
 ```bash
 curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/santa/rules/" \
+  "https://$ZTL_FQDN/api/santa/rules/" \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://zentral.example.com/api/santa/rules/?target_type=TEAMID" \
+  "https://$ZTL_FQDN/api/santa/rules/?target_type=TEAMID" \
   |python3 -m json.tool
 ```
 
@@ -341,7 +341,7 @@ $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @rule.json \
-  "https://zentral.example.com/api/santa/rules/"\
+  "https://$ZTL_FQDN/api/santa/rules/"\
   |python3 -m json.tool
 ```
 
@@ -397,7 +397,7 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/santa/rules/1/" \
+  "https://$ZTL_FQDN/api/santa/rules/1/" \
   |python3 -m json.tool
 ```
 
@@ -466,7 +466,7 @@ $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @rule_update.json \
-  "https://zentral.example.com/api/santa/rules/8/"\
+  "https://$ZTL_FQDN/api/santa/rules/8/"\
   |python3 -m json.tool
 ```
 
@@ -522,7 +522,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://zentral.example.com/api/santa/rules/8/"
+  "https://$ZTL_FQDN/api/santa/rules/8/"
 ```
 
 ### /api/santa/ingest/fileinfo/
@@ -542,7 +542,7 @@ $ santactl fileinfo --json \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d @- \
-  https://zentral.example.com/api/santa/ingest/fileinfo/
+  https://$ZTL_FQDN/api/santa/ingest/fileinfo/
 ```
 
 This response is a JSON object with some counters:
@@ -655,7 +655,7 @@ $ curl -XPOST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @ruleset.json \
-  https://zentral.example.com/api/santa/rulesets/update/\
+  https://$ZTL_FQDN/api/santa/rulesets/update/\
   |python3 -m json.tool
 ```
 
@@ -800,7 +800,7 @@ $ curl -XPOST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/yaml' \
   --data-binary @ruleset2.yml \
-  https://zentral.example.com/api/santa/rulesets/update/\
+  https://$ZTL_FQDN/api/santa/rulesets/update/\
   |python3 -m json.tool
 ```
 
@@ -843,13 +843,13 @@ Examples
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/configurations/ \
+  https://$ZTL_FQDN/api/santa/configurations/ \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/configurations/?name=Default \
+  https://$ZTL_FQDN/api/santa/configurations/?name=Default \
   |python3 -m json.tool
 ```
 
@@ -914,7 +914,7 @@ $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @configuration.json \
-  https://zentral.example.com/api/santa/configurations/\
+  https://$ZTL_FQDN/api/santa/configurations/\
   |python3 -m json.tool
 ```
 
@@ -956,7 +956,7 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/configurations/1/ \
+  https://$ZTL_FQDN/api/santa/configurations/1/ \
   |python3 -m json.tool
 ```
 
@@ -1021,7 +1021,7 @@ $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @configuration.json \
-  https://zentral.example.com/api/santa/configurations/1/\
+  https://$ZTL_FQDN/api/santa/configurations/1/\
   |python3 -m json.tool
 ```
 
@@ -1061,7 +1061,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/configurations/1/
+  https://$ZTL_FQDN/api/santa/configurations/1/
 ```
 
 ### /api/santa/enrollments/
@@ -1078,13 +1078,13 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/enrollments/ \
+  https://$ZTL_FQDN/api/santa/enrollments/ \
   |python3 -m json.tool
 ```
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/enrollments/?configuration_id=1 \
+  https://$ZTL_FQDN/api/santa/enrollments/?configuration_id=1 \
   |python3 -m json.tool
 ```
 
@@ -1142,7 +1142,7 @@ $ curl -X POST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @enrollment.json \
-  https://zentral.example.com/api/santa/enrollments/\
+  https://$ZTL_FQDN/api/santa/enrollments/\
   |python3 -m json.tool
 ```
 
@@ -1185,7 +1185,7 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/enrollments/1/ \
+  https://$ZTL_FQDN/api/santa/enrollments/1/ \
   |python3 -m json.tool
 ```
 
@@ -1239,7 +1239,7 @@ $ curl -X PUT \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -d @configuration.json \
-  https://zentral.example.com/api/santa/enrollments/1/\
+  https://$ZTL_FQDN/api/santa/enrollments/1/\
   |python3 -m json.tool
 ```
 
@@ -1279,7 +1279,7 @@ Example
 ```bash
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/enrollments/5/
+  https://$ZTL_FQDN/api/santa/enrollments/5/
 ```
 
 ### /api/santa/enrollments/`<int:pk>`/plist/
@@ -1294,7 +1294,7 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/enrollments/1/plist/ \
+  https://$ZTL_FQDN/api/santa/enrollments/1/plist/ \
   --output zentral_santa_configuration.enrollment.plist
 ```
 
@@ -1310,6 +1310,6 @@ Example
 
 ```bash
 $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://zentral.example.com/api/santa/enrollments/1/configuration_profile/ \
+  https://$ZTL_FQDN/api/santa/enrollments/1/configuration_profile/ \
   --output com.example.zentral.santa_configuration.mobileconfig
 ```

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -212,19 +212,13 @@ There are five HTTP API endpoints available.
 
 #### Authentication
 
-API requests are authenticated using a token in the `Authorization` HTTP header.
-
-To get a token, you can create a service account. As a superuser, go to Setup > Manage users, and in the "Service accounts" subsection, click on the [Create] button. Pick a name for your service account and [Save]. You will be redirected to a token view. The token is only displayed once. To reveal it, click on the eye icon. Once you have saved it (in a password manager, in a configuration variable, …), you can click on the [OK] button.
-
-You can also add an API token to a normal user, although it is not recommended. To do so, click on the user in the User list, and click on the [+] button next to the API token boolean.
-
-If you have lost or leaked a token, you can delete it by clicking on the user or service account name, and then click on the 🗑 next to the API token boolean.
-
-The format for the `Authorization` header is the following:
+API requests are authenticated using a token in the `Authorization` HTTP header:
 
 ```
 Authorization: Token the_token_string
 ```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
 #### Content type
 

--- a/docs/apps/turbo.md
+++ b/docs/apps/turbo.md
@@ -349,7 +349,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://$ZTL_HOST/api/turbo/configurations/?name=Default" \
+  "https://$ZTL_FQDN/api/turbo/configurations/?name=Default" \
   |python3 -m json.tool
 ```
 
@@ -404,7 +404,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @configuration.json \
-  https://$ZTL_HOST/api/turbo/configurations/ \
+  https://$ZTL_FQDN/api/turbo/configurations/ \
   |python3 -m json.tool
 ```
 
@@ -438,7 +438,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/configurations/194a8af8-9e57-41b2-9b17-66ebc568c2dc/ \
+  https://$ZTL_FQDN/api/turbo/configurations/194a8af8-9e57-41b2-9b17-66ebc568c2dc/ \
   |python3 -m json.tool
 ```
 
@@ -487,7 +487,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @configuration.json \
-  https://$ZTL_HOST/api/turbo/configurations/194a8af8-9e57-41b2-9b17-66ebc568c2dc/ \
+  https://$ZTL_FQDN/api/turbo/configurations/194a8af8-9e57-41b2-9b17-66ebc568c2dc/ \
   |python3 -m json.tool
 ```
 
@@ -522,7 +522,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/turbo/configurations/194a8af8-9e57-41b2-9b17-66ebc568c2dc/
+  https://$ZTL_FQDN/api/turbo/configurations/194a8af8-9e57-41b2-9b17-66ebc568c2dc/
 ```
 
 Response (204 No Content):
@@ -546,7 +546,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/enrollments/ \
+  https://$ZTL_FQDN/api/turbo/enrollments/ \
   |python3 -m json.tool
 ```
 
@@ -610,7 +610,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @enrollment.json \
-  https://$ZTL_HOST/api/turbo/enrollments/ \
+  https://$ZTL_FQDN/api/turbo/enrollments/ \
   |python3 -m json.tool
 ```
 
@@ -654,7 +654,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/enrollments/1/ \
+  https://$ZTL_FQDN/api/turbo/enrollments/1/ \
   |python3 -m json.tool
 ```
 
@@ -687,7 +687,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @enrollment.json \
-  https://$ZTL_HOST/api/turbo/enrollments/1/ \
+  https://$ZTL_FQDN/api/turbo/enrollments/1/ \
   |python3 -m json.tool
 ```
 
@@ -705,7 +705,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/turbo/enrollments/1/
+  https://$ZTL_FQDN/api/turbo/enrollments/1/
 ```
 
 ### /api/turbo/enrollments/`<int:pk>`/plist/
@@ -724,7 +724,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -o zentral_turbo_configuration.plist \
-  https://$ZTL_HOST/api/turbo/enrollments/1/plist/
+  https://$ZTL_FQDN/api/turbo/enrollments/1/plist/
 ```
 
 ### /api/turbo/enrollments/`<int:pk>`/configuration_profile/
@@ -743,7 +743,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -o zentral_turbo_configuration.mobileconfig \
-  https://$ZTL_HOST/api/turbo/enrollments/1/configuration_profile/
+  https://$ZTL_FQDN/api/turbo/enrollments/1/configuration_profile/
 ```
 
 ### /api/turbo/scripts/
@@ -763,7 +763,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/scripts/ \
+  https://$ZTL_FQDN/api/turbo/scripts/ \
   |python3 -m json.tool
 ```
 
@@ -829,7 +829,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @script.json \
-  https://$ZTL_HOST/api/turbo/scripts/ \
+  https://$ZTL_FQDN/api/turbo/scripts/ \
   |python3 -m json.tool
 ```
 
@@ -868,7 +868,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/scripts/e6479cde-e17e-4f56-940e-7ccd59211c1a/ \
+  https://$ZTL_FQDN/api/turbo/scripts/e6479cde-e17e-4f56-940e-7ccd59211c1a/ \
   |python3 -m json.tool
 ```
 
@@ -904,7 +904,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @script.json \
-  https://$ZTL_HOST/api/turbo/scripts/e6479cde-e17e-4f56-940e-7ccd59211c1a/ \
+  https://$ZTL_FQDN/api/turbo/scripts/e6479cde-e17e-4f56-940e-7ccd59211c1a/ \
   |python3 -m json.tool
 ```
 
@@ -946,7 +946,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/turbo/scripts/e6479cde-e17e-4f56-940e-7ccd59211c1a/
+  https://$ZTL_FQDN/api/turbo/scripts/e6479cde-e17e-4f56-940e-7ccd59211c1a/
 ```
 
 ### /api/turbo/mscp_checks/
@@ -967,7 +967,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  "https://$ZTL_HOST/api/turbo/mscp_checks/?baseline=cis_lvl1" \
+  "https://$ZTL_FQDN/api/turbo/mscp_checks/?baseline=cis_lvl1" \
   |python3 -m json.tool
 ```
 
@@ -1020,7 +1020,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @mscp_check.json \
-  https://$ZTL_HOST/api/turbo/mscp_checks/ \
+  https://$ZTL_FQDN/api/turbo/mscp_checks/ \
   |python3 -m json.tool
 ```
 
@@ -1084,7 +1084,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/mscp_checks/a657104d-952b-489c-9816-14a32f12c7b6/ \
+  https://$ZTL_FQDN/api/turbo/mscp_checks/a657104d-952b-489c-9816-14a32f12c7b6/ \
   |python3 -m json.tool
 ```
 
@@ -1113,7 +1113,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @mscp_check.json \
-  https://$ZTL_HOST/api/turbo/mscp_checks/a657104d-952b-489c-9816-14a32f12c7b6/ \
+  https://$ZTL_FQDN/api/turbo/mscp_checks/a657104d-952b-489c-9816-14a32f12c7b6/ \
   |python3 -m json.tool
 ```
 
@@ -1131,7 +1131,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/turbo/mscp_checks/a657104d-952b-489c-9816-14a32f12c7b6/
+  https://$ZTL_FQDN/api/turbo/mscp_checks/a657104d-952b-489c-9816-14a32f12c7b6/
 ```
 
 ### /api/turbo/recurring_jobs/
@@ -1151,7 +1151,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/recurring_jobs/ \
+  https://$ZTL_FQDN/api/turbo/recurring_jobs/ \
   |python3 -m json.tool
 ```
 
@@ -1216,7 +1216,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @recurring_job.json \
-  https://$ZTL_HOST/api/turbo/recurring_jobs/ \
+  https://$ZTL_FQDN/api/turbo/recurring_jobs/ \
   |python3 -m json.tool
 ```
 
@@ -1260,7 +1260,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/recurring_jobs/a4193fe0-4011-4926-8f54-b83d3e9d6987/ \
+  https://$ZTL_FQDN/api/turbo/recurring_jobs/a4193fe0-4011-4926-8f54-b83d3e9d6987/ \
   |python3 -m json.tool
 ```
 
@@ -1294,7 +1294,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @recurring_job.json \
-  https://$ZTL_HOST/api/turbo/recurring_jobs/a4193fe0-4011-4926-8f54-b83d3e9d6987/ \
+  https://$ZTL_FQDN/api/turbo/recurring_jobs/a4193fe0-4011-4926-8f54-b83d3e9d6987/ \
   |python3 -m json.tool
 ```
 
@@ -1310,7 +1310,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/turbo/recurring_jobs/a4193fe0-4011-4926-8f54-b83d3e9d6987/
+  https://$ZTL_FQDN/api/turbo/recurring_jobs/a4193fe0-4011-4926-8f54-b83d3e9d6987/
 ```
 
 ### /api/turbo/one_time_jobs/
@@ -1330,7 +1330,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/one_time_jobs/ \
+  https://$ZTL_FQDN/api/turbo/one_time_jobs/ \
   |python3 -m json.tool
 ```
 
@@ -1388,7 +1388,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X POST -d @one_time_job.json \
-  https://$ZTL_HOST/api/turbo/one_time_jobs/ \
+  https://$ZTL_FQDN/api/turbo/one_time_jobs/ \
   |python3 -m json.tool
 ```
 
@@ -1425,7 +1425,7 @@ Example:
 ```bash
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
-  https://$ZTL_HOST/api/turbo/one_time_jobs/94c61ba9-abc9-4aaf-99f3-b9ea2552d62a/ \
+  https://$ZTL_FQDN/api/turbo/one_time_jobs/94c61ba9-abc9-4aaf-99f3-b9ea2552d62a/ \
   |python3 -m json.tool
 ```
 
@@ -1457,7 +1457,7 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -X PUT -d @one_time_job.json \
-  https://$ZTL_HOST/api/turbo/one_time_jobs/94c61ba9-abc9-4aaf-99f3-b9ea2552d62a/ \
+  https://$ZTL_FQDN/api/turbo/one_time_jobs/94c61ba9-abc9-4aaf-99f3-b9ea2552d62a/ \
   |python3 -m json.tool
 ```
 
@@ -1473,7 +1473,7 @@ Example:
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -X DELETE \
-  https://$ZTL_HOST/api/turbo/one_time_jobs/94c61ba9-abc9-4aaf-99f3-b9ea2552d62a/
+  https://$ZTL_FQDN/api/turbo/one_time_jobs/94c61ba9-abc9-4aaf-99f3-b9ea2552d62a/
 ```
 
 ## Device API

--- a/docs/apps/turbo.md
+++ b/docs/apps/turbo.md
@@ -307,19 +307,13 @@ Rows removed more than 30 days ago are purged; use `--days` to change that. One-
 
 #### Authentication
 
-API requests are authenticated using a token in the `Authorization` HTTP header.
-
-To get a token, you can create a service account. As a superuser, go to Setup > Manage users, and in the "Service accounts" subsection, click on the [Create] button. Pick a name for your service account and [Save]. You will be redirected to a token view. The token is only displayed once. To reveal it, click on the eye icon. Once you have saved it (in a password manager, in a configuration variable, …), you can click on the [OK] button.
-
-You can also add an API token to a normal user, although it is not recommended. To do so, click on the user in the User list, and click on the [+] button next to the API token boolean.
-
-If you have lost or leaked a token, you can delete it by clicking on the user or service account name, and then click on the 🗑 next to the API token boolean.
-
-The format for the `Authorization` header is the following:
+API requests are authenticated using a token in the `Authorization` HTTP header:
 
 ```
 Authorization: Token the_token_string
 ```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
 #### Content type
 

--- a/docs/apps/wsone.md
+++ b/docs/apps/wsone.md
@@ -42,6 +42,18 @@ To receive events in Zentral, and trigger the automatic device synchronizations,
 
 ## HTTP API
 
+### Requests
+
+#### Authentication
+
+API requests are authenticated using a token in the `Authorization` HTTP header:
+
+```
+Authorization: Token the_token_string
+```
+
+See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
+
 ### `/api/wsone/instances/`
 
 * method: GET

--- a/docs/apps/wsone.md
+++ b/docs/apps/wsone.md
@@ -67,7 +67,7 @@ Use this endpoint to list all available Zentral Workspace ONE instances.
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
-  https://zentral.example.com/api/wsone/instances/ \
+  https://$ZTL_FQDN/api/wsone/instances/ \
   |python3 -m json.tool
 ```
 
@@ -101,7 +101,7 @@ Use this endpoint to get a specific Zentral Workspace ONE instance.
 curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
-  https://zentral.example.com/api/wsone/instances/1/ \
+  https://$ZTL_FQDN/api/wsone/instances/1/ \
   |python3 -m json.tool
 ```
 
@@ -135,7 +135,7 @@ curl \
   -XPOST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -H 'Content-Type: application/json' \
-  https://zentral.example.com/api/wsone/instances/1/sync/ \
+  https://$ZTL_FQDN/api/wsone/instances/1/sync/ \
   |python3 -m json.tool
 ```
 

--- a/docs/configuration/okta_scim.md
+++ b/docs/configuration/okta_scim.md
@@ -12,7 +12,7 @@ The SCIM synchronization is part of the Zentral API. To let Okta authenticate wi
 
 ### Service account
 
-A Zentral service account is a Zentral user that cannot log into the admin console. Create a service account for your SCIM integration. Pick a name and a description. Do not forget to note the API token — you will need it later to configure the Okta application. Note also the service account's numeric primary key (visible in the URL of the service-account detail page).
+A Zentral service account is a Zentral account that cannot log into the admin console. [Create one](../apps/core.md#service-accounts) for your SCIM integration, then [add an API token](../apps/core.md#api-tokens) to it from its detail page — the token is displayed once, and you will need it later to configure the Okta application. Note also the service account's numeric primary key (visible in the URL of the service-account detail page).
 
 ### Policy
 


### PR DESCRIPTION
Stacked on #1622 — the base is `20260820-turbo-docs`, because the first commit edits `docs/apps/turbo.md`, which only exists on that branch. Retarget to `main` once #1622 merges.

## 1. Centralize the API token docs (`7cd4ff59`)

The "how do I get a token" block was duplicated **verbatim in four module pages**, and essentially every sentence of it had gone stale:

| The docs said | Reality |
|---|---|
| "go to Setup > Manage users" | It is the **Platform settings** menu (⋮, top right) → *Users* |
| "You will be redirected to a token view" after saving a service account | Creating a service account mints **no token** — you add one afterwards from its detail page |
| "click on the [OK] button" | The button is **Close** |
| "add an API token to a normal user … click on the [+] button" | **Refused with a 403.** A human user's token can only be created by that user, from their own profile |
| "the API token boolean" / "🗑 next to the … boolean" | Not a boolean — an `APIToken` model, several per account, each with a name and its own expiry, in a table with per-row edit/delete |

Nothing documented token names, expiry, the `ztlu_`/`ztls_` prefixes, `remove_expired_api_tokens`, or who is allowed to issue a token for whom.

So it is now documented once, in a new **API authentication** section on the core page: the `Authorization` header, service accounts, the token list and its controls, the issuance rules, expiry and purging, and OIDC API token issuers — the exchange endpoint was already documented, but nothing said how to *set up* an issuer.

The eight module pages keep the header format locally (it is what you need at that moment) and link out for the rest. Four of them — munki, inventory, mdm, wsone — had **no** authentication section at all while using `$ZTL_API_TOKEN` in every example.

`configuration/okta_scim.md` inherited the same false premise and is fixed too.

### How the wording was verified

Field labels, button tooltips and the refusal behaviour were read off the **rendered pages** — a throwaway test case that logs in and GETs each one — rather than inferred from the templates. That is what caught the create-token form labelling its field **Expiry** while the token list column reads **Expiration date**; I had documented the latter for both. PBAC action names come from the engine's `legacy_perm_actions` map, not from guesswork.

## 2. Standardize the host placeholder (`98459bc4`)

Four conventions were in use for the same thing: `$ZTL_HOST` (turbo, munki), `$ZTL_FQDN` (inventory, mdm, core), a hardcoded `zentral.example.com` (santa, osquery, monolith) and one bare `$FQDN`. Now all `$ZTL_FQDN`, which names the mandatory `api.fqdn` key and matches the `$ZTL_API_TOKEN` alongside it.

**Only curl-command URLs were rewritten.** `zentral.example.com` stays where it sits inside a JSON *response* body — the enrollment download URLs in santa, monolith and turbo, and the source names in the store docs — since there it is a value the server rendered, not a placeholder. The substitution was anchored to lines starting with the URL, and the result is exactly 168 insertions for 168 deletions: a pure 1:1 substitution with nothing else moved.

## Verification

- `mkdocs build --strict` exits 0.
- Every `href="#…"` in the built `apps/core/index.html` resolves to an `id` on the same page; the 8 module links resolve to `#api-authentication`, and the two `okta_scim` links to `#service-accounts` / `#api-tokens`.
- Post-sweep greps for `ZTL_HOST`, bare `$FQDN`, and curl-line `zentral.example.com` all return zero.
