### PR TITLE
Untangle the api.fqdn / api.tls_hostname accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@ The Santa sync operations of a machine are serialized on its enrolled machine ro
 
 Fixed the Santa preflight that overwrote what another request committed on the same enrolled machine: it saved every column of the row it read. Only the attributes the client reports are written now.
 
+Fixed the 500 error when a user saves a Santa configuration with client certificate authentication on a server with no mTLS FQDN. The form put its error on a field removed from the configuration, and Django refuses an error on a field that does not exist.
+
 The inventory history cleanup deletes in bounded batches now. One unbounded statement for each table could delete millions of rows in one transaction, and keep the database at its maximum capacity for the full run. Each batch is a transaction, and a batch that gives an integrity error is retried alone.
 
 Fixed the MDM devices list that moved devices between its pages: it sorted on the last seen timestamp, which is null until a device checks in. The sort includes the primary key now.

--- a/ee/server/realms/backends/openidc/__init__.py
+++ b/ee/server/realms/backends/openidc/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from realms.backends.base import BaseBackend
 from realms.exceptions import RealmUserError
 from zentral.utils.json import remove_null_character
@@ -18,11 +18,10 @@ class OpenIDConnectRealmBackend(BaseBackend):
         path = reverse("realms_public:openidc_ac_redirect", args=(self.instance.uuid,))
         if self.legacy_public_endpoints_mounted:
             path = path.removeprefix("/public")
-        return "{}{}".format(settings["api"]["tls_hostname"].rstrip("/"), path)
+        return f"{api_base_url()}{path}"
 
     def idp_initiated_login_uri(self):
-        return "{}{}".format(settings["api"]["tls_hostname"].rstrip("/"),
-                             reverse("realms_public:login", args=(self.instance.uuid,)))
+        return f'{api_base_url()}{reverse("realms_public:login", args=(self.instance.uuid,))}'
 
     def extra_attributes_for_display(self):
         config = self.instance.config

--- a/ee/server/realms/backends/saml/__init__.py
+++ b/ee/server/realms/backends/saml/__init__.py
@@ -9,7 +9,7 @@ from saml2.client import Saml2Client
 from saml2.config import Config as Saml2Config
 from saml2.saml import NAMEID_FORMAT_EMAILADDRESS
 
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.utils.json import remove_null_character
 
 logger = logging.getLogger("zentral.realms.backends.saml")
@@ -35,7 +35,7 @@ class SAMLRealmBackend(BaseBackend):
         path = reverse("realms_public:saml_acs", args=(self.instance.uuid,))
         if self.legacy_public_endpoints_mounted:
             path = path.removeprefix("/public")
-        return "{}{}".format(settings["api"]["tls_hostname"].rstrip("/"), path)
+        return f"{api_base_url()}{path}"
 
     def entity_id(self):
         """
@@ -48,7 +48,7 @@ class SAMLRealmBackend(BaseBackend):
         path = reverse("realms_public:saml_metadata", args=(self.instance.uuid,))
         if self.legacy_public_endpoints_mounted:
             path = path.removeprefix("/public")
-        return "{}{}".format(settings["api"]["tls_hostname"].rstrip("/"), path)
+        return f"{api_base_url()}{path}"
 
     def get_saml2_config(self, missing_idp_metadata_ok=False):
         settings = {

--- a/ee/server/realms/scim_views.py
+++ b/ee/server/realms/scim_views.py
@@ -11,7 +11,7 @@ from rest_framework.utils.encoders import JSONEncoder
 from rest_framework.views import APIView, exception_handler
 from accounts.api_authentication import APITokenAuthentication
 from realms.models import Realm, RealmGroup, RealmUser
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.utils.drf import DefaultDjangoModelPermissions
 from .models import realm_group_members_updated
 from .scim import SCIMUser, SCIMException, SCIMGroup
@@ -116,7 +116,7 @@ class SCIMView(APIView):
         return reverse(full_url_name, args=all_args)
 
     def get_location(self, url_name, *args):
-        return "https://{}{}".format(settings["api"]["fqdn"], self.get_path(url_name, *args))
+        return f"{api_base_url()}{self.get_path(url_name, *args)}"
 
     @staticmethod
     def build_response(data, status):

--- a/ee/zentral/contrib/wsone/models.py
+++ b/ee/zentral/contrib/wsone/models.py
@@ -5,7 +5,7 @@ from django.core.validators import MinLengthValidator
 from django.db import models
 from django.db.models import F
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.core.secret_engines import decrypt_str, encrypt_str, rewrap
 
 
@@ -46,7 +46,7 @@ class Instance(models.Model):
         return reverse("wsone:instance", args=(self.pk,))
 
     def get_event_notifications_full_url(self):
-        return "https://{}{}".format(settings["api"]["fqdn"], reverse("wsone:event_notifications", args=(self.pk,)))
+        return f'{api_base_url()}{reverse("wsone:event_notifications", args=(self.pk,))}'
 
     def save(self, *args, **kwargs):
         if not self.pk:

--- a/server/accounts/forms.py
+++ b/server/accounts/forms.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from urllib.parse import urlparse
 
 import celpy
 import pyotp
@@ -20,7 +19,7 @@ from webauthn import generate_authentication_options, options_to_json, verify_au
 from webauthn.helpers import parse_authentication_credential_json
 from webauthn.helpers.structs import PublicKeyCredentialDescriptor
 
-from zentral.conf import settings as zentral_settings
+from zentral.conf import api_base_url, settings as zentral_settings
 from zentral.conf.config import ConfigList
 from zentral.utils.base64 import trimmed_urlsafe_b64decode
 from zentral.utils.forms import SelectMultipleWithDisabledOptions
@@ -322,7 +321,7 @@ class AddTOTPForm(forms.Form):
             return self.fields["secret"].initial
 
     def get_provisioning_uri(self):
-        label = urlparse(zentral_settings["api"]["tls_hostname"]).netloc
+        label = zentral_settings["api"]["fqdn"]
         return pyotp.totp.TOTP(self.initial_secret).provisioning_uri(self.user.email, label)
 
     def clean_name(self):
@@ -446,7 +445,7 @@ class VerifyWebAuthnForm(BaseVerifyForm):
                 credential=credential,
                 expected_challenge=trimmed_urlsafe_b64decode(webauthn_challenge["challenge"]),
                 expected_rp_id=expected_rp_id,
-                expected_origin=zentral_settings["api"]["tls_hostname"],
+                expected_origin=api_base_url(),
                 credential_public_key=device.public_key.tobytes(),
                 credential_current_sign_count=device.sign_count,
                 require_user_verification=False,

--- a/server/accounts/password_reset.py
+++ b/server/accounts/password_reset.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.functional import SimpleLazyObject
 from django.utils.http import urlsafe_base64_encode
-from zentral.conf import settings
+from zentral.conf import api_base_url, settings
 from zentral.conf.config import ConfigDict
 from zentral.core.exceptions import ImproperlyConfigured
 
@@ -36,10 +36,7 @@ class BasePasswordResetHandler:
         if isinstance(uid, bytes):
             uid = uid.decode("ascii")
         token = default_token_generator.make_token(user)
-        return "{}{}".format(
-            settings["api"]["tls_hostname"],
-            reverse('password_reset_confirm', args=(uid, token))
-        )
+        return f"{api_base_url()}{reverse('password_reset_confirm', args=(uid, token))}"
 
     def get_password_reset_context(self, user, invitation=False):
         ctx = {

--- a/server/accounts/views/user.py
+++ b/server/accounts/views/user.py
@@ -23,7 +23,7 @@ from accounts.forms import (
     UpdateProfileForm,
 )
 from accounts.models import UserTOTP, UserWebAuthn
-from zentral.conf import settings as zentral_settings
+from zentral.conf import api_base_url, settings as zentral_settings
 from zentral.utils.base64 import trimmed_urlsafe_b64decode
 
 logger = logging.getLogger("zentral.accounts.views.user")
@@ -155,7 +155,7 @@ class RegisterWebAuthnDeviceView(LoginRequiredMixin, FormView):
             verification = verify_registration_response(
                 credential=credential,
                 expected_challenge=trimmed_urlsafe_b64decode(webauthn_challenge["challenge"]),
-                expected_origin=zentral_settings["api"]["tls_hostname"],
+                expected_origin=api_base_url(),
                 expected_rp_id=zentral_settings["api"]["fqdn"],
                 require_user_verification=False
             )

--- a/server/realms/views.py
+++ b/server/realms/views.py
@@ -9,7 +9,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, FormView, ListView, TemplateView, UpdateView, View
-from zentral.conf import settings as zentral_settings
+from zentral.conf import api_base_url
 from zentral.utils.views import UserPaginationListView
 from .backends.registry import backend_classes
 from .forms import AddRealmUserToGroupForm, RealmGroupSearchForm, RealmUserSearchForm
@@ -99,10 +99,10 @@ class RealmView(PermissionRequiredMixin, DetailView):
         )
         ctx["realm"] = self.object
         if self.object.scim_enabled:
-            ctx["scim_root_url"] = 'https://{}{}'.format(
-                zentral_settings["api"]["fqdn"],
-                reverse("realms_public:scim_resource_types", args=(self.object.pk,)).replace("/ResourceTypes", "/")
-            )
+            scim_root_path = reverse(
+                "realms_public:scim_resource_types", args=(self.object.pk,)
+            ).replace("/ResourceTypes", "/")
+            ctx["scim_root_url"] = f"{api_base_url()}{scim_root_path}"
         # realm group mappings
         ctx["realm_group_mappings"] = realm_group_mappings
         ctx["realm_group_mapping_count"] = realm_group_mappings.count()

--- a/tests/conf/test_config.py
+++ b/tests/conf/test_config.py
@@ -3,7 +3,7 @@ from tempfile import NamedTemporaryFile
 from unittest.mock import call, Mock
 from django.test import SimpleTestCase
 from zentral.conf.config import ConfigDict, ConfigList
-from zentral.conf import ZentralSettings
+from zentral.conf import api_base_url, settings, ZentralSettings
 
 
 class ConfTestCase(SimpleTestCase):
@@ -190,3 +190,12 @@ class ConfTestCase(SimpleTestCase):
                                      "tls_hostname_for_client_cert_auth": "https://zentral-mtls"}})
         self.assertEqual(c["api"]["fqdn"], "zentral")
         self.assertEqual(c["api"]["fqdn_mtls"], "zentral-mtls")
+
+    def test_api_base_url(self):
+        self.assertEqual(api_base_url(), "https://zentral")
+        # deployments still configured with the deprecated key must get the same base URL
+        self.assertEqual(api_base_url(), settings["api"]["tls_hostname"])
+
+    def test_api_base_url_for_client_cert_auth(self):
+        self.assertEqual(api_base_url(True), "https://zentral-mtls")
+        self.assertEqual(api_base_url(True), settings["api"]["tls_hostname_for_client_cert_auth"])

--- a/tests/inventory/test_models.py
+++ b/tests/inventory/test_models.py
@@ -1,22 +1,39 @@
 import json
 from datetime import datetime
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 
 from tests.mdm.utils import force_software_update_enforcement
 from tests.munki.utils import force_enrollment as force_munki_enrollment
+from zentral.conf import settings
 from zentral.contrib.inventory.models import (
     BusinessUnit,
     EnrollmentSecret,
     MachineTag,
     MetaBusinessUnit,
+    MetaMachine,
     Tag,
     Taxonomy,
 )
 
 
 class InventoryModelsTestCase(TestCase):
+
+    # MetaMachine
+
+    def test_meta_machine_get_url(self):
+        machine = MetaMachine(get_random_string(12))
+        self.assertEqual(machine.get_url(),
+                         f'https://{settings["api"]["fqdn"]}{machine.get_absolute_url()}')
+
+    def test_meta_machine_get_url_missing_fqdn(self):
+        machine = MetaMachine(get_random_string(12))
+        with patch("zentral.contrib.inventory.models.api_base_url", side_effect=KeyError("fqdn")):
+            with self.assertLogs("zentral.contrib.inventory.models", level="WARNING") as cm:
+                self.assertIsNone(machine.get_url())
+        self.assertIn("Missing api.fqdn configuration key", cm.output[0])
 
     # BusinessUnit
 

--- a/tests/mdm/test_ota_enrollment.py
+++ b/tests/mdm/test_ota_enrollment.py
@@ -4,11 +4,12 @@ import uuid
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
+from zentral.conf import settings
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.mdm.crypto import verify_signed_payload
 from zentral.contrib.mdm.models import EnrolledDevice, OTAEnrollment, OTAEnrollmentSession, ReEnrollmentSession
 from zentral.contrib.mdm.payloads import build_scep_payload
-from .utils import complete_enrollment_session, force_ota_enrollment, force_realm_user
+from .utils import complete_enrollment_session, force_ota_enrollment, force_realm, force_realm_user
 
 
 class TestOTAEnrollment(TestCase):
@@ -16,6 +17,19 @@ class TestOTAEnrollment(TestCase):
     def setUpTestData(cls):
         cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
         cls.mbu.create_enrollment_business_unit()
+
+    def test_ota_enrollment_no_realm_no_enroll_full_url(self):
+        enrollment = force_ota_enrollment(self.mbu)
+        self.assertIsNone(enrollment.get_enroll_full_url())
+
+    def test_ota_enrollment_enroll_full_url(self):
+        enrollment = force_ota_enrollment(self.mbu, realm=force_realm())
+        # the URL is displayed for an operator to hand out, it needs the scheme
+        self.assertEqual(
+            enrollment.get_enroll_full_url(),
+            f'https://{settings["api"]["fqdn"]}'
+            + reverse("mdm_public:ota_enrollment_enroll", args=(enrollment.pk,))
+        )
 
     def test_ota_enrollment_cannot_be_deleted(self):
         enrollment = force_ota_enrollment(self.mbu)

--- a/tests/santa/test_forms.py
+++ b/tests/santa/test_forms.py
@@ -1,6 +1,7 @@
+from unittest.mock import patch
 from django.test import TestCase
-from zentral.contrib.santa.forms import RuleForm
-from zentral.contrib.santa.models import Rule
+from zentral.contrib.santa.forms import ConfigurationForm, RuleForm
+from zentral.contrib.santa.models import Configuration, Rule
 from tests.santa.utils import force_configuration
 
 
@@ -33,3 +34,35 @@ class RuleFormFieldPopTests(TestCase):
             self.assertIn("custom_url", form.fields)
         finally:
             field.choices = old_choices
+
+
+class ConfigurationFormClientCertAuthTests(TestCase):
+    # the test configuration sets api.fqdn_mtls, so the mTLS endpoint is considered configured
+    form_data = {
+        "name": "cca",
+        "client_mode": Configuration.MONITOR_MODE,
+        "client_certificate_auth": True,
+        "batch_size": 50,
+        "full_sync_interval": 600,
+        "allow_unknown_shard": 100,
+        "enable_all_event_upload_shard": 0,
+        "sync_incident_severity": 0,
+        "banned_threshold": -26,
+        "partially_allowlisted_threshold": 5,
+        "globally_allowlisted_threshold": 50,
+        "default_voting_weight": 0,
+    }
+
+    def test_client_certificate_auth_ok_when_fqdn_mtls_configured(self):
+        form = ConfigurationForm(data=self.form_data)
+        form.is_valid()
+        self.assertNotIn("client_certificate_auth", form.errors)
+
+    def test_client_certificate_auth_error_when_fqdn_mtls_missing(self):
+        with patch("zentral.contrib.santa.forms.settings", {"api": {}}):
+            form = ConfigurationForm(data=self.form_data)
+            form.is_valid()
+        self.assertEqual(
+            form.errors["client_certificate_auth"],
+            ["The server requiring the client cert for authentication is not configured."]
+        )

--- a/tests/santa/test_setup_views.py
+++ b/tests/santa/test_setup_views.py
@@ -682,6 +682,23 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
              }}
         )
 
+    def test_enrollment_plist_client_certificate_auth(self):
+        configuration, enrollment = self._force_enrollment()
+        configuration.client_certificate_auth = True
+        configuration.save()
+        self.login("santa.view_enrollment")
+        response = self.client.get(reverse("santa_api:enrollment_plist", args=(enrollment.pk,)))
+        self.assertEqual(response.status_code, 200)
+        plist_config = plistlib.loads(response.content)
+        self.assertEqual(
+            plist_config,
+            {'ClientMode': configuration.client_mode,
+             'SyncBaseURL': f'https://{settings["api"]["fqdn_mtls"]}/public/santa/sync/',
+             'SyncExtraHeaders': {
+                 'Zentral-Authorization': f'Bearer {enrollment.secret.secret}'
+             }}
+        )
+
     def test_enrollment_with_voting_plist(self):
         realm = force_realm(user_portal=True)
         configuration, enrollment = self._force_enrollment(voting_realm=realm)

--- a/tests/server_realms/test_realm_views.py
+++ b/tests/server_realms/test_realm_views.py
@@ -17,6 +17,7 @@ from realms.models import (
     RoleMapping,
 )
 from tests.zentral_test_utils.login_case import LoginCase
+from zentral.conf import settings
 from .utils import (
     force_group,
     force_realm,
@@ -284,6 +285,27 @@ class RealmViewsTestCase(TestCase, LoginCase):
         self.login()
         response = self.client.get(reverse("realms:view", args=(realm.pk,)))
         self.assertEqual(response.status_code, 403)
+
+    def test_view_realm_scim_root_url(self):
+        realm = force_realm()
+        realm.scim_enabled = True
+        realm.save()
+        self.login("realms.view_realm")
+        response = self.client.get(reverse("realms:view", args=(realm.pk,)))
+        self.assertEqual(response.status_code, 200)
+        # the operator copies this URL into the IdP, it needs the scheme
+        self.assertEqual(
+            response.context["scim_root_url"],
+            f'https://{settings["api"]["fqdn"]}'
+            + reverse("realms_public:scim_resource_types", args=(realm.pk,)).replace("/ResourceTypes", "/")
+        )
+
+    def test_view_realm_no_scim_root_url(self):
+        realm = force_realm()
+        self.login("realms.view_realm")
+        response = self.client.get(reverse("realms:view", args=(realm.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("scim_root_url", response.context)
 
     def test_view_realm_no_link(self):
         realm = force_realm()

--- a/tests/turbo/test_setup_enrollments.py
+++ b/tests/turbo/test_setup_enrollments.py
@@ -2,6 +2,7 @@ import plistlib
 from unittest.mock import patch
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from zentral.conf import settings
 from zentral.contrib.turbo.models import Enrollment
 from zentral.contrib.turbo.utils import build_configuration_profile
 from zentral.utils.payloads import get_payload_identifier
@@ -212,7 +213,8 @@ class TurboSetupEnrollmentsTestCase(TurboSetupTestCase):
         self.assertEqual(int(response["Content-Length"]), len(content))
         data = plistlib.loads(content)
         self.assertEqual(data["EnrollmentSecret"], enrollment.secret.secret)
-        self.assertIn("BaseURL", data)
+        # the agent uses BaseURL as-is: without the scheme it cannot build a request
+        self.assertEqual(data["BaseURL"], f'https://{settings["api"]["fqdn"]}')
         self.assertNotIn("ManagedAgents", data)
 
     @patch("zentral.contrib.turbo.api_views.enrollments.build_configuration_plist")
@@ -251,7 +253,7 @@ class TurboSetupEnrollmentsTestCase(TurboSetupTestCase):
         # modern flat custom-settings payload: keys directly on the com.zentral.turbo payload
         self.assertEqual(payload["PayloadType"], "com.zentral.turbo")
         self.assertEqual(payload["EnrollmentSecret"], enrollment.secret.secret)
-        self.assertIn("BaseURL", payload)
+        self.assertEqual(payload["BaseURL"], f'https://{settings["api"]["fqdn"]}')
         self.assertNotIn("PayloadContent", payload)
         self.assertNotIn("mcx_preference_settings", content.decode("utf-8"))
 

--- a/tests/utils/test_osx_package.py
+++ b/tests/utils/test_osx_package.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.test import SimpleTestCase
-from zentral.utils.osx_package import (BasePackageBuilder, get_package_builders,
-                                       get_standalone_package_builders, get_tls_hostname)
+from zentral.utils.osx_package import (BasePackageBuilder, get_api_fqdn, get_package_builders,
+                                       get_standalone_package_builders)
 from .packages import DummyPackageBuilder, build_dummy_package
 
 
@@ -125,13 +125,13 @@ class OSXPackageBuilderTestCase(SimpleTestCase):
         self.assertIsNone(builder.get_etag())
         self.assertIsNone(builder.get_last_modified_dt())
 
-    # tls hostname
+    # api fqdn
 
-    def test_get_tls_hostname(self):
+    def test_get_api_fqdn(self):
         api = {"fqdn": "zentral.example.com", "fqdn_mtls": "zentral-mtls.example.com"}
         with patch("zentral.utils.osx_package.settings", {"api": api}):
-            self.assertEqual(get_tls_hostname(), "zentral.example.com")
-            self.assertEqual(get_tls_hostname(for_client_cert_auth=True), "zentral-mtls.example.com")
+            self.assertEqual(get_api_fqdn(), "zentral.example.com")
+            self.assertEqual(get_api_fqdn(for_client_cert_auth=True), "zentral-mtls.example.com")
 
     # package builders
 

--- a/zentral/conf/__init__.py
+++ b/zentral/conf/__init__.py
@@ -9,7 +9,7 @@ from zentral.core.exceptions import ImproperlyConfigured
 from .config import ConfigDict, ResolverMethodProxy
 
 
-__all__ = ['settings', 'user_templates_dir']
+__all__ = ['api_base_url', 'settings', 'user_templates_dir']
 
 
 logger = logging.getLogger("zentral.conf")
@@ -141,6 +141,21 @@ class ZentralSettings(ConfigDict):
 
 
 settings = ZentralSettings(get_configuration())
+
+
+#
+# API base URLs
+#
+# api.fqdn and api.fqdn_mtls only hold the host, but a lot of the payloads, profiles and
+# scripts we generate need the full base URL. Going through APIDict, which also accepts the
+# deprecated api.tls_hostname* keys, would work too, but it makes the shape of the value
+# impossible to guess from the call site: api.fqdn is a host, api.tls_hostname is a URL.
+#
+
+
+def api_base_url(for_client_cert_auth=False):
+    fqdn = settings["api"]["fqdn_mtls" if for_client_cert_auth else "fqdn"]
+    return f"https://{fqdn}"
 
 
 #

--- a/zentral/contrib/google_workspace/api_client.py
+++ b/zentral/contrib/google_workspace/api_client.py
@@ -10,7 +10,7 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from .models import Connection
 
 
@@ -103,7 +103,7 @@ class _AdminSDKClient(APIClient):
         return InstalledAppFlow.from_client_config(
             self.client_config,
             scopes=self.scopes,
-            redirect_uri="https://{}{}".format(settings["api"]["fqdn"], reverse("google_workspace:redirect")),
+            redirect_uri=f'{api_base_url()}{reverse("google_workspace:redirect")}',
         )
 
     def _dir_svc(self):

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -23,7 +23,7 @@ from django.utils.timesince import timesince
 from django.utils.translation import gettext_lazy as _
 from realms.models import RealmUser
 
-from zentral.conf import settings
+from zentral.conf import api_base_url, settings
 from zentral.core.compliance_checks.utils import get_machine_compliance_check_statuses
 from zentral.core.incidents.models import MachineIncident, Status
 from zentral.utils.model_extras import find_all_related_objects
@@ -992,11 +992,11 @@ class MetaMachine:
 
     def get_url(self):
         try:
-            tls_hostname = settings['api']['tls_hostname']
+            base_url = api_base_url()
         except KeyError:
-            logger.warning("Missing api.tls_hostname configuration key")
+            logger.warning("Missing api.fqdn configuration key")
         else:
-            return "{}{}".format(tls_hostname.rstrip('/'), self.get_absolute_url())
+            return f"{base_url}{self.get_absolute_url()}"
 
     @property
     def names_with_sources(self):

--- a/zentral/contrib/mdm/commands/install_enterprise_application.py
+++ b/zentral/contrib/mdm/commands/install_enterprise_application.py
@@ -1,6 +1,6 @@
 import logging
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.mdm.models import Artifact, Channel, Platform, TargetArtifact
 from zentral.contrib.mdm.payloads import substitute_variables
 from .base import register_command, Command
@@ -21,9 +21,8 @@ class InstallEnterpriseApplication(Command):
     def build_command(self):
         enterprise_app = self.artifact_version.enterprise_app
         manifest = enterprise_app.manifest
-        manifest["items"][0]["assets"][0]["url"] = "https://{}{}".format(settings["api"]["fqdn"],
-                                                                         reverse("mdm_public:enterprise_app_download",
-                                                                                 args=(self.db_command.uuid,)))
+        download_path = reverse("mdm_public:enterprise_app_download", args=(self.db_command.uuid,))
+        manifest["items"][0]["assets"][0]["url"] = f"{api_base_url()}{download_path}"
         cmd = {"Manifest": manifest}
         configuration = enterprise_app.get_configuration()
         if configuration:

--- a/zentral/contrib/mdm/declarations/cert_asset.py
+++ b/zentral/contrib/mdm/declarations/cert_asset.py
@@ -1,6 +1,6 @@
 import logging
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.mdm.cert_issuer_backends import test_acme_payload
 from zentral.contrib.mdm.models import Artifact, CertAsset, Platform
 from .exceptions import DeclarationError
@@ -65,8 +65,8 @@ def build_cert_asset(enrollment_session, target, declaration_identifier):
         "ServerToken": server_token,
         "Payload": {
             "Reference": {
-                "DataURL": "https://{}{}".format(
-                    settings["api"]["fqdn"],
+                "DataURL": "{}{}".format(
+                    api_base_url(),
                     reverse(f"mdm_public:{url_name}",
                             args=(dump_cert_asset_token(enrollment_session, target, artifact_version_pk),))
                 ),

--- a/zentral/contrib/mdm/declarations/data_asset.py
+++ b/zentral/contrib/mdm/declarations/data_asset.py
@@ -1,6 +1,6 @@
 import logging
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.mdm.models import Artifact, DataAsset
 from .exceptions import DeclarationError
 from .utils import (dump_artifact_version_token,
@@ -43,8 +43,8 @@ def build_data_asset(enrollment_session, target, declaration_identifier):
         "ServerToken": server_token,
         "Payload": {
             "Reference": {
-                "DataURL": "https://{}{}".format(
-                    settings["api"]["fqdn"],
+                "DataURL": "{}{}".format(
+                    api_base_url(),
                     reverse("mdm_public:data_asset_download_view",
                             args=(dump_data_asset_token(enrollment_session, target, artifact_version_pk),))
                 ),

--- a/zentral/contrib/mdm/declarations/declaration.py
+++ b/zentral/contrib/mdm/declarations/declaration.py
@@ -1,6 +1,6 @@
 import logging
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.mdm.models import Artifact, Declaration
 from zentral.contrib.mdm.payloads import substitute_variables
 from .exceptions import DeclarationError
@@ -39,8 +39,8 @@ def build_declaration(enrollment_session, target, declaration_identifier):
                   for ref in declaration.declarationref_set.all()}
     # substitute ManifestURL package references with signed package_manifest URLs
     manifest_url_refs = {
-        tuple(ref.key): "https://{}{}".format(
-            settings["api"]["fqdn"],
+        tuple(ref.key): "{}{}".format(
+            api_base_url(),
             reverse(
                 "mdm_public:package_manifest",
                 args=(dump_package_manifest_token(enrollment_session, target, ref.package.pk),),

--- a/zentral/contrib/mdm/declarations/legacy_profile.py
+++ b/zentral/contrib/mdm/declarations/legacy_profile.py
@@ -1,6 +1,6 @@
 import logging
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.mdm.models import Artifact, Profile
 from .utils import (dump_artifact_version_token,
                     load_artifact_version_token,
@@ -37,8 +37,8 @@ def build_legacy_profile(enrollment_session, target, declaration_identifier):
         "Identifier": declaration_identifier,
         "ServerToken": server_token,
         "Payload": {
-            "ProfileURL": "https://{}{}".format(
-                settings["api"]["fqdn"],
+            "ProfileURL": "{}{}".format(
+                api_base_url(),
                 reverse("mdm_public:profile_download_view",
                         args=(dump_legacy_profile_token(enrollment_session, target, artifact_version_pk),))
             )

--- a/zentral/contrib/mdm/dep.py
+++ b/zentral/contrib/mdm/dep.py
@@ -15,7 +15,7 @@ from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 
-from zentral.conf import settings
+from zentral.conf import api_base_url, settings
 from zentral.utils.certificates import split_certificate_chain
 from zentral.utils.time import naive_utcnow
 
@@ -94,11 +94,9 @@ def decrypt_dep_token(dep_token, payload):
 
 
 def serialize_dep_profile(dep_enrollment):
+    enroll_path = reverse("mdm_public:dep_enroll", args=(dep_enrollment.enrollment_secret.secret,))
     payload = {"profile_name": dep_enrollment.name[:125],
-               "url": "{}{}".format(
-                   settings["api"]["tls_hostname"],
-                   reverse("mdm_public:dep_enroll", args=(dep_enrollment.enrollment_secret.secret,))
-               )}
+               "url": f"{api_base_url()}{enroll_path}"}
     if dep_enrollment.pk:
         payload["devices"] = list(dep_enrollment.depdevice_set.values_list("serial_number", flat=True))
     else:
@@ -106,10 +104,8 @@ def serialize_dep_profile(dep_enrollment):
 
     # do authentication in webview if a realm is present
     if dep_enrollment.realm:
-        payload["configuration_web_url"] = "{}{}".format(
-            settings["api"]["tls_hostname"],
-            reverse("mdm_public:dep_web_enroll", args=(dep_enrollment.enrollment_secret.secret,))
-        )
+        web_enroll_path = reverse("mdm_public:dep_web_enroll", args=(dep_enrollment.enrollment_secret.secret,))
+        payload["configuration_web_url"] = f"{api_base_url()}{web_enroll_path}"
 
     # standard attibutes
     for attr in ("allow_pairing",

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -26,7 +26,7 @@ from django.utils.timesince import timesince
 from django.utils.translation import gettext_lazy as _
 from realms.models import Realm, RealmGroup, RealmUser
 
-from zentral.conf import settings
+from zentral.conf import api_base_url, settings
 from zentral.contrib.inventory.models import (
     EnrollmentSecret,
     EnrollmentSecretRequest,
@@ -1727,8 +1727,7 @@ class OTAEnrollment(MDMEnrollment):
 
     def get_enroll_full_url(self):
         if self.realm:
-            return "{}{}".format(settings["api"]["tls_hostname"],
-                                 reverse("mdm_public:ota_enrollment_enroll", args=(self.pk,)))
+            return f'{api_base_url()}{reverse("mdm_public:ota_enrollment_enroll", args=(self.pk,))}'
 
     def revoke(self):
         if not self.enrollment_secret.revoked_at:

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -26,7 +26,7 @@ from django.utils.timesince import timesince
 from django.utils.translation import gettext_lazy as _
 from realms.models import Realm, RealmGroup, RealmUser
 
-from zentral.conf import api_base_url, settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import (
     EnrollmentSecret,
     EnrollmentSecretRequest,
@@ -2431,8 +2431,8 @@ class UserEnrollment(MDMEnrollment):
 
     def get_service_discovery_full_url(self):
         if self.realm:
-            return "https://{}{}".format(
-                settings["api"]["fqdn"],
+            return "{}{}".format(
+                api_base_url(),
                 reverse("mdm_public:user_enrollment_service_discovery", args=(self.enrollment_secret.secret,))
             )
 

--- a/zentral/contrib/mdm/payloads.py
+++ b/zentral/contrib/mdm/payloads.py
@@ -219,13 +219,12 @@ def build_mdm_configuration_profile(enrollment_session, machine_info=None):
                                "com.apple.mdm.per-user-connections"],
         "CheckOutWhenRemoved": True,
     }
-    if settings["apps"]["zentral.contrib.mdm"].get("mtls_proxy", True):
-        fqdn_key = "fqdn_mtls"
-    else:
+    mtls_proxy = settings["apps"]["zentral.contrib.mdm"].get("mtls_proxy", True)
+    if not mtls_proxy:
         mdm_config["SignMessage"] = True
-        fqdn_key = "fqdn"
-    mdm_config["ServerURL"] = "https://{}{}".format(settings["api"][fqdn_key], reverse("mdm_public:connect"))
-    mdm_config["CheckInURL"] = "https://{}{}".format(settings["api"][fqdn_key], reverse("mdm_public:checkin"))
+    base_url = api_base_url(mtls_proxy)
+    mdm_config["ServerURL"] = f'{base_url}{reverse("mdm_public:connect")}'
+    mdm_config["CheckInURL"] = f'{base_url}{reverse("mdm_public:checkin")}'
     managed_apple_id = getattr(enrollment_session, "managed_apple_id", None)
     if managed_apple_id:
         # account-driven user enrollment

--- a/zentral/contrib/mdm/payloads.py
+++ b/zentral/contrib/mdm/payloads.py
@@ -2,7 +2,7 @@ import logging
 import plistlib
 from django.http import HttpResponse
 from django.urls import reverse
-from zentral.conf import settings
+from zentral.conf import api_base_url, settings
 from zentral.utils.certificates import split_certificate_chain
 from zentral.utils.payloads import generate_payload_uuid, get_payload_identifier
 from zentral.utils.payloads import sign_payload
@@ -183,7 +183,7 @@ def build_profile_service_configuration_profile(ota_obj):
         raise ValueError("ota_obj not an OTAEnrollment nor an OTAEnrollmentSession")
     return build_profile(display_name,
                          "profile-service",
-                         {"URL": "{}{}".format(settings["api"]["tls_hostname"], url_path),
+                         {"URL": f"{api_base_url()}{url_path}",
                           "DeviceAttributes": ["UDID",
                                                "VERSION",
                                                "PRODUCT",

--- a/zentral/contrib/mdm/public_views/mdm.py
+++ b/zentral/contrib/mdm/public_views/mdm.py
@@ -19,7 +19,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.views.generic import View
 
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import MetaBusinessUnit
 from zentral.contrib.inventory.utils import add_machine_tags
 from zentral.contrib.mdm.apps_books import ensure_target_asset_assignments
@@ -719,8 +719,8 @@ class PackageManifestView(DownloadView):
                                              Target(self.enrolled_device, self.enrolled_user),
                                              package.pk)
         asset = manifest["items"][0]["assets"][0]
-        asset["url"] = "https://{}{}".format(
-            settings["api"]["fqdn"],
+        asset["url"] = "{}{}".format(
+            api_base_url(),
             reverse("mdm_public:package_file", args=(file_token,)),
         )
         return HttpResponse(plistlib.dumps(manifest), content_type="application/x-plist")

--- a/zentral/contrib/mdm/public_views/user.py
+++ b/zentral/contrib/mdm/public_views/user.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.generic import View
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.exceptions import EnrollmentSecretVerificationFailed
 from zentral.contrib.inventory.utils import verify_enrollment_secret
 from zentral.contrib.mdm.events import UserEnrollmentRequestEvent
@@ -24,8 +24,8 @@ class UserEnrollmentServiceDiscoveryView(View):
         return JsonResponse({
             "Servers": [
                 {"Version": "mdm-byod",
-                 "BaseURL": "https://{}{}".format(
-                     settings["api"]["fqdn"],
+                 "BaseURL": "{}{}".format(
+                     api_base_url(),
                      reverse("mdm_public:enroll_user", args=(user_enrollment.enrollment_secret.secret,)))}
             ]
         })
@@ -53,8 +53,8 @@ class EnrollUserView(PostEventMixin, View):
         authorization = request.headers.get("Authorization")
         if not authorization:
             user_enrollment_session = UserEnrollmentSession.objects.create_from_user_enrollment(self.user_enrollment)
-            url = "https://{}{}".format(
-                settings["api"]["fqdn"],
+            url = "{}{}".format(
+                api_base_url(),
                 reverse("mdm_public:authenticate_user", args=(user_enrollment_session.enrollment_secret.secret,))
             )
             response = HttpResponse("Unauthorized", status=401)

--- a/zentral/contrib/monolith/serializers.py
+++ b/zentral/contrib/monolith/serializers.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 from rest_framework import serializers
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret, Tag
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
 from .conf import monolith_conf
@@ -131,9 +131,8 @@ class EnrollmentSerializer(serializers.ModelSerializer):
         return obj.enrolledmachine_set.count()
 
     def get_download_url(self, fmt, obj):
-        fqdn = settings["api"]["fqdn"]
         path = reverse(f"monolith_api:enrollment_{fmt}", args=(obj.pk,))
-        return f'https://{fqdn}{path}'
+        return f"{api_base_url()}{path}"
 
     def get_configuration_profile_download_url(self, obj):
         return self.get_download_url("configuration_profile", obj)

--- a/zentral/contrib/monolith/utils.py
+++ b/zentral/contrib/monolith/utils.py
@@ -4,7 +4,7 @@ import plistlib
 
 from django.core.files.base import ContentFile
 
-from zentral.utils.osx_package import get_api_fqdn
+from zentral.conf import api_base_url
 from zentral.utils.payloads import generate_payload_uuid, get_payload_identifier
 from zentral.utils.text import shard as compute_shard
 from zentral.utils.time import naive_utc_fromisoformat
@@ -81,7 +81,7 @@ def build_configuration(enrollment):
     # TODO: hardcoded
     config = {
         "ClientIdentifier": "$SERIALNUMBER",
-        "SoftwareRepoURL": f"https://{get_api_fqdn()}/public/monolith/munki_repo",
+        "SoftwareRepoURL": f"{api_base_url()}/public/monolith/munki_repo",
         "FollowHTTPRedirects": "all",
         # "ManifestURL": None,  # no special Manifest URL with monolith
         # force redirect via monolith for Icon and Client Resource

--- a/zentral/contrib/monolith/utils.py
+++ b/zentral/contrib/monolith/utils.py
@@ -4,7 +4,7 @@ import plistlib
 
 from django.core.files.base import ContentFile
 
-from zentral.utils.osx_package import get_tls_hostname
+from zentral.utils.osx_package import get_api_fqdn
 from zentral.utils.payloads import generate_payload_uuid, get_payload_identifier
 from zentral.utils.text import shard as compute_shard
 from zentral.utils.time import naive_utc_fromisoformat
@@ -34,7 +34,7 @@ def make_package_info(builder, manifest_enrollment_package, package_content):
         'FQDN="$($PLUTIL -extract fqdn raw $ENROLLMENT_PLIST 2> /dev/null)"\n'
         f'if [[ "$ENROLLMENT_ID" != "{builder.enrollment.pk}" ]] '
         f'|| [[ "$ENROLLMENT_VERSION" != "{builder.enrollment.version}" ]] '
-        f'|| [[ "$FQDN" != "{builder.get_tls_hostname()}" ]]\n'
+        f'|| [[ "$FQDN" != "{builder.get_api_fqdn()}" ]]\n'
         'then\n'
         # the current values are not the expected values, install
         'exit 0\n'
@@ -81,7 +81,7 @@ def build_configuration(enrollment):
     # TODO: hardcoded
     config = {
         "ClientIdentifier": "$SERIALNUMBER",
-        "SoftwareRepoURL": "https://{}/public/monolith/munki_repo".format(get_tls_hostname()),
+        "SoftwareRepoURL": f"https://{get_api_fqdn()}/public/monolith/munki_repo",
         "FollowHTTPRedirects": "all",
         # "ManifestURL": None,  # no special Manifest URL with monolith
         # force redirect via monolith for Icon and Client Resource

--- a/zentral/contrib/munki/osx_package/builder.py
+++ b/zentral/contrib/munki/osx_package/builder.py
@@ -20,10 +20,10 @@ class MunkiZentralEnrollPkgBuilder(EnrollmentPackageBuilder):
         return '[[ -d "/opt/zentral/lib/Turbo.app" ]] && exit 1\n'
 
     def extra_build_steps(self):
-        tls_hostname = self.get_tls_hostname()
+        fqdn = self.get_api_fqdn()
         # munki zentral preflight and postflight script
         replacements = [
-            ("%TLS_HOSTNAME%", tls_hostname),
+            ("%TLS_HOSTNAME%", fqdn),
             ("%TLS_SERVER_CERTS%", self.include_tls_server_certs() or ""),
         ]
         for phase in ("preflight", "postflight"):
@@ -34,7 +34,7 @@ class MunkiZentralEnrollPkgBuilder(EnrollmentPackageBuilder):
         postinstall_script = self.get_build_path("scripts", "postinstall")
         replacements.extend([
             ("%ENROLLMENT_SECRET%", self.build_kwargs["enrollment_secret_secret"]),
-            ("%ENROLLMENT_URL%", "https://{}{}".format(tls_hostname, reverse("munki_public:enroll"))),
+            ("%ENROLLMENT_URL%", f'https://{fqdn}{reverse("munki_public:enroll")}'),
             ("%HAS_DISTRIBUTOR%", "YES" if self.build_kwargs.get("has_distributor") else "NO"),
         ])
         self.replace_in_file(postinstall_script, replacements)
@@ -43,4 +43,4 @@ class MunkiZentralEnrollPkgBuilder(EnrollmentPackageBuilder):
         with open(self.get_root_path(f"usr/local/zentral/{self.local_subfolder}/enrollment.plist"), "wb") as f:
             plistlib.dump({"enrollment": {"id": self.enrollment.pk,
                                           "version": self.enrollment.version},
-                           "fqdn": tls_hostname}, f)
+                           "fqdn": fqdn}, f)

--- a/zentral/contrib/munki/serializers.py
+++ b/zentral/contrib/munki/serializers.py
@@ -2,7 +2,7 @@ from django.db.models import F
 from django.urls import reverse
 from rest_framework import serializers
 
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
 from zentral.core.compliance_checks.models import ComplianceCheck
@@ -45,7 +45,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
 
     def get_package_download_url(self, obj):
         path = reverse("munki_api:enrollment_package", args=(obj.pk,))
-        return f'https://{settings["api"]["fqdn"]}{path}'
+        return f"{api_base_url()}{path}"
 
     def create(self, validated_data):
         secret_data = validated_data.pop('secret')

--- a/zentral/contrib/osquery/linux_script/builder.py
+++ b/zentral/contrib/osquery/linux_script/builder.py
@@ -25,7 +25,7 @@ class OsqueryZentralEnrollScriptBuilder(APIConfigToolsMixin):
             content = f.read()
 
         # tls hostname
-        content = content.replace("%TLS_HOSTNAME%", self.get_tls_hostname())
+        content = content.replace("%TLS_HOSTNAME%", self.get_api_fqdn())
 
         serialized_flags = self.build_kwargs["serialized_flags"]
 

--- a/zentral/contrib/osquery/osx_package/builder.py
+++ b/zentral/contrib/osquery/osx_package/builder.py
@@ -79,7 +79,7 @@ class OsqueryZentralEnrollPkgBuilder(EnrollmentPackageBuilder):
         )
 
         # tls_hostname and osqueryd paths in postinstall
-        tls_hostname = self.get_tls_hostname()
+        tls_hostname = self.get_api_fqdn()
         self.replace_in_file(self.get_build_path("scripts", "postinstall"),
                              (("%TLS_HOSTNAME%", tls_hostname), osqueryd_paths_replacement))
 

--- a/zentral/contrib/osquery/powershell_script/builder.py
+++ b/zentral/contrib/osquery/powershell_script/builder.py
@@ -25,7 +25,7 @@ class OsqueryZentralEnrollPowershellScriptBuilder(APIConfigToolsMixin):
             content = f.read()
 
         # tls hostname
-        tls_hostname = self.get_tls_hostname()
+        tls_hostname = self.get_api_fqdn()
         content = content.replace("%TLS_HOSTNAME%", tls_hostname)
 
         serialized_flags = self.build_kwargs["serialized_flags"]

--- a/zentral/contrib/osquery/serializers.py
+++ b/zentral/contrib/osquery/serializers.py
@@ -2,7 +2,7 @@ from django.db.models import F
 from django.urls import reverse
 from django.utils.text import slugify
 from rest_framework import serializers
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
 from .compliance_checks import sync_query_compliance_check
@@ -43,7 +43,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
 
     def get_artifact_download_url(self, view_name, obj):
         path = reverse(f"osquery_api:{view_name}", args=(obj.pk,))
-        return f'https://{settings["api"]["fqdn"]}{path}'
+        return f"{api_base_url()}{path}"
 
     def get_package_download_url(self, obj):
         return self.get_artifact_download_url("enrollment_package", obj)

--- a/zentral/contrib/puppet/models.py
+++ b/zentral/contrib/puppet/models.py
@@ -10,7 +10,7 @@ from django.db.models import F
 from django.db.models.signals import post_delete, post_save
 from django.urls import reverse
 from django.utils.crypto import constant_time_compare
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.core.secret_engines import decrypt_str, encrypt_str, rewrap
 from zentral.utils.certificates import iter_cert_trees
 
@@ -85,7 +85,7 @@ class Instance(models.Model):
         return reverse("puppet:instance", args=(self.pk,))
 
     def get_post_report_full_url(self):
-        return "https://{}{}".format(settings["api"]["fqdn"], reverse("puppet:post_report", args=(self.pk,)))
+        return f'{api_base_url()}{reverse("puppet:post_report", args=(self.pk,))}'
 
     def save(self, *args, **kwargs):
         if not self.pk:

--- a/zentral/contrib/santa/forms.py
+++ b/zentral/contrib/santa/forms.py
@@ -62,18 +62,11 @@ class ConfigurationForm(forms.ModelForm):
                            "Can't use a bloked path regex in Lockdown mode.")
 
         # client certificate authentication
-        client_certificate_auth = cleaned_data.get("client_certificate_auth", False)
-        client_auth_certificate_issuer_cn = cleaned_data.get("client_auth_certificate_issuer_cn")
-        if client_auth_certificate_issuer_cn and not client_certificate_auth:
-            self.add_error("client_certificate_auth",
-                           "Needs to be checked to use Client auth certificate issuer CN")
-        if (client_certificate_auth or client_auth_certificate_issuer_cn) and \
-           "tls_hostname_for_client_cert_auth" not in settings["api"]:
-            for field in ("client_certificate_auth", "client_auth_certificate_issuer_cn"):
-                self.add_error(
-                    field,
-                    "The server requiring the client cert for authentication is not configured."
-                )
+        if cleaned_data.get("client_certificate_auth") and "fqdn_mtls" not in settings["api"]:
+            self.add_error(
+                "client_certificate_auth",
+                "The server requiring the client cert for authentication is not configured."
+            )
 
         # block USB
         block_usb_mount = cleaned_data.get("block_usb_mount")

--- a/zentral/contrib/santa/serializers.py
+++ b/zentral/contrib/santa/serializers.py
@@ -8,7 +8,7 @@ from django.db.models import F
 from django.urls import reverse
 from rest_framework import serializers
 
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
 
@@ -40,7 +40,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
 
     def get_artifact_download_url(self, view_name, obj):
         path = reverse(f"santa_api:{view_name}", args=(obj.pk,))
-        return f'https://{settings["api"]["fqdn"]}{path}'
+        return f"{api_base_url()}{path}"
 
     def get_plist_download_url(self, obj):
         return self.get_artifact_download_url("enrollment_plist", obj)

--- a/zentral/contrib/santa/utils.py
+++ b/zentral/contrib/santa/utils.py
@@ -25,14 +25,13 @@ def build_santa_enrollment_configuration(enrollment):
     })
     realm = configuration.voting_realm
     if realm and realm.user_portal and settings["apps"]["zentral.contrib.santa"].get("user_portal"):
-        fqdn = settings["api"]["fqdn"]
         path = reverse("realms_public:santa_up:event_detail", args=(realm.pk,))
         params = (
             "bofid=%bundle_or_file_identifier%&fid=%file_identifier%"
             "&mid=%machine_id%&tid=%team_id%&sid=%signing_id%&cdh=%cdhash%"
         )
         config["EventDetailText"] = "More info"
-        config["EventDetailURL"] = f"https://{fqdn}{path}?{params}"
+        config["EventDetailURL"] = f"{api_base_url()}{path}?{params}"
     return config
 
 

--- a/zentral/contrib/santa/utils.py
+++ b/zentral/contrib/santa/utils.py
@@ -6,7 +6,7 @@ from dateutil import parser
 from django.db import connection, transaction
 from django.urls import reverse
 
-from zentral.conf import settings
+from zentral.conf import api_base_url, settings
 from zentral.utils.payloads import generate_payload_uuid, get_payload_identifier, sign_payload
 from zentral.utils.time import naive_utcnow
 
@@ -16,11 +16,8 @@ from .models import Rule, Target
 def build_santa_enrollment_configuration(enrollment):
     configuration = enrollment.configuration
     config = configuration.get_local_config()
-    base_url_key = "tls_hostname"
-    if configuration.client_certificate_auth:
-        base_url_key = "tls_hostname_for_client_cert_auth"
     config.update({
-        "SyncBaseURL": "{}/public/santa/sync/".format(settings["api"][base_url_key]),
+        "SyncBaseURL": f"{api_base_url(configuration.client_certificate_auth)}/public/santa/sync/",
         # See https://developer.apple.com/documentation/foundation/nsurlrequest#1776617
         # Authorization is reserved, so we use 'Zentral-Authorization'
         # See also https://github.com/northpolesec/santa/blob/344a35aaf63c24a56f7a021ce18ecab090584da3/Source/common/SNTConfigurator.h#L418-L421  # NOQA

--- a/zentral/contrib/turbo/serializers.py
+++ b/zentral/contrib/turbo/serializers.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework import serializers
 
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
 
@@ -45,7 +45,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
 
     def get_artifact_download_url(self, view_name, obj):
         path = reverse(f"turbo_api:{view_name}", args=(obj.pk,))
-        return f'https://{settings["api"]["fqdn"]}{path}'
+        return f"{api_base_url()}{path}"
 
     def get_configuration_profile_download_url(self, obj):
         return self.get_artifact_download_url("enrollment_configuration_profile", obj)

--- a/zentral/contrib/turbo/utils.py
+++ b/zentral/contrib/turbo/utils.py
@@ -1,6 +1,6 @@
 import plistlib
 
-from zentral.conf import settings
+from zentral.conf import api_base_url
 from zentral.utils.payloads import generate_payload_uuid, get_payload_identifier, sign_payload
 
 
@@ -8,7 +8,7 @@ def build_turbo_enrollment_configuration(enrollment):
     # Managed defaults for the com.zentral.turbo domain. The agent reads BaseURL as the host root and
     # appends public/turbo/ itself, then exchanges EnrollmentSecret for a per-device token at enroll time.
     return {
-        "BaseURL": settings["api"]["tls_hostname"],
+        "BaseURL": api_base_url(),
         "EnrollmentSecret": enrollment.secret.secret,
     }
 

--- a/zentral/utils/osx_package.py
+++ b/zentral/utils/osx_package.py
@@ -210,7 +210,7 @@ class ProductArchiveBuilder(BasePackageBuilder):
         self.pkg_refs.append({"id": pkg_identifier, "version": pkg_version})
 
 
-def get_tls_hostname(for_client_cert_auth=False):
+def get_api_fqdn(for_client_cert_auth=False):
     if for_client_cert_auth:
         key = "fqdn_mtls"
     else:
@@ -223,8 +223,8 @@ def distribute_tls_server_certs():
 
 
 class APIConfigToolsMixin(object):
-    def get_tls_hostname(self, for_client_cert_auth=False):
-        return get_tls_hostname(for_client_cert_auth)
+    def get_api_fqdn(self, for_client_cert_auth=False):
+        return get_api_fqdn(for_client_cert_auth)
 
     def get_tls_fullchain(self):
         if distribute_tls_server_certs():


### PR DESCRIPTION
## What this is

`docs/configuration/api.md` marks `api.tls_hostname` as deprecated in favour of `api.fqdn`, yet the payload and URL builders still read it. **This was not a live bug** — `APIDict` in `zentral/conf/__init__.py` derives each form from the other at config-load time, so both keys always resolve.

The real problem was that two similarly named accessors returned **different shapes**:

| accessor | returns |
|---|---|
| `settings["api"]["tls_hostname"]` | `https://zentral.example.com` (URL, with scheme) |
| `get_tls_hostname()` in `zentral/utils/osx_package.py` | `zentral.example.com` (bare FQDN — it reads `api.fqdn`) |

A reader who assumed those agreed got a doubled or a missing scheme. `zentral/contrib/mdm/payloads.py` and `server/accounts/views/user.py` each used both within a few lines of each other. Swapping the deprecated key for `api.fqdn` without prepending `https://` would have produced a scheme-less `BaseURL`, so this needed untangling rather than a find-and-replace.

## What to use

| You need | Value | Before | From now on |
|---|---|---|---|
| FQDN | `zentral.example.com` | `settings["api"]["fqdn"]` | `settings["api"]["fqdn"]` (unchanged) |
| FQDN, mTLS | `zentral-mtls.example.com` | `settings["api"]["fqdn_mtls"]` | `settings["api"]["fqdn_mtls"]` (unchanged) |
| Base URL | `https://zentral.example.com` | `settings["api"]["tls_hostname"]` (deprecated key) | `api_base_url()` |
| Base URL, mTLS | `https://zentral-mtls.example.com` | `settings["api"]["tls_hostname_for_client_cert_auth"]` (deprecated key) | `api_base_url(for_client_cert_auth=True)` |

`api_base_url` comes from `zentral.conf`. The two FQDN keys do not change: read them directly.

Package builders have their own FQDN accessor, because they already hold a builder instance. It is renamed:

| You need | Before | From now on |
|---|---|---|
| FQDN, in a builder | `self.get_tls_hostname()` | `self.get_api_fqdn()` |
| FQDN, mTLS, in a builder | `self.get_tls_hostname(for_client_cert_auth=True)` | `self.get_api_fqdn(for_client_cert_auth=True)` |

Do not import `get_api_fqdn` from `zentral.utils.osx_package` outside a builder. That module loads the package build machinery. Use `settings["api"]["fqdn"]`.

## The commits

**1. `santa: fix the client certificate auth configuration check`** — the one behaviour change, so it leads and can be reviewed alone. `ConfigurationForm.clean()` added its "mTLS not configured" error to `client_auth_certificate_issuer_cn`, a field removed from the model in `0031_auto_20220812_0925` (2022). `add_error()` raises `ValueError` for an unknown field, so ticking **Client certificate authentication** on a server with no mTLS FQDN returned a 500 instead of the validation error. The companion check on that field could never fire either: it was never in `cleaned_data`. The presence check also moves from the deprecated `api.tls_hostname_for_client_cert_auth` to `api.fqdn_mtls`. This commit carries the CHANGELOG entry.

**2. `conf: add api_base_url() and stop reading the deprecated api.tls_hostname key`** — the helper returns `https://{fqdn}` from the non-deprecated key. It lives in `zentral/conf` rather than next to `get_tls_hostname`, because `zentral/utils/osx_package.py` pulls in `subprocess`/`tempfile`/`shutil` that `accounts`, `realms` and `mdm` have no reason to import.

Migrated to it: turbo `BaseURL`, santa `SyncBaseURL`, the DEP profile `url` and `configuration_web_url`, the OTA enroll URL and profile-service `URL`, the password reset URL, the WebAuthn `expected_origin`, `MetaMachine.get_url()`, and the SAML and OIDC realm backend URLs. After this commit no application code reads a deprecated `api.tls_hostname*` key.

Two incidental cleanups fell out. The TOTP provisioning label went through `urlparse(...).netloc` to get the host back out of the URL, and reads `api.fqdn` directly now. The `.rstrip("/")` calls disappear, because a netloc never carries a trailing slash. The dead module-level `settings` import in the SAML backend goes too: a local in `get_saml2_config` shadowed it.

**3. `utils: rename get_tls_hostname() to get_api_fqdn()`** — the accessor says what it returns now. osquery's `--tls_hostname` flag and the `%TLS_HOSTNAME%` placeholders keep their names, because that is the agent's vocabulary and it does take a host. Every remaining `tls_hostname` in application code is osquery's.

**4. `conf: build the remaining base URLs with api_base_url()`** — every site that wrote `https://` in front of `api.fqdn` by hand now calls the helper. Those sites were correct and none of them read the deprecated key, but they left the shape of the value as a property of the call site instead of the accessor. The MDM `ServerURL` and `CheckInURL` selected `fqdn` or `fqdn_mtls` into an `fqdn_key` variable, which is what `api_base_url(for_client_cert_auth=...)` expresses.

Three sites keep their manual prefix on purpose. The jamf webhook and the Apps and Books notification URL read `api.webhook_fqdn`, a separate key that can point somewhere else, so `api_base_url()` would be wrong. The munki package builder already holds the bare FQDN for the `%TLS_HOSTNAME%` placeholder and the enrollment plist, and two accessors in one function would read worse than the prefix.

**The conf-layer shim is untouched.** It is what keeps deployments configured with `api.tls_hostname` working, and `test_api_base_url` pins `api_base_url()` to the value the deprecated key yields, so the two cannot drift.

## Tests

New tests: `api_base_url()` and its mTLS variant, including that each matches the deprecated key it replaces; the turbo `BaseURL` in the plist and in the configuration profile, asserted against `https://{fqdn}` instead of the previous `assertIn("BaseURL", ...)`, which is the scheme regression this guards; the santa `SyncBaseURL` on the client certificate path, which had no coverage; `MetaMachine.get_url()` and its missing-FQDN warning; `OTAEnrollment.get_enroll_full_url()` with and without a realm; the realm `scim_root_url`; and both branches of the santa client certificate check.

The full suite passes (8315 tests), `ruff` is clean, and every edited line is covered. The coverage was verified by intersecting the `coverage json` missing_lines with the `git diff -U0` hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
