### PR TITLE
munki: compare the script check excluded tags against themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2026.6
+
+
+### Bug fixes
+
+
+Fixed the version of a Munki script check being bumped by every API update, including the ones that changed nothing: the excluded tags were compared with the included tags. A version change discards the results still in flight and makes every machine in scope run the check again.
+
+
 ## 2026.5
 
 

--- a/tests/munki/test_api_views.py
+++ b/tests/munki/test_api_views.py
@@ -57,6 +57,24 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         enrollment_secret = EnrollmentSecret.objects.create(meta_business_unit=self.mbu)
         return Enrollment.objects.create(configuration=configuration, secret=enrollment_secret)
 
+    def script_check_update_data(self, script_check, **updates):
+        # mirrors the stored state, so a call without updates builds a no-op PUT payload
+        data = {
+            "name": script_check.compliance_check.name,
+            "description": script_check.compliance_check.description,
+            "type": script_check.type,
+            "source": script_check.source,
+            "expected_result": script_check.expected_result,
+            "arch_amd64": script_check.arch_amd64,
+            "arch_arm64": script_check.arch_arm64,
+            "min_os_version": script_check.min_os_version,
+            "max_os_version": script_check.max_os_version,
+            "tags": [t.pk for t in script_check.tags.all()],
+            "excluded_tags": [t.pk for t in script_check.excluded_tags.all()],
+        }
+        data.update(updates)
+        return data
+
     # RequestCase implementation
 
     def _get_api_key(self):
@@ -1222,6 +1240,77 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
         self.assertEqual(len(callbacks), 1)
+
+    def test_update_script_check_no_change_no_version_bump(self):
+        tags = [Tag.objects.create(name=get_random_string(12))]
+        excluded_tags = [Tag.objects.create(name=get_random_string(12))]
+        script_check = force_script_check(tags=tags, excluded_tags=excluded_tags)
+        self.set_permissions("munki.change_scriptcheck")
+        response = self.put(reverse("munki_api:script_check", args=(script_check.pk,)),
+                            self.script_check_update_data(script_check))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 1)
+        script_check.refresh_from_db()
+        self.assertEqual(script_check.compliance_check.version, 1)
+        self.assertEqual(list(script_check.tags.all()), tags)
+        self.assertEqual(list(script_check.excluded_tags.all()), excluded_tags)
+
+    def test_update_script_check_only_tags_version_bump(self):
+        excluded_tags = [Tag.objects.create(name=get_random_string(12))]
+        script_check = force_script_check(tags=[Tag.objects.create(name=get_random_string(12))],
+                                          excluded_tags=excluded_tags)
+        tags = [Tag.objects.create(name=get_random_string(12))]
+        self.set_permissions("munki.change_scriptcheck")
+        response = self.put(reverse("munki_api:script_check", args=(script_check.pk,)),
+                            self.script_check_update_data(script_check, tags=[t.pk for t in tags]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 2)
+        script_check.refresh_from_db()
+        self.assertEqual(script_check.compliance_check.version, 2)
+        self.assertEqual(list(script_check.tags.all()), tags)
+        self.assertEqual(list(script_check.excluded_tags.all()), excluded_tags)
+
+    def test_update_script_check_only_excluded_tags_version_bump(self):
+        # the script check must start without tags: the excluded tags are the only thing left to change,
+        # so a comparison made against the wrong attribute cannot be masked by the included tags one
+        script_check = force_script_check()
+        excluded_tags = [Tag.objects.create(name=get_random_string(12))]
+        self.set_permissions("munki.change_scriptcheck")
+        response = self.put(reverse("munki_api:script_check", args=(script_check.pk,)),
+                            self.script_check_update_data(script_check,
+                                                          excluded_tags=[t.pk for t in excluded_tags]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 2)
+        script_check.refresh_from_db()
+        self.assertEqual(script_check.compliance_check.version, 2)
+        self.assertEqual(list(script_check.tags.all()), [])
+        self.assertEqual(list(script_check.excluded_tags.all()), excluded_tags)
+
+    def test_update_script_check_only_max_os_version_version_bump(self):
+        # unlike turbo, munki bumps the version for any script check change, not only a source change:
+        # a different scope means a different set of machines has to run the check
+        script_check = force_script_check()
+        self.set_permissions("munki.change_scriptcheck")
+        response = self.put(reverse("munki_api:script_check", args=(script_check.pk,)),
+                            self.script_check_update_data(script_check, max_os_version="15"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 2)
+        script_check.refresh_from_db()
+        self.assertEqual(script_check.compliance_check.version, 2)
+        self.assertEqual(script_check.max_os_version, "15")
+
+    def test_update_script_check_only_name_and_description_no_version_bump(self):
+        script_check = force_script_check()
+        name = get_random_string(12)
+        self.set_permissions("munki.change_scriptcheck")
+        response = self.put(reverse("munki_api:script_check", args=(script_check.pk,)),
+                            self.script_check_update_data(script_check, name=name, description="yolo"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 1)
+        script_check.refresh_from_db()
+        self.assertEqual(script_check.compliance_check.name, name)
+        self.assertEqual(script_check.compliance_check.description, "yolo")
+        self.assertEqual(script_check.compliance_check.version, 1)
 
     # delete script check
 

--- a/tests/munki/test_script_check_views.py
+++ b/tests/munki/test_script_check_views.py
@@ -419,6 +419,64 @@ class MunkiScriptCheckViewsTestCase(TestCase, LoginCase):
         self.assertFormError(response.context["script_check_form"], "expected_result", "Invalid integer")
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_script_check_post_no_change_no_version_bump(self, post_event):
+        tags = [Tag.objects.create(name=get_random_string(12))]
+        excluded_tags = [Tag.objects.create(name=get_random_string(12))]
+        sc = force_script_check(tags=tags, excluded_tags=excluded_tags)
+        self.login("munki.change_scriptcheck", "munki.view_scriptcheck")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("munki:update_script_check", args=(sc.pk,)),
+                {"ccf-name": sc.compliance_check.name,
+                 "ccf-description": sc.compliance_check.description,
+                 "scf-type": sc.type,
+                 "scf-source": sc.source,
+                 "scf-expected_result": sc.expected_result,
+                 "scf-tags": [t.pk for t in tags],
+                 "scf-excluded_tags": [t.pk for t in excluded_tags],
+                 "scf-arch_amd64": sc.arch_amd64,
+                 "scf-arch_arm64": sc.arch_arm64,
+                 "scf-min_os_version": sc.min_os_version,
+                 "scf-max_os_version": sc.max_os_version},
+                follow=True,
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "munki/scriptcheck_detail.html")
+        script_check = response.context["object"]
+        self.assertEqual(script_check.compliance_check.version, 1)
+        self.assertEqual(list(script_check.tags.all()), tags)
+        self.assertEqual(list(script_check.excluded_tags.all()), excluded_tags)
+        self.assertEqual(len(callbacks), 0)
+        post_event.assert_not_called()
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_script_check_post_only_excluded_tags_version_bump(self, post_event):
+        sc = force_script_check()
+        excluded_tags = [Tag.objects.create(name=get_random_string(12))]
+        self.login("munki.change_scriptcheck", "munki.view_scriptcheck")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("munki:update_script_check", args=(sc.pk,)),
+                {"ccf-name": sc.compliance_check.name,
+                 "ccf-description": sc.compliance_check.description,
+                 "scf-type": sc.type,
+                 "scf-source": sc.source,
+                 "scf-expected_result": sc.expected_result,
+                 "scf-excluded_tags": [t.pk for t in excluded_tags],
+                 "scf-arch_amd64": sc.arch_amd64,
+                 "scf-arch_arm64": sc.arch_arm64,
+                 "scf-min_os_version": sc.min_os_version,
+                 "scf-max_os_version": sc.max_os_version},
+                follow=True,
+            )
+        self.assertEqual(response.status_code, 200)
+        script_check = response.context["object"]
+        self.assertEqual(script_check.compliance_check.version, 2)
+        self.assertEqual(list(script_check.excluded_tags.all()), excluded_tags)
+        self.assertEqual(len(callbacks), 1)
+        self.assertEqual(len(post_event.call_args_list), 1)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_update_script_check_post_ok(self, post_event):
         sc = force_script_check()
         prev_value = sc.serialize_for_event()

--- a/zentral/contrib/munki/serializers.py
+++ b/zentral/contrib/munki/serializers.py
@@ -167,7 +167,7 @@ class ScriptCheckSerializer(serializers.ModelSerializer):
             setattr(instance, key, value)
         if sorted(instance.tags.all(), key=lambda t: t.pk) != tags:
             script_check_updated = True
-        if sorted(instance.excluded_tags.all(), key=lambda t: t.pk) != tags:
+        if sorted(instance.excluded_tags.all(), key=lambda t: t.pk) != excluded_tags:
             script_check_updated = True
         if script_check_updated:
             compliance_check.version = F("version") + 1


### PR DESCRIPTION
## The bug

`ScriptCheckSerializer.update()` decides whether to bump the compliance check version by diffing every submitted field against the stored one. The excluded tags branch compared the stored excluded tags to the submitted **included** tags:

```python
if sorted(instance.tags.all(), key=lambda t: t.pk) != tags:
    script_check_updated = True
if sorted(instance.excluded_tags.all(), key=lambda t: t.pk) != tags:  # <-- excluded_tags
    script_check_updated = True
```

`validate()` requires the two sets to be disjoint, so for any check that actually uses tags the second comparison is true on **every** PUT, no-op ones included.

## Why it matters

The version is a machine-facing cursor, not just a display value. In `commit_script_check_results()` a result whose version no longer matches is dropped:

https://github.com/zentralopensource/zentral/blob/main/zentral/contrib/munki/compliance_checks.py#L112-L116

So each spurious bump discards the in-flight results and makes every machine in scope run the check again. A client that reads a check and writes it back unchanged — a terraform plan with no diff to apply, for one — re-ran the whole scope.

## The mirrored false negative

Writing the check against `tags` can also *miss* a real change, when the submitted tags equal the stored excluded tags. With disjointness enforced that needs both to be empty: adding excluded tags to a check that has no tags at all. The included-tags branch does not fire either, so the bump is missed entirely.

`test_update_script_check_only_excluded_tags_version_bump` is built on exactly that shape, so it fails in both directions rather than being masked by the tags comparison. Verified by reintroducing the bug: the no-op test fails `2 != 1` and the excluded-tags test fails `1 != 2`.

## The UI path is not affected

`UpdateScriptCheckView` gates the bump on `ScriptCheckForm.has_changed()`, and Django compares each field against its own initial value, so there is no equivalent slip. Two tests pin that, since nothing covered a no-op POST before — and the UI is in fact stricter than the API here: a no-op POST emits no audit event at all.

## Semantics pinned by the remaining tests

The API bumps the version on **any** script check field change, not only a source change as in turbo. That looks deliberate for munki — a changed architecture or OS version gate changes which machines the check applies to — so it is kept and pinned:

- no-op PUT → version unchanged
- tags only / excluded tags only / `max_os_version` only → version bumped
- name and description only → version unchanged (they live on the compliance check, and the UI gates on the script check form alone too)

## Testing

- `tests.munki` — 309 tests, OK
- full suite as CI runs it — 7806 tests, OK
- `ruff check` clean on all three files
- patch coverage: the single changed production line is covered (`coverage json` missing_lines ∩ `git diff -U0` hunks = empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)