### PR TITLE
docs: audit the API documentation and fill the gaps

### DIFF
--- a/docs/apps/core.md
+++ b/docs/apps/core.md
@@ -104,7 +104,7 @@ An issuer that does not accept a token — bad signature, wrong audience, or a c
 
 Once the issuer exists, the workload exchanges its identity token at [`/api/accounts/token_issuers/oidc/<uuid:issuer_id>/auth/`](#apiaccountstoken_issuersoidcuuidissuer_idauth). The tokens it mints are ordinary API tokens with an expiry, and appear in the service account's token list like any other.
 
-Issuers can also be managed over the API, at `/api/accounts/token_issuers/oidc/`.
+Issuers can also be managed over the API — see [`/api/accounts/token_issuers/oidc/`](#apiaccountstoken_issuersoidc).
 
 ## HTTP API
 
@@ -155,10 +155,153 @@ curl -H "Authorization: Token $ZTL_API_TOKEN" \
      https://$ZTL_FQDN/api/task_result/d40e9320-8c0c-459b-bfdb-001a9f73619f/download/
 ```
 
+### `/api/accounts/token_issuers/oidc/`
+
+The issuers themselves, as described in [OIDC API token issuers](#oidc-api-token-issuers). An issuer can only be attached to a service account, and only by someone allowed to [issue credentials for it](#who-can-issue-a-token-for-whom).
+
+**NB:** creating or updating an issuer fetches the OpenID configuration from the `issuer_uri` to validate it, so the Zentral server needs to be able to reach the provider. An unreachable or non-OpenID URI is a `400`.
+
+#### List all OIDC API token issuers
+
+* method: GET
+* PBAC action: `Accounts::Action::"viewOIDCAPITokenIssuer"`
+* Optional filter parameter:
+    * `name`: name of the issuer
+* Optional ordering parameter:
+    * `ordering`: `created_at` or `-created_at`. `-created_at` by default.
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/accounts/token_issuers/oidc/ \
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": "4d3fcc26-1509-4221-985e-7da77e1106dc",
+            "name": "GitHub Actions - infra",
+            "description": "Deploys from the infra repository",
+            "issuer_uri": "https://token.actions.githubusercontent.com",
+            "audience": "https://zentral.example.com",
+            "cel_condition": "claims.repository == \"acme/infra\"",
+            "max_validity": 900,
+            "created_at": "2026-08-20T13:06:49.861942",
+            "updated_at": "2026-08-20T13:06:49.861947",
+            "user": 8
+        }
+    ]
+}
+```
+
+#### Add an OIDC API token issuer
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Accounts::Action::"createOIDCAPITokenIssuer"`
+
+`user` is the primary key of the service account the issuer mints tokens for.
+
+Example:
+
+issuer.json
+
+```json
+{
+  "user": 8,
+  "name": "GitHub Actions - infra",
+  "description": "Deploys from the infra repository",
+  "issuer_uri": "https://token.actions.githubusercontent.com",
+  "audience": "https://zentral.example.com",
+  "cel_condition": "claims.repository == \"acme/infra\"",
+  "max_validity": 900
+}
+```
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST -d @issuer.json \
+  https://$ZTL_FQDN/api/accounts/token_issuers/oidc/ \
+  |python3 -m json.tool
+```
+
+Response (201 Created):
+
+```json
+{
+    "id": "4d3fcc26-1509-4221-985e-7da77e1106dc",
+    "name": "GitHub Actions - infra",
+    "description": "Deploys from the infra repository",
+    "issuer_uri": "https://token.actions.githubusercontent.com",
+    "audience": "https://zentral.example.com",
+    "cel_condition": "claims.repository == \"acme/infra\"",
+    "max_validity": 900,
+    "created_at": "2026-08-20T13:06:49.861942",
+    "updated_at": "2026-08-20T13:06:49.861947",
+    "user": 8
+}
+```
+
+### `/api/accounts/token_issuers/oidc/<uuid:pk>/`
+
+#### Get an OIDC API token issuer
+
+* method: GET
+* PBAC action: `Accounts::Action::"viewOIDCAPITokenIssuer"`
+* `<uuid:pk>`: the primary key of the issuer
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/accounts/token_issuers/oidc/4d3fcc26-1509-4221-985e-7da77e1106dc/ \
+  |python3 -m json.tool
+```
+
+#### Update an OIDC API token issuer
+
+* method: PUT
+* Content-Type: application/json
+* PBAC action: `Accounts::Action::"updateOIDCAPITokenIssuer"`
+* `<uuid:pk>`: the primary key of the issuer
+
+Send every attribute, `user` included — it is re-checked against your own roles on each update.
+
+#### Delete an OIDC API token issuer
+
+* method: DELETE
+* PBAC action: `Accounts::Action::"deleteOIDCAPITokenIssuer"`
+* `<uuid:pk>`: the primary key of the issuer
+
+Deleting an issuer stops it minting new tokens. The tokens it already minted stay valid until they expire — delete them from the service account's token list to revoke them now.
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -X DELETE \
+  https://$ZTL_FQDN/api/accounts/token_issuers/oidc/4d3fcc26-1509-4221-985e-7da77e1106dc/
+```
+
+Response (204 No Content)
+
 ### `/api/accounts/token_issuers/oidc/<uuid:issuer_id>/auth/`
 
 * method: POST
-* PBAC action: none
+* PBAC action: none — the identity token is the credential
 
 Use this endpoint to exchange an OIDC identity token (Signed JWT) for a short-lived API token. The issuer must be set up first — see [OIDC API token issuers](#oidc-api-token-issuers).
 

--- a/docs/apps/inventory.md
+++ b/docs/apps/inventory.md
@@ -264,7 +264,306 @@ Authorization: Token the_token_string
 
 See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
-### `/api/inventory/machines/<url_safe_serial_number>/meta/`
+### `/api/inventory/meta_business_units/`
+
+A meta business unit groups the business units reported by the different inventory sources, and is what enrollments are scoped to.
+
+#### List all meta business units
+
+* method: GET
+* PBAC action: `Inventory::Action::"viewMetaBusinessUnit"`
+* Optional filter parameter:
+    * `name`: name of the meta business unit
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     https://$ZTL_FQDN/api/inventory/meta_business_units/ \
+     |python3 -m json.tool
+```
+
+Response:
+
+```json
+[
+    {
+        "id": 8,
+        "name": "Acme",
+        "api_enrollment_enabled": true,
+        "created_at": "2026-08-20T13:17:44.071303",
+        "updated_at": "2026-08-20T13:17:44.071308"
+    }
+]
+```
+
+#### Add a meta business unit
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Inventory::Action::"createMetaBusinessUnit"`
+
+Set `api_enrollment_enabled` to `true` to create the business unit that enrollments require. It can be turned on later, but **not off again** — a request trying to disable it is a `400`.
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Acme", "api_enrollment_enabled": true}' \
+     https://$ZTL_FQDN/api/inventory/meta_business_units/ \
+     |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+    "id": 8,
+    "name": "Acme",
+    "api_enrollment_enabled": true,
+    "created_at": "2026-08-20T13:17:44.071303",
+    "updated_at": "2026-08-20T13:17:44.071308"
+}
+```
+
+### `/api/inventory/meta_business_units/<int:pk>/`
+
+* methods: GET, PUT, DELETE
+* PBAC actions: `Inventory::Action::"viewMetaBusinessUnit"`, `Inventory::Action::"updateMetaBusinessUnit"`, `Inventory::Action::"deleteMetaBusinessUnit"`
+* `<int:pk>`: the primary key of the meta business unit
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     https://$ZTL_FQDN/api/inventory/meta_business_units/8/ \
+     |python3 -m json.tool
+```
+
+### `/api/inventory/taxonomies/`
+
+A taxonomy groups tags that are alternatives to one another — a machine carries at most one tag per taxonomy.
+
+#### List all taxonomies
+
+* method: GET
+* PBAC action: `Inventory::Action::"viewTaxonomy"`
+* Optional filter parameter:
+    * `name`: name of the taxonomy
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     https://$ZTL_FQDN/api/inventory/taxonomies/ \
+     |python3 -m json.tool
+```
+
+Response:
+
+```json
+[
+    {
+        "id": 1,
+        "meta_business_unit": null,
+        "name": "Location",
+        "created_at": "2026-08-20T13:17:44.078865",
+        "updated_at": "2026-08-20T13:17:44.078867"
+    }
+]
+```
+
+#### Add a taxonomy
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Inventory::Action::"createTaxonomy"`
+
+`meta_business_unit` is optional — leave it out for a taxonomy available everywhere.
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Location"}' \
+     https://$ZTL_FQDN/api/inventory/taxonomies/ \
+     |python3 -m json.tool
+```
+
+### `/api/inventory/taxonomies/<int:pk>/`
+
+* methods: GET, PUT, DELETE
+* PBAC actions: `Inventory::Action::"viewTaxonomy"`, `Inventory::Action::"updateTaxonomy"`, `Inventory::Action::"deleteTaxonomy"`
+* `<int:pk>`: the primary key of the taxonomy
+
+### `/api/inventory/tags/`
+
+#### List all tags
+
+* method: GET
+* PBAC action: `Inventory::Action::"viewTag"`
+* Optional filter parameter:
+    * `name`: name of the tag
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     https://$ZTL_FQDN/api/inventory/tags/ \
+     |python3 -m json.tool
+```
+
+Response:
+
+```json
+[
+    {
+        "id": 5,
+        "taxonomy": 1,
+        "meta_business_unit": null,
+        "name": "Berlin",
+        "slug": "berlin",
+        "color": "0079bf"
+    }
+]
+```
+
+#### Add a tag
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Inventory::Action::"createTag"`
+
+|Attribute|Description|
+|---|---|
+|`name`|Required, and unique across every tag. The `slug` is derived from it and is read only.|
+|`taxonomy`|Optional. The primary key of a taxonomy. This is the usual way to scope a tag.|
+|`meta_business_unit`|Optional. Restricts the tag to one meta business unit.|
+|`color`|A six-digit hex colour, without the leading `#`. `0079bf` by default.|
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Berlin", "taxonomy": 1, "color": "0079bf"}' \
+     https://$ZTL_FQDN/api/inventory/tags/ \
+     |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+    "id": 5,
+    "taxonomy": 1,
+    "meta_business_unit": null,
+    "name": "Berlin",
+    "slug": "berlin",
+    "color": "0079bf"
+}
+```
+
+### `/api/inventory/tags/<int:pk>/`
+
+* methods: GET, PUT, DELETE
+* PBAC actions: `Inventory::Action::"viewTag"`, `Inventory::Action::"updateTag"`, `Inventory::Action::"deleteTag"`
+* `<int:pk>`: the primary key of the tag
+
+Deleting a tag removes it from every machine that carries it.
+
+### `/api/inventory/jmespath_checks/`
+
+The [inventory compliance checks](#compliance-checks) described above.
+
+|Attribute|Description|
+|---|---|
+|`name`|Required, and unique across the inventory JMESPath checks. It is the name of the compliance check.|
+|`description`|Optional, free text.|
+|`source_name`|The name of the inventory source the check is evaluated against — `Zentral`, `Munki`, `Osquery`, …|
+|`platforms`|The platforms the check applies to: `LINUX`, `MACOS`, `WINDOWS`, `ANDROID`, `IOS`, `IPADOS`, `TVOS`.|
+|`tags`|Restrict the check to the machines carrying any of these tags. Empty means every machine of the source and platforms.|
+|`jmespath_expression`|The [JMESPath](https://jmespath.org/) expression evaluated against the machine snapshot tree. It must return a boolean.|
+
+`version` and `compliance_check_id` are read only.
+
+#### List all JMESPath checks
+
+* method: GET
+* PBAC action: `Inventory::Action::"viewJMESPathCheck"`
+* Optional filter parameter:
+    * `name`: name of the check
+
+Example:
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     https://$ZTL_FQDN/api/inventory/jmespath_checks/ \
+     |python3 -m json.tool
+```
+
+Response:
+
+```json
+[
+    {
+        "name": "SIP enabled",
+        "description": "System Integrity Protection must be on",
+        "version": 1,
+        "compliance_check_id": 11,
+        "id": 1,
+        "source_name": "Zentral",
+        "platforms": [
+            "MACOS"
+        ],
+        "tags": [],
+        "jmespath_expression": "os_version.name == 'macOS'",
+        "created_at": "2026-08-20T13:17:44.088465",
+        "updated_at": "2026-08-20T13:17:44.088467"
+    }
+]
+```
+
+#### Add a JMESPath check
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Inventory::Action::"createJMESPathCheck"`
+
+Example:
+
+jmespath_check.json
+
+```json
+{
+  "name": "SIP enabled",
+  "description": "System Integrity Protection must be on",
+  "source_name": "Zentral",
+  "platforms": ["MACOS"],
+  "tags": [],
+  "jmespath_expression": "os_version.name == 'macOS'"
+}
+```
+
+```bash
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d @jmespath_check.json \
+     https://$ZTL_FQDN/api/inventory/jmespath_checks/ \
+     |python3 -m json.tool
+```
+
+### `/api/inventory/jmespath_checks/<int:pk>/`
+
+* methods: GET, PUT, DELETE
+* PBAC actions: `Inventory::Action::"viewJMESPathCheck"`, `Inventory::Action::"updateJMESPathCheck"`, `Inventory::Action::"deleteJMESPathCheck"`
+* `<int:pk>`: the primary key of the check
+
+Deleting a check deletes its compliance check and all its machine statuses.
+
+### `/api/inventory/machines/<str:urlsafe_serial_number>/meta/`
 
 * method: GET
 * PBAC action: `Inventory::Action::"viewMachineSnapshot"`
@@ -757,6 +1056,37 @@ Example:
 curl -XPOST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   https://$ZTL_FQDN/api/inventory/machines/export_program_instances/\
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+  "task_id": "b1512b8d-1e17-4181-a1c3-93a7243fddd3",
+  "task_result_url": "/api/task_result/b1512b8d-1e17-4181-a1c3-93a7243fddd3/"
+}
+```
+
+### `/api/inventory/machines/export/`
+
+* method: POST
+* PBAC actions:
+	* `Inventory::Action::"viewMachineSnapshot"`
+* optional parameters, in the **query string**:
+	* `export_format`: `xlsx` or `zip`. `xlsx` by default. Any other value is a `400`.
+	* the filters of the machine search, exactly as they appear in the *Inventory > Machines* URL — `sf` (search filter), `q`, `pf` (platform), `tf` (type), and the tag / source / business-unit filters.
+
+Use this endpoint to export the machine list. The `zip` format produces one file per section of the inventory rather than a single sheet.
+
+Unlike the other inventory export endpoints, which take their parameters in the JSON body, this one reads them from the query string — it accepts the same query as the machine list page, so the simplest way to build a call is to filter the list in the web console and copy its query string.
+
+Example:
+
+```bash
+curl -XPOST \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/inventory/machines/export/?export_format=zip" \
   |python3 -m json.tool
 ```
 

--- a/docs/apps/inventory.md
+++ b/docs/apps/inventory.md
@@ -266,6 +266,9 @@ See [API authentication](core.md#api-authentication) for how to create a service
 
 ### `/api/inventory/meta_business_units/`
 
+Terraform resource: [`zentral_meta_business_unit`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/meta_business_unit)  
+Terraform data source: [`zentral_meta_business_unit`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/meta_business_unit)
+
 A meta business unit groups the business units reported by the different inventory sources, and is what enrollments are scoped to.
 
 #### List all meta business units
@@ -343,6 +346,9 @@ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 
 ### `/api/inventory/taxonomies/`
 
+Terraform resource: [`zentral_taxonomy`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/taxonomy)  
+Terraform data source: [`zentral_taxonomy`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/taxonomy)
+
 A taxonomy groups tags that are alternatives to one another — a machine carries at most one tag per taxonomy.
 
 #### List all taxonomies
@@ -399,6 +405,9 @@ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 * `<int:pk>`: the primary key of the taxonomy
 
 ### `/api/inventory/tags/`
+
+Terraform resource: [`zentral_tag`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/tag)  
+Terraform data source: [`zentral_tag`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/tag)
 
 #### List all tags
 
@@ -475,6 +484,9 @@ Response:
 Deleting a tag removes it from every machine that carries it.
 
 ### `/api/inventory/jmespath_checks/`
+
+Terraform resource: [`zentral_jmespath_check`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/jmespath_check)  
+Terraform data source: [`zentral_jmespath_check`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/jmespath_check)
 
 The [inventory compliance checks](#compliance-checks) described above.
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -689,14 +689,14 @@ They are grouped in tables below rather than given a section each: the request a
 
 An **artifact** is a named thing to install, and carries one or more **artifact versions**. A **blueprint** collects artifacts, and a **blueprint artifact** is the link between the two, carrying the scope. See [MDM Blueprints](#mdm-blueprints).
 
-|Endpoint|Methods|PBAC actions|
-|---|---|---|
-|`/api/mdm/artifacts/`|GET, POST|`MDM::Action::"viewArtifact"`, `MDM::Action::"createArtifact"`|
-|`/api/mdm/artifacts/<uuid:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewArtifact"`, `MDM::Action::"updateArtifact"`, `MDM::Action::"deleteArtifact"`|
-|`/api/mdm/blueprints/`|GET, POST|`MDM::Action::"viewBlueprint"`, `MDM::Action::"createBlueprint"`|
-|`/api/mdm/blueprints/<int:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewBlueprint"`, `MDM::Action::"updateBlueprint"`, `MDM::Action::"deleteBlueprint"`|
-|`/api/mdm/blueprint_artifacts/`|GET, POST|`MDM::Action::"viewBlueprintArtifact"`, `MDM::Action::"createBlueprintArtifact"`|
-|`/api/mdm/blueprint_artifacts/<int:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewBlueprintArtifact"`, `MDM::Action::"updateBlueprintArtifact"`, `MDM::Action::"deleteBlueprintArtifact"`|
+|Endpoint|Methods|PBAC actions|Terraform|
+|---|---|---|---|
+|`/api/mdm/artifacts/`|GET, POST|`MDM::Action::"viewArtifact"`, `MDM::Action::"createArtifact"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_artifact), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_artifact)|
+|`/api/mdm/artifacts/<uuid:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewArtifact"`, `MDM::Action::"updateArtifact"`, `MDM::Action::"deleteArtifact"`|↑|
+|`/api/mdm/blueprints/`|GET, POST|`MDM::Action::"viewBlueprint"`, `MDM::Action::"createBlueprint"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_blueprint), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_blueprint)|
+|`/api/mdm/blueprints/<int:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewBlueprint"`, `MDM::Action::"updateBlueprint"`, `MDM::Action::"deleteBlueprint"`|↑|
+|`/api/mdm/blueprint_artifacts/`|GET, POST|`MDM::Action::"viewBlueprintArtifact"`, `MDM::Action::"createBlueprintArtifact"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_blueprint_artifact)|
+|`/api/mdm/blueprint_artifacts/<int:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewBlueprintArtifact"`, `MDM::Action::"updateBlueprintArtifact"`, `MDM::Action::"deleteBlueprintArtifact"`|↑|
 
 #### Artifact versions
 
@@ -704,55 +704,59 @@ One collection per kind of artifact version. Each object belongs to an artifact 
 
 Note the path parameter: these detail routes key on the **artifact version** primary key, `<uuid:artifact_version_pk>` — except packages, which key on `<uuid:pk>`.
 
-|Endpoint|Methods|PBAC actions|
-|---|---|---|
-|`/api/mdm/profiles/`, `/api/mdm/profiles/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewProfile"`, `"createProfile"`, `"updateProfile"`, `"deleteProfile"`|
-|`/api/mdm/declarations/`, `/api/mdm/declarations/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDeclaration"`, `"createDeclaration"`, `"updateDeclaration"`, `"deleteDeclaration"`|
-|`/api/mdm/cert_assets/`, `/api/mdm/cert_assets/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewCertAsset"`, `"createCertAsset"`, `"updateCertAsset"`, `"deleteCertAsset"`|
-|`/api/mdm/data_assets/`, `/api/mdm/data_assets/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDataAsset"`, `"createDataAsset"`, `"updateDataAsset"`, `"deleteDataAsset"`|
-|`/api/mdm/enterprise_apps/`, `/api/mdm/enterprise_apps/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewEnterpriseApp"`, `"createEnterpriseApp"`, `"updateEnterpriseApp"`, `"deleteEnterpriseApp"`|
-|`/api/mdm/store_apps/`, `/api/mdm/store_apps/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewStoreApp"`, `"createStoreApp"`, `"updateStoreApp"`, `"deleteStoreApp"`|
-|`/api/mdm/provisioning_profiles/`, `/api/mdm/provisioning_profiles/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewProvisioningProfile"`, `"createProvisioningProfile"`, `"updateProvisioningProfile"`, `"deleteProvisioningProfile"`|
-|`/api/mdm/packages/`, `/api/mdm/packages/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewPackage"`, `"createPackage"`, `"updatePackage"`, `"deletePackage"`|
+|Endpoint|Methods|PBAC actions|Terraform resource|
+|---|---|---|---|
+|`/api/mdm/profiles/`, `/api/mdm/profiles/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewProfile"`, `"createProfile"`, `"updateProfile"`, `"deleteProfile"`|[`zentral_mdm_profile`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_profile)|
+|`/api/mdm/declarations/`, `/api/mdm/declarations/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDeclaration"`, `"createDeclaration"`, `"updateDeclaration"`, `"deleteDeclaration"`|[`zentral_mdm_declaration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_declaration)|
+|`/api/mdm/cert_assets/`, `/api/mdm/cert_assets/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewCertAsset"`, `"createCertAsset"`, `"updateCertAsset"`, `"deleteCertAsset"`|[`zentral_mdm_cert_asset`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_cert_asset)|
+|`/api/mdm/data_assets/`, `/api/mdm/data_assets/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDataAsset"`, `"createDataAsset"`, `"updateDataAsset"`, `"deleteDataAsset"`|[`zentral_mdm_data_asset`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_data_asset)|
+|`/api/mdm/enterprise_apps/`, `/api/mdm/enterprise_apps/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewEnterpriseApp"`, `"createEnterpriseApp"`, `"updateEnterpriseApp"`, `"deleteEnterpriseApp"`|[`zentral_mdm_enterprise_app`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_enterprise_app)|
+|`/api/mdm/store_apps/`, `/api/mdm/store_apps/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewStoreApp"`, `"createStoreApp"`, `"updateStoreApp"`, `"deleteStoreApp"`|[`zentral_mdm_store_app`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_store_app)|
+|`/api/mdm/provisioning_profiles/`, `/api/mdm/provisioning_profiles/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewProvisioningProfile"`, `"createProvisioningProfile"`, `"updateProvisioningProfile"`, `"deleteProvisioningProfile"`|[`zentral_mdm_provisioning_profile`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_provisioning_profile)|
+|`/api/mdm/packages/`, `/api/mdm/packages/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewPackage"`, `"createPackage"`, `"updatePackage"`, `"deletePackage"`|[`zentral_mdm_package`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_package)|
+
+None of the artifact version types has a data source: you create versions, you do not look them up by name.
 
 #### Enrollments
 
-|Endpoint|Methods|PBAC actions|
-|---|---|---|
-|`/api/mdm/dep_enrollments/`, `/api/mdm/dep_enrollments/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDEPEnrollment"`, `"createDEPEnrollment"`, `"updateDEPEnrollment"`, `"deleteDEPEnrollment"`|
-|`/api/mdm/ota_enrollments/`, `/api/mdm/ota_enrollments/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewOTAEnrollment"`, `"createOTAEnrollment"`, `"updateOTAEnrollment"`, `"deleteOTAEnrollment"`|
-|`/api/mdm/dep_enrollment_custom_views/`, `/api/mdm/dep_enrollment_custom_views/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDEPEnrollmentCustomView"`, `"createDEPEnrollmentCustomView"`, `"updateDEPEnrollmentCustomView"`, `"deleteDEPEnrollmentCustomView"`|
-|`/api/mdm/enrollment_custom_views/`, `/api/mdm/enrollment_custom_views/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewEnrollmentCustomView"`, `"createEnrollmentCustomView"`, `"updateEnrollmentCustomView"`, `"deleteEnrollmentCustomView"`|
+|Endpoint|Methods|PBAC actions|Terraform|
+|---|---|---|---|
+|`/api/mdm/dep_enrollments/`, `/api/mdm/dep_enrollments/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDEPEnrollment"`, `"createDEPEnrollment"`, `"updateDEPEnrollment"`, `"deleteDEPEnrollment"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_dep_enrollment)|
+|`/api/mdm/ota_enrollments/`, `/api/mdm/ota_enrollments/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewOTAEnrollment"`, `"createOTAEnrollment"`, `"updateOTAEnrollment"`, `"deleteOTAEnrollment"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_ota_enrollment), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_ota_enrollment)|
+|`/api/mdm/dep_enrollment_custom_views/`, `/api/mdm/dep_enrollment_custom_views/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDEPEnrollmentCustomView"`, `"createDEPEnrollmentCustomView"`, `"updateDEPEnrollmentCustomView"`, `"deleteDEPEnrollmentCustomView"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_dep_enrollment_custom_view)|
+|`/api/mdm/enrollment_custom_views/`, `/api/mdm/enrollment_custom_views/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewEnrollmentCustomView"`, `"createEnrollmentCustomView"`, `"updateEnrollmentCustomView"`, `"deleteEnrollmentCustomView"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_enrollment_custom_view)|
 
 #### Certificate issuers
 
 The ACME and SCEP issuers a profile or a DEP enrollment references to have the devices obtain their identity certificates.
 
-|Endpoint|Methods|PBAC actions|
-|---|---|---|
-|`/api/mdm/acme_issuers/`, `/api/mdm/acme_issuers/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewACMEIssuer"`, `"createACMEIssuer"`, `"updateACMEIssuer"`, `"deleteACMEIssuer"`|
-|`/api/mdm/scep_issuers/`, `/api/mdm/scep_issuers/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewSCEPIssuer"`, `"createSCEPIssuer"`, `"updateSCEPIssuer"`, `"deleteSCEPIssuer"`|
+|Endpoint|Methods|PBAC actions|Terraform|
+|---|---|---|---|
+|`/api/mdm/acme_issuers/`, `/api/mdm/acme_issuers/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewACMEIssuer"`, `"createACMEIssuer"`, `"updateACMEIssuer"`, `"deleteACMEIssuer"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_acme_issuer), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_acme_issuer)|
+|`/api/mdm/scep_issuers/`, `/api/mdm/scep_issuers/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewSCEPIssuer"`, `"createSCEPIssuer"`, `"updateSCEPIssuer"`, `"deleteSCEPIssuer"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_scep_issuer), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_scep_issuer)|
 
 #### Configurations
 
 The configurations a blueprint links to, described under [FileVault Configuration](#filevault-configuration), [Recovery Password Configuration](#recovery-password-configuration) and [Software Update Enforcement Configuration](#software-update-enforcement-configuration).
 
-|Endpoint|Methods|PBAC actions|
-|---|---|---|
-|`/api/mdm/filevault_configs/`, `/api/mdm/filevault_configs/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewFileVaultConfig"`, `"createFileVaultConfig"`, `"updateFileVaultConfig"`, `"deleteFileVaultConfig"`|
-|`/api/mdm/recovery_password_configs/`, `/api/mdm/recovery_password_configs/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewRecoveryPasswordConfig"`, `"createRecoveryPasswordConfig"`, `"updateRecoveryPasswordConfig"`, `"deleteRecoveryPasswordConfig"`|
-|`/api/mdm/software_update_enforcements/`, `/api/mdm/software_update_enforcements/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewSoftwareUpdateEnforcement"`, `"createSoftwareUpdateEnforcement"`, `"updateSoftwareUpdateEnforcement"`, `"deleteSoftwareUpdateEnforcement"`|
+|Endpoint|Methods|PBAC actions|Terraform|
+|---|---|---|---|
+|`/api/mdm/filevault_configs/`, `/api/mdm/filevault_configs/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewFileVaultConfig"`, `"createFileVaultConfig"`, `"updateFileVaultConfig"`, `"deleteFileVaultConfig"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_filevault_config), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_filevault_config)|
+|`/api/mdm/recovery_password_configs/`, `/api/mdm/recovery_password_configs/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewRecoveryPasswordConfig"`, `"createRecoveryPasswordConfig"`, `"updateRecoveryPasswordConfig"`, `"deleteRecoveryPasswordConfig"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_recovery_password_config), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_recovery_password_config)|
+|`/api/mdm/software_update_enforcements/`, `/api/mdm/software_update_enforcements/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewSoftwareUpdateEnforcement"`, `"createSoftwareUpdateEnforcement"`, `"updateSoftwareUpdateEnforcement"`, `"deleteSoftwareUpdateEnforcement"`|[resource](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/mdm_software_update_enforcement), [data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_software_update_enforcement)|
 
 #### Read-only objects
 
 These three are owned by Apple's side of the integration, not by Zentral: a push certificate is uploaded through the web console after a round trip to the Apple Push Certificates Portal, and DEP virtual servers and Apps and Books locations come from tokens. The API therefore only reads them — there is no `POST`, `PUT` or `DELETE`.
 
-|Endpoint|Methods|PBAC action|
-|---|---|---|
-|`/api/mdm/push_certificates/`, `/api/mdm/push_certificates/<int:pk>/`|GET|`MDM::Action::"viewPushCertificate"`|
-|`/api/mdm/dep/virtual_servers/`, `/api/mdm/dep/virtual_servers/<int:pk>/`|GET|`MDM::Action::"viewDEPVirtualServer"`|
-|`/api/mdm/dep/virtual_servers/<int:pk>/beta_tokens/`|GET|`MDM::Action::"viewDEPVirtualServer"`|
-|`/api/mdm/locations/<int:pk>/`|GET|`MDM::Action::"viewLocation"`|
+|Endpoint|Methods|PBAC action|Terraform|
+|---|---|---|---|
+|`/api/mdm/push_certificates/`, `/api/mdm/push_certificates/<int:pk>/`|GET|`MDM::Action::"viewPushCertificate"`|[data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_push_certificate)|
+|`/api/mdm/dep/virtual_servers/`, `/api/mdm/dep/virtual_servers/<int:pk>/`|GET|`MDM::Action::"viewDEPVirtualServer"`|[data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_dep_virtual_server)|
+|`/api/mdm/dep/virtual_servers/<int:pk>/beta_tokens/`|GET|`MDM::Action::"viewDEPVirtualServer"`|—|
+|`/api/mdm/locations/<int:pk>/`|GET|`MDM::Action::"viewLocation"`|[data source](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_location)|
+
+The Terraform column matches: these four have a **data source only**, no resource, for the same reason the API is read-only.
 
 `/api/mdm/dep/virtual_servers/<int:pk>/beta_tokens/` returns the seeding tokens of the virtual server — see [Browse the beta tokens](#browse-the-beta-tokens). `/api/mdm/locations/` is documented [below](#apimdmlocations).
 
@@ -1530,6 +1534,8 @@ Response: HTTP 204 No Content
 
 ### `/api/mdm/locations/`
 
+Terraform data source: [`zentral_mdm_location`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_location) — read only, see [Read-only objects](#read-only-objects).
+
  * method: `GET`
  * PBAC action: `MDM::Action::"viewLocation"`
  * available filters:
@@ -1575,6 +1581,8 @@ Result:
 ```
 
 ### `/api/mdm/location_assets/`
+
+Terraform data source: [`zentral_mdm_location_asset`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/mdm_location_asset)
 
  * method: `GET`
  * PBAC action: `MDM::Action::"viewLocationAsset"`

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -673,6 +673,89 @@ Authorization: Token the_token_string
 
 See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
+### Object endpoints
+
+Most of the MDM objects described earlier on this page — artifacts, blueprints, enrollments, issuers and the various configurations — are exposed as plain REST collections that all behave the same way:
+
+* `GET` on the collection lists it, `POST` creates;
+* `GET`, `PUT` and `DELETE` on the detail route read, replace and remove one object;
+* `PUT` is a full replacement. `PATCH` is a `405` throughout Zentral, so send every attribute;
+* the `Content-Type` is `application/json`;
+* where a list endpoint is filterable it is filterable on `name`.
+
+They are grouped in tables below rather than given a section each: the request and response bodies mirror the corresponding web-console forms, which are documented above, and the [Terraform provider](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs) documents every attribute of the ones it covers. The endpoints that do **not** follow the pattern — the device and user commands, the DEP device operations, the exports and the sync triggers — keep their own sections further down.
+
+#### Artifacts and blueprints
+
+An **artifact** is a named thing to install, and carries one or more **artifact versions**. A **blueprint** collects artifacts, and a **blueprint artifact** is the link between the two, carrying the scope. See [MDM Blueprints](#mdm-blueprints).
+
+|Endpoint|Methods|PBAC actions|
+|---|---|---|
+|`/api/mdm/artifacts/`|GET, POST|`MDM::Action::"viewArtifact"`, `MDM::Action::"createArtifact"`|
+|`/api/mdm/artifacts/<uuid:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewArtifact"`, `MDM::Action::"updateArtifact"`, `MDM::Action::"deleteArtifact"`|
+|`/api/mdm/blueprints/`|GET, POST|`MDM::Action::"viewBlueprint"`, `MDM::Action::"createBlueprint"`|
+|`/api/mdm/blueprints/<int:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewBlueprint"`, `MDM::Action::"updateBlueprint"`, `MDM::Action::"deleteBlueprint"`|
+|`/api/mdm/blueprint_artifacts/`|GET, POST|`MDM::Action::"viewBlueprintArtifact"`, `MDM::Action::"createBlueprintArtifact"`|
+|`/api/mdm/blueprint_artifacts/<int:pk>/`|GET, PUT, DELETE|`MDM::Action::"viewBlueprintArtifact"`, `MDM::Action::"updateBlueprintArtifact"`, `MDM::Action::"deleteBlueprintArtifact"`|
+
+#### Artifact versions
+
+One collection per kind of artifact version. Each object belongs to an artifact and carries its own version number and scope; creating one is how you ship a new version of an artifact.
+
+Note the path parameter: these detail routes key on the **artifact version** primary key, `<uuid:artifact_version_pk>` — except packages, which key on `<uuid:pk>`.
+
+|Endpoint|Methods|PBAC actions|
+|---|---|---|
+|`/api/mdm/profiles/`, `/api/mdm/profiles/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewProfile"`, `"createProfile"`, `"updateProfile"`, `"deleteProfile"`|
+|`/api/mdm/declarations/`, `/api/mdm/declarations/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDeclaration"`, `"createDeclaration"`, `"updateDeclaration"`, `"deleteDeclaration"`|
+|`/api/mdm/cert_assets/`, `/api/mdm/cert_assets/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewCertAsset"`, `"createCertAsset"`, `"updateCertAsset"`, `"deleteCertAsset"`|
+|`/api/mdm/data_assets/`, `/api/mdm/data_assets/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDataAsset"`, `"createDataAsset"`, `"updateDataAsset"`, `"deleteDataAsset"`|
+|`/api/mdm/enterprise_apps/`, `/api/mdm/enterprise_apps/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewEnterpriseApp"`, `"createEnterpriseApp"`, `"updateEnterpriseApp"`, `"deleteEnterpriseApp"`|
+|`/api/mdm/store_apps/`, `/api/mdm/store_apps/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewStoreApp"`, `"createStoreApp"`, `"updateStoreApp"`, `"deleteStoreApp"`|
+|`/api/mdm/provisioning_profiles/`, `/api/mdm/provisioning_profiles/<uuid:artifact_version_pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewProvisioningProfile"`, `"createProvisioningProfile"`, `"updateProvisioningProfile"`, `"deleteProvisioningProfile"`|
+|`/api/mdm/packages/`, `/api/mdm/packages/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewPackage"`, `"createPackage"`, `"updatePackage"`, `"deletePackage"`|
+
+#### Enrollments
+
+|Endpoint|Methods|PBAC actions|
+|---|---|---|
+|`/api/mdm/dep_enrollments/`, `/api/mdm/dep_enrollments/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDEPEnrollment"`, `"createDEPEnrollment"`, `"updateDEPEnrollment"`, `"deleteDEPEnrollment"`|
+|`/api/mdm/ota_enrollments/`, `/api/mdm/ota_enrollments/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewOTAEnrollment"`, `"createOTAEnrollment"`, `"updateOTAEnrollment"`, `"deleteOTAEnrollment"`|
+|`/api/mdm/dep_enrollment_custom_views/`, `/api/mdm/dep_enrollment_custom_views/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewDEPEnrollmentCustomView"`, `"createDEPEnrollmentCustomView"`, `"updateDEPEnrollmentCustomView"`, `"deleteDEPEnrollmentCustomView"`|
+|`/api/mdm/enrollment_custom_views/`, `/api/mdm/enrollment_custom_views/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewEnrollmentCustomView"`, `"createEnrollmentCustomView"`, `"updateEnrollmentCustomView"`, `"deleteEnrollmentCustomView"`|
+
+#### Certificate issuers
+
+The ACME and SCEP issuers a profile or a DEP enrollment references to have the devices obtain their identity certificates.
+
+|Endpoint|Methods|PBAC actions|
+|---|---|---|
+|`/api/mdm/acme_issuers/`, `/api/mdm/acme_issuers/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewACMEIssuer"`, `"createACMEIssuer"`, `"updateACMEIssuer"`, `"deleteACMEIssuer"`|
+|`/api/mdm/scep_issuers/`, `/api/mdm/scep_issuers/<uuid:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewSCEPIssuer"`, `"createSCEPIssuer"`, `"updateSCEPIssuer"`, `"deleteSCEPIssuer"`|
+
+#### Configurations
+
+The configurations a blueprint links to, described under [FileVault Configuration](#filevault-configuration), [Recovery Password Configuration](#recovery-password-configuration) and [Software Update Enforcement Configuration](#software-update-enforcement-configuration).
+
+|Endpoint|Methods|PBAC actions|
+|---|---|---|
+|`/api/mdm/filevault_configs/`, `/api/mdm/filevault_configs/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewFileVaultConfig"`, `"createFileVaultConfig"`, `"updateFileVaultConfig"`, `"deleteFileVaultConfig"`|
+|`/api/mdm/recovery_password_configs/`, `/api/mdm/recovery_password_configs/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewRecoveryPasswordConfig"`, `"createRecoveryPasswordConfig"`, `"updateRecoveryPasswordConfig"`, `"deleteRecoveryPasswordConfig"`|
+|`/api/mdm/software_update_enforcements/`, `/api/mdm/software_update_enforcements/<int:pk>/`|GET, POST / GET, PUT, DELETE|`MDM::Action::"viewSoftwareUpdateEnforcement"`, `"createSoftwareUpdateEnforcement"`, `"updateSoftwareUpdateEnforcement"`, `"deleteSoftwareUpdateEnforcement"`|
+
+#### Read-only objects
+
+These three are owned by Apple's side of the integration, not by Zentral: a push certificate is uploaded through the web console after a round trip to the Apple Push Certificates Portal, and DEP virtual servers and Apps and Books locations come from tokens. The API therefore only reads them — there is no `POST`, `PUT` or `DELETE`.
+
+|Endpoint|Methods|PBAC action|
+|---|---|---|
+|`/api/mdm/push_certificates/`, `/api/mdm/push_certificates/<int:pk>/`|GET|`MDM::Action::"viewPushCertificate"`|
+|`/api/mdm/dep/virtual_servers/`, `/api/mdm/dep/virtual_servers/<int:pk>/`|GET|`MDM::Action::"viewDEPVirtualServer"`|
+|`/api/mdm/dep/virtual_servers/<int:pk>/beta_tokens/`|GET|`MDM::Action::"viewDEPVirtualServer"`|
+|`/api/mdm/locations/<int:pk>/`|GET|`MDM::Action::"viewLocation"`|
+
+`/api/mdm/dep/virtual_servers/<int:pk>/beta_tokens/` returns the seeding tokens of the virtual server — see [Browse the beta tokens](#browse-the-beta-tokens). `/api/mdm/locations/` is documented [below](#apimdmlocations).
+
 ### `/api/mdm/dep/devices/`
 
  * method: `GET`

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -120,6 +120,9 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 
 ### /api/monolith/repositories/
 
+Terraform resource: [`zentral_monolith_repository`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_repository)  
+Terraform data source: [`zentral_monolith_repository`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/monolith_repository)
+
 A repository is where the Munki packages and pkginfo files come from. See [Repositories](#repositories) for the difference between the backends.
 
 |Attribute|Description|
@@ -328,6 +331,9 @@ Only one sync runs at a time for a given repository. If a sync is already in pro
 
 ### /api/monolith/manifests/
 
+Terraform resource: [`zentral_monolith_manifest`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_manifest)  
+Terraform data source: [`zentral_monolith_manifest`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/monolith_manifest)
+
 #### List all manifests
 
 * method: GET
@@ -535,6 +541,9 @@ Response
 
 ### /api/monolith/catalogs/
 
+Terraform resource: [`zentral_monolith_catalog`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_catalog)  
+Terraform data source: [`zentral_monolith_catalog`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/monolith_catalog)
+
 #### List all catalogs
 
 * method: GET
@@ -696,6 +705,9 @@ Response (204 No Content)
 
 ### /api/monolith/conditions/
 
+Terraform resource: [`zentral_monolith_condition`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_condition)  
+Terraform data source: [`zentral_monolith_condition`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/monolith_condition)
+
 #### List all conditions
 
 * method: GET
@@ -851,6 +863,9 @@ $ curl -X DELETE \
 Response (204 No Content)
 
 ### /api/monolith/enrollments/
+
+Terraform resource: [`zentral_monolith_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_enrollment)  
+Terraform data source: [`zentral_monolith_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/monolith_enrollment)
 
 #### List all enrollments
 
@@ -1069,6 +1084,8 @@ Response (204 No Content)
 
 ### /api/monolith/enrollments/`<int:pk>`/plist/
 
+The [`zentral_monolith_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_enrollment) Terraform resource exposes this URL as its read-only `plist_url` attribute.
+
 #### Download the enrollment plist file
 
 * method: GET
@@ -1087,6 +1104,8 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 
 ### /api/monolith/enrollments/`<int:pk>`/configuration_profile/
 
+The [`zentral_monolith_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_enrollment) Terraform resource exposes this URL as its read-only `configuration_profile_url` attribute.
+
 #### Download the enrollment configuration profile
 
 * method: GET
@@ -1104,6 +1123,8 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 ```
 
 ### /api/monolith/manifest_enrollment_packages/
+
+Terraform resource: [`zentral_monolith_manifest_enrollment_package`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_manifest_enrollment_package)
 
 A manifest enrollment package attaches another module's enrollment — munki, osquery, … — to a manifest, so that monolith adds the corresponding package to the manifest of the machines in scope. The builders available are the ones listed under `enrollment_package_builders` in the [monolith configuration](#zentral-configuration).
 
@@ -1215,6 +1236,8 @@ $ curl -X DELETE \
 Response (204 No Content)
 
 ### /api/monolith/manifest_catalogs/
+
+Terraform resource: [`zentral_monolith_manifest_catalog`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_manifest_catalog)
 
 #### List all manifest catalogs
 
@@ -1377,6 +1400,8 @@ Response (204 No Content)
 
 ### /api/monolith/manifest_sub_manifests/
 
+Terraform resource: [`zentral_monolith_manifest_sub_manifest`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_manifest_sub_manifest)
+
 #### List all manifest sub manifests
 
 * method: GET
@@ -1538,6 +1563,9 @@ Response (204 No Content)
 
 ### /api/monolith/sub_manifests/
 
+Terraform resource: [`zentral_monolith_sub_manifest`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_sub_manifest)  
+Terraform data source: [`zentral_monolith_sub_manifest`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/monolith_sub_manifest)
+
 #### List all sub manifests
 
 * method: GET
@@ -1698,6 +1726,8 @@ $ curl -X DELETE \
 Response (204 No Content)
 
 ### /api/monolith/sub_manifest_pkg_infos/
+
+Terraform resource: [`zentral_monolith_sub_manifest_pkg_info`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/monolith_sub_manifest_pkg_info)
 
 #### List all sub manifest pkg infos
 

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -118,6 +118,154 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 
 * `Content-Type: application/json`
 
+### /api/monolith/repositories/
+
+A repository is where the Munki packages and pkginfo files come from. See [Repositories](#repositories) for the difference between the backends.
+
+|Attribute|Description|
+|---|---|
+|`name`|Required, unique.|
+|`backend`|`S3`, `AZURE` or `VIRTUAL`. A `VIRTUAL` repository holds packages uploaded directly into Zentral.|
+|`s3_kwargs` / `azure_kwargs`|The backend settings. Only the one matching `backend` is used; the other stays `null`.|
+|`meta_business_unit`|Optional. Restricts the repository to one business unit. Once set it cannot be changed.|
+
+`provisioning_uid`, `icon_hashes`, `client_resources` and `last_synced_at` are read only. A repository created by provisioning carries a `provisioning_uid`, and can be neither updated nor deleted over the API — it is owned by whatever provisioned it.
+
+#### List all repositories
+
+* method: GET
+* PBAC action: `Monolith::Action::"viewRepository"`
+* Optional filter parameter:
+    * `name`: name of the repository
+
+Example
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/repositories/" \
+  |python3 -m json.tool
+```
+
+Response
+
+```json
+[
+    {
+        "id": 4,
+        "provisioning_uid": null,
+        "backend": "VIRTUAL",
+        "azure_kwargs": null,
+        "s3_kwargs": null,
+        "name": "Virtual",
+        "meta_business_unit": 7,
+        "icon_hashes": {},
+        "client_resources": [],
+        "created_at": "2026-08-20T13:12:53.147701",
+        "updated_at": "2026-08-20T13:12:53.149058",
+        "last_synced_at": null
+    }
+]
+```
+
+#### Add a repository
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Monolith::Action::"createRepository"`
+
+Example
+
+repository.json
+
+```json
+{
+  "name": "S3",
+  "backend": "S3",
+  "s3_kwargs": {
+    "bucket": "acme-munki",
+    "region_name": "eu-central-1",
+    "prefix": "munki_repo"
+  }
+}
+```
+
+```bash
+$ curl -X POST \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @repository.json \
+  "https://$ZTL_FQDN/api/monolith/repositories/" \
+  |python3 -m json.tool
+```
+
+Response (201 Created)
+
+```json
+{
+    "id": 5,
+    "provisioning_uid": null,
+    "backend": "S3",
+    "azure_kwargs": null,
+    "s3_kwargs": {
+        "bucket": "acme-munki",
+        "region_name": "eu-central-1",
+        "prefix": "munki_repo"
+    },
+    "name": "S3",
+    "meta_business_unit": null,
+    "icon_hashes": {},
+    "client_resources": [],
+    "created_at": "2026-08-20T13:12:53.155983",
+    "updated_at": "2026-08-20T13:12:53.156155",
+    "last_synced_at": null
+}
+```
+
+**IMPORTANT** When using AWS S3 buckets, do not put credentials in `s3_kwargs` — use [AWS instance profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html), [task IAM roles](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html) or another integrated authentication mechanism.
+
+### /api/monolith/repositories/`<int:pk>`/
+
+#### Get a repository
+
+* method: GET
+* PBAC action: `Monolith::Action::"viewRepository"`
+* `<int:pk>`: the primary key of the repository
+
+Example
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/repositories/4/" \
+  |python3 -m json.tool
+```
+
+#### Update a repository
+
+* method: PUT
+* Content-Type: application/json
+* PBAC action: `Monolith::Action::"updateRepository"`
+* `<int:pk>`: the primary key of the repository
+
+A provisioned repository cannot be updated. Neither can `meta_business_unit` be changed once it is set.
+
+#### Delete a repository
+
+* method: DELETE
+* PBAC action: `Monolith::Action::"deleteRepository"`
+* `<int:pk>`: the primary key of the repository
+
+A repository whose catalogs are linked to a manifest cannot be deleted, and neither can a provisioned one.
+
+Example
+
+```bash
+$ curl -X DELETE \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/repositories/4/"
+```
+
+Response (204 No Content)
+
 ### /api/monolith/repositories/`<int:pk>`/sync/
 
 #### Fetch the package infos, the icons, the client resources from the repository
@@ -344,6 +492,46 @@ $ curl -X DELETE \
 ```
 
 Response (204 No Content)
+
+### /api/monolith/manifests/`<int:pk>`/cache_servers/
+
+#### Register a Munki cache server
+
+* method: POST
+* Content-Type: application/json
+* PBAC actions — **all three** are required:
+    * `Monolith::Action::"updateManifest"`
+    * `Monolith::Action::"createCacheServer"`
+    * `Monolith::Action::"updateCacheServer"`
+* `<int:pk>`: the primary key of the manifest.
+
+Use this endpoint from a [Munki cache server](https://github.com/munki/munki/wiki/Managed-Software-Center-Preferences) to register itself with a manifest. Zentral then serves that cache server's `base_url` to the machines reaching it from the same public IP address.
+
+|Attribute|Description|
+|---|---|
+|`name`|Required. The cache server name. Registering again with the same name updates the existing record rather than adding one.|
+|`base_url`|Required. The URL the machines should fetch the packages from.|
+
+The caller's public IP address is recorded from the request — it is not part of the payload.
+
+Example
+
+```bash
+$ curl -X POST \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Berlin office", "base_url": "http://munki-cache.acme.example.com"}' \
+  "https://$ZTL_FQDN/api/monolith/manifests/1/cache_servers/" \
+  |python3 -m json.tool
+```
+
+Response
+
+```json
+{
+  "status": 0
+}
+```
 
 ### /api/monolith/catalogs/
 
@@ -875,6 +1063,153 @@ Example
 $ curl -X DELETE \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   "https://$ZTL_FQDN/api/monolith/enrollments/1/"
+```
+
+Response (204 No Content)
+
+### /api/monolith/enrollments/`<int:pk>`/plist/
+
+#### Download the enrollment plist file
+
+* method: GET
+* PBAC action: `Monolith::Action::"viewEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+A plist with the Munki configuration keys, for a custom settings payload on the `ManagedInstalls` preference domain. This is the URL returned as the enrollment's `plist_download_url`.
+
+Example
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/1/plist/" \
+  --output zentral_monolith_configuration.plist
+```
+
+### /api/monolith/enrollments/`<int:pk>`/configuration_profile/
+
+#### Download the enrollment configuration profile
+
+* method: GET
+* PBAC action: `Monolith::Action::"viewEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+The same keys as a signed configuration profile, ready to distribute over MDM. This is the URL returned as the enrollment's `configuration_profile_download_url`.
+
+Example
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/enrollments/1/configuration_profile/" \
+  --output zentral_monolith_configuration.mobileconfig
+```
+
+### /api/monolith/manifest_enrollment_packages/
+
+A manifest enrollment package attaches another module's enrollment — munki, osquery, … — to a manifest, so that monolith adds the corresponding package to the manifest of the machines in scope. The builders available are the ones listed under `enrollment_package_builders` in the [monolith configuration](#zentral-configuration).
+
+|Attribute|Description|
+|---|---|
+|`manifest`|Required. The primary key of the manifest.|
+|`builder`|Required. The dotted path of the builder, exactly as configured in `enrollment_package_builders`.|
+|`enrollment_pk`|Required. The primary key of the enrollment to distribute, in the module the builder belongs to.|
+|`tags`|The tags a machine must carry to get the package. **All** of them are required — unlike catalogs, enrollment packages use AND logic. Empty means every machine.|
+
+`version` is read only, and bumped whenever the package is rebuilt.
+
+#### List all manifest enrollment packages
+
+* method: GET
+* PBAC action: `Monolith::Action::"viewManifestEnrollmentPackage"`
+* Optional filter parameters:
+    * `manifest_id`: the primary key of a manifest
+    * `builder`: the dotted path of a builder
+
+Example
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/manifest_enrollment_packages/?manifest_id=1" \
+  |python3 -m json.tool
+```
+
+Response
+
+```json
+[
+    {
+        "id": 1,
+        "manifest": 1,
+        "tags": [
+            3
+        ],
+        "builder": "zentral.contrib.osquery.osx_package.builder.OsqueryZentralEnrollPkgBuilder",
+        "enrollment_pk": 2,
+        "version": 1,
+        "created_at": "2026-08-20T13:12:53.147701",
+        "updated_at": "2026-08-20T13:12:53.149058"
+    }
+]
+```
+
+#### Add a manifest enrollment package
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Monolith::Action::"createManifestEnrollmentPackage"`
+
+Adding one bumps the manifest version and builds the package. The enrollment it points at becomes owned by monolith — from then on it cannot be updated or deleted through its own module's API.
+
+Example
+
+manifest_enrollment_package.json
+
+```json
+{
+  "manifest": 1,
+  "builder": "zentral.contrib.osquery.osx_package.builder.OsqueryZentralEnrollPkgBuilder",
+  "enrollment_pk": 2,
+  "tags": [3]
+}
+```
+
+```bash
+$ curl -X POST \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @manifest_enrollment_package.json \
+  "https://$ZTL_FQDN/api/monolith/manifest_enrollment_packages/" \
+  |python3 -m json.tool
+```
+
+### /api/monolith/manifest_enrollment_packages/`<int:pk>`/
+
+#### Get a manifest enrollment package
+
+* method: GET
+* PBAC action: `Monolith::Action::"viewManifestEnrollmentPackage"`
+* `<int:pk>`: the primary key of the manifest enrollment package.
+
+#### Update a manifest enrollment package
+
+* method: PUT
+* Content-Type: application/json
+* PBAC action: `Monolith::Action::"updateManifestEnrollmentPackage"`
+* `<int:pk>`: the primary key of the manifest enrollment package.
+
+#### Delete a manifest enrollment package
+
+* method: DELETE
+* PBAC action: `Monolith::Action::"deleteManifestEnrollmentPackage"`
+* `<int:pk>`: the primary key of the manifest enrollment package.
+
+Deleting one bumps the manifest version and removes the package from the manifests. The underlying enrollment is **kept** — it is released back to its own module, not deleted.
+
+Example
+
+```bash
+$ curl -X DELETE \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/monolith/manifest_enrollment_packages/1/"
 ```
 
 Response (204 No Content)

--- a/docs/apps/munki.md
+++ b/docs/apps/munki.md
@@ -35,6 +35,8 @@ See [API authentication](core.md#api-authentication) for how to create a service
 
 ### /api/munki/configurations/
 
+Terraform resource: [`zentral_munki_configuration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/munki_configuration)  
+Terraform data source: [`zentral_munki_configuration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/munki_configuration)
 
 #### List all configurations
 
@@ -295,6 +297,9 @@ Response (204 No Content)
 
 ### /api/munki/enrollments/
 
+Terraform resource: [`zentral_munki_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/munki_enrollment)  
+Terraform data source: [`zentral_munki_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/munki_enrollment)
+
 #### List all enrollments
 
 * method: GET
@@ -508,6 +513,8 @@ Response (204 No Content)
 
 ### /api/munki/enrollments/`<int:pk>`/package/
 
+The [`zentral_munki_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/munki_enrollment) Terraform resource exposes this URL as its read-only `package_url` attribute.
+
 #### Download a Zentral enrollment package
 
 * method: GET
@@ -523,6 +530,9 @@ curl \
 ```
 
 ### /api/munki/script_checks/
+
+Terraform resource: [`zentral_munki_script_check`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/munki_script_check)  
+Terraform data source: [`zentral_munki_script_check`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/munki_script_check)
 
 A script check is a script the Munki agent runs on the machines in its scope, at most once every `script_checks_run_interval_seconds` (a [configuration](#apimunkiconfigurations) attribute). It is a [compliance check](inventory.md#compliance-checks): the agent reports the script's output, and Zentral compares it to the expected result to derive the machine's status.
 

--- a/docs/apps/munki.md
+++ b/docs/apps/munki.md
@@ -521,3 +521,229 @@ curl \
   -o zentral_munki_enrollment_package.pkg \
   https://$ZTL_FQDN/api/munki/enrollments/1/package/
 ```
+
+### /api/munki/script_checks/
+
+A script check is a script the Munki agent runs on the machines in its scope, at most once every `script_checks_run_interval_seconds` (a [configuration](#apimunkiconfigurations) attribute). It is a [compliance check](inventory.md#compliance-checks): the agent reports the script's output, and Zentral compares it to the expected result to derive the machine's status.
+
+|Attribute|Description|
+|---|---|
+|`name`|Required, and unique across the Munki script checks. It is the name of the compliance check.|
+|`description`|Optional, free text.|
+|`type`|`ZSH_STR`, `ZSH_INT` or `ZSH_BOOL` — the type the script's output is compared as. `ZSH_STR` by default.|
+|`source`|The zsh script. Its output is compared to `expected_result`.|
+|`expected_result`|The value the output must equal for the machine to be compliant. It has to parse as the declared `type` — an integer for `ZSH_INT`, `true`/`false` for `ZSH_BOOL`.|
+|`tags`|Run only on the machines carrying any of these tags. Empty means every machine.|
+|`excluded_tags`|Never run on the machines carrying any of these tags. Must be disjoint from `tags`.|
+|`arch_amd64` / `arch_arm64`|Whether the check runs on Intel, on Apple Silicon, or on both. At least one is required.|
+|`min_os_version` / `max_os_version`|The macOS version range the check runs on. Blank for no bound. `max_os_version` is exclusive.|
+
+`version` and `compliance_check_id` are read only.
+
+#### List all script checks
+
+* method: GET
+* PBAC action: `Munki::Action::"viewScriptCheck"`
+* Optional filter parameter:
+    * `name`: name of the script check
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/munki/script_checks/ \
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+[
+    {
+        "name": "FileVault enabled",
+        "description": "Check that FileVault is on",
+        "version": 1,
+        "compliance_check_id": 10,
+        "id": 1,
+        "tags": [
+            3
+        ],
+        "excluded_tags": [
+            4
+        ],
+        "arch_amd64": true,
+        "arch_arm64": true,
+        "min_os_version": "14",
+        "max_os_version": "",
+        "type": "ZSH_BOOL",
+        "source": "/usr/bin/fdesetup isactive",
+        "expected_result": "true",
+        "created_at": "2026-08-20T13:03:23.767041",
+        "updated_at": "2026-08-20T13:03:23.767043"
+    }
+]
+```
+
+#### Add a script check
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Munki::Action::"createScriptCheck"`
+
+Example:
+
+script_check.json
+
+```json
+{
+  "name": "FileVault enabled",
+  "description": "Check that FileVault is on",
+  "type": "ZSH_BOOL",
+  "source": "/usr/bin/fdesetup isactive",
+  "expected_result": "true",
+  "tags": [3],
+  "excluded_tags": [4],
+  "arch_amd64": true,
+  "arch_arm64": true,
+  "min_os_version": "14",
+  "max_os_version": ""
+}
+```
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST -d @script_check.json \
+  https://$ZTL_FQDN/api/munki/script_checks/ \
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+    "name": "FileVault enabled",
+    "description": "Check that FileVault is on",
+    "version": 1,
+    "compliance_check_id": 10,
+    "id": 1,
+    "tags": [
+        3
+    ],
+    "excluded_tags": [
+        4
+    ],
+    "arch_amd64": true,
+    "arch_arm64": true,
+    "min_os_version": "14",
+    "max_os_version": "",
+    "type": "ZSH_BOOL",
+    "source": "/usr/bin/fdesetup isactive",
+    "expected_result": "true",
+    "created_at": "2026-08-20T13:03:23.767041",
+    "updated_at": "2026-08-20T13:03:23.767043"
+}
+```
+
+### /api/munki/script_checks/`<int:pk>`/
+
+#### Get a script check
+
+* method: GET
+* PBAC action: `Munki::Action::"viewScriptCheck"`
+* `<int:pk>`: the primary key of the script check
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/munki/script_checks/1/ \
+  |python3 -m json.tool
+```
+
+#### Update a script check
+
+* method: PUT
+* Content-Type: application/json
+* PBAC action: `Munki::Action::"updateScriptCheck"`
+* `<int:pk>`: the primary key of the script check
+
+**Any** change to the check — its source, its expected result, its scope or its compatibility gate — bumps the version, and the machines in scope run it again on their next check-in. This is unlike the [Turbo scripts](turbo.md#apiturboscripts), where only a source change bumps the version.
+
+Example:
+
+script_check.json
+
+```json
+{
+  "name": "FileVault enabled",
+  "description": "Check that FileVault is on",
+  "type": "ZSH_BOOL",
+  "source": "/usr/bin/fdesetup isactive",
+  "expected_result": "true",
+  "tags": [3],
+  "excluded_tags": [4],
+  "arch_amd64": true,
+  "arch_arm64": false,
+  "min_os_version": "14",
+  "max_os_version": ""
+}
+```
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X PUT -d @script_check.json \
+  https://$ZTL_FQDN/api/munki/script_checks/1/ \
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+    "name": "FileVault enabled",
+    "description": "Check that FileVault is on",
+    "version": 2,
+    "compliance_check_id": 10,
+    "id": 1,
+    "tags": [
+        3
+    ],
+    "excluded_tags": [
+        4
+    ],
+    "arch_amd64": true,
+    "arch_arm64": false,
+    "min_os_version": "14",
+    "max_os_version": "",
+    "type": "ZSH_BOOL",
+    "source": "/usr/bin/fdesetup isactive",
+    "expected_result": "true",
+    "created_at": "2026-08-20T13:03:23.767041",
+    "updated_at": "2026-08-20T13:03:23.786024"
+}
+```
+
+#### Delete a script check
+
+* method: DELETE
+* PBAC action: `Munki::Action::"deleteScriptCheck"`
+* `<int:pk>`: the primary key of the script check
+
+Deleting a script check deletes its compliance check and all its machine statuses.
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -X DELETE \
+  https://$ZTL_FQDN/api/munki/script_checks/1/
+```
+
+Response (204 No Content)

--- a/docs/apps/munki.md
+++ b/docs/apps/munki.md
@@ -681,7 +681,9 @@ curl \
 * PBAC action: `Munki::Action::"updateScriptCheck"`
 * `<int:pk>`: the primary key of the script check
 
-**Any** change to the check — its source, its expected result, its scope or its compatibility gate — bumps the version, and the machines in scope run it again on their next check-in. This is unlike the [Turbo scripts](turbo.md#apiturboscripts), where only a source change bumps the version.
+A change to the check itself — its source, its expected result, its scope (`tags` / `excluded_tags`) or its compatibility gate — bumps the version, and the machines in scope run it again on their next check-in. This is unlike the [Turbo scripts](turbo.md#apiturboscripts), where only a source change bumps the version.
+
+Renaming a check or editing its description does **not** bump the version. Those two attributes belong to the compliance check rather than to the script check, and neither changes what the machines have to run.
 
 Example:
 

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -30,6 +30,9 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 
 ### /api/osquery/atcs/
 
+Terraform resource: [`zentral_osquery_atc`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_atc)  
+Terraform data source: [`zentral_osquery_atc`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/osquery_atc)
+
 #### List all ATCs.
 
 * method: GET
@@ -273,6 +276,9 @@ Response (204 No Content)
 
 ### /api/osquery/configurations/
 
+Terraform resource: [`zentral_osquery_configuration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_configuration)  
+Terraform data source: [`zentral_osquery_configuration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/osquery_configuration)
+
 #### List all Configurations.
 
 * method: GET
@@ -508,6 +514,8 @@ Response (204 No Content)
 
 ### /api/osquery/configuration_packs/
 
+Terraform resource: [`zentral_osquery_configuration_pack`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_configuration_pack)
+
 #### List all Configuration Packs.
 
 * method: GET
@@ -691,6 +699,9 @@ $ curl -X DELETE \
 Response (204 No Content)
 
 ### /api/osquery/enrollments/
+
+Terraform resource: [`zentral_osquery_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_enrollment)  
+Terraform data source: [`zentral_osquery_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/osquery_enrollment)
 
 An enrollment ties an Osquery configuration to a [meta business unit](inventory.md) and, optionally, to tags and enrollment restrictions. Its secret is baked into the packages and scripts the three download endpoints below produce.
 
@@ -883,6 +894,8 @@ Response (204 No Content)
 
 ### /api/osquery/enrollments/`<int:pk>`/package/
 
+The [`zentral_osquery_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_enrollment) Terraform resource exposes this URL as its read-only `package_url` attribute.
+
 #### Download the macOS enrollment package.
 
 * method: GET
@@ -900,6 +913,8 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 ```
 
 ### /api/osquery/enrollments/`<int:pk>`/script/
+
+The [`zentral_osquery_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_enrollment) Terraform resource exposes this URL as its read-only `script_url` attribute.
 
 #### Download the Linux enrollment script.
 
@@ -919,6 +934,8 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 
 ### /api/osquery/enrollments/`<int:pk>`/powershell_script/
 
+The [`zentral_osquery_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_enrollment) Terraform resource exposes this URL as its read-only `powershell_script_url` attribute.
+
 #### Download the Windows enrollment script.
 
 * method: GET
@@ -936,6 +953,9 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 ```
 
 ### /api/osquery/file_categories/
+
+Terraform resource: [`zentral_osquery_file_category`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_file_category)  
+Terraform data source: [`zentral_osquery_file_category`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/osquery_file_category)
 
 #### List all FileCategories.
 
@@ -1147,6 +1167,9 @@ $ curl -X DELETE \
 Response (204 No Content)
 
 ### /api/osquery/packs/
+
+Terraform resource: [`zentral_osquery_pack`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_pack)  
+Terraform data source: [`zentral_osquery_pack`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/osquery_pack)
 
 #### List all Packs.
 
@@ -1548,6 +1571,9 @@ You should get a response close to this one:
 ```
 
 ### /api/osquery/queries/
+
+Terraform resource: [`zentral_osquery_query`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/osquery_query)  
+Terraform data source: [`zentral_osquery_query`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/osquery_query)
 
 #### List all queries.
 

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -690,6 +690,251 @@ $ curl -X DELETE \
 
 Response (204 No Content)
 
+### /api/osquery/enrollments/
+
+An enrollment ties an Osquery configuration to a [meta business unit](inventory.md) and, optionally, to tags and enrollment restrictions. Its secret is baked into the packages and scripts the three download endpoints below produce.
+
+|Attribute|Description|
+|---|---|
+|`configuration`|Required. The primary key of the Osquery configuration.|
+|`osquery_release`|Optional. The Osquery release to install, for the enrollment packages that bundle one. Blank to install none.|
+|`secret.meta_business_unit`|Required. The primary key of the meta business unit the machines are assigned to at enrollment.|
+|`secret.tags`|Optional. The tags the machines get at enrollment.|
+|`secret.serial_numbers`, `secret.udids`|Optional. Restrict the enrollment to these machines. Blank means any machine.|
+|`secret.quota`|Optional. Maximum number of enrollments. Blank means no limit.|
+
+`version`, `enrolled_machines_count`, the three `*_download_url` attributes and `secret.secret` are read only.
+
+#### List all enrollments.
+
+* method: GET
+* Content-Type: application/json
+* PBAC action: `Osquery::Action::"viewEnrollment"`
+
+Example:
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/" \
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+[
+    {
+        "id": 1,
+        "configuration": 1,
+        "osquery_release": "5.12.1",
+        "secret": {
+            "id": 5,
+            "secret": "z1DRxu4HJaN9mI4H5u097McsM2XqLSzvwtmDn2tx3PVUoTVBu6cZXDUdDJPWJbAD",
+            "meta_business_unit": 6,
+            "tags": [],
+            "serial_numbers": [
+                "012345678"
+            ],
+            "udids": null,
+            "quota": 10,
+            "request_count": 0
+        },
+        "version": 1,
+        "enrolled_machines_count": 0,
+        "package_download_url": "https://zentral.example.com/api/osquery/enrollments/1/package/",
+        "powershell_script_download_url": "https://zentral.example.com/api/osquery/enrollments/1/powershell_script/",
+        "script_download_url": "https://zentral.example.com/api/osquery/enrollments/1/script/",
+        "created_at": "2026-08-20T13:08:24.788735",
+        "updated_at": "2026-08-20T13:08:24.788737"
+    }
+]
+```
+
+#### Add a new enrollment.
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Osquery::Action::"createEnrollment"`
+
+Example:
+
+enrollment.json
+
+```json
+{
+  "configuration": 1,
+  "osquery_release": "5.12.1",
+  "secret": {
+    "meta_business_unit": 6,
+    "quota": 10,
+    "serial_numbers": ["012345678"]
+  }
+}
+```
+
+```bash
+$ curl -X POST \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/" \
+  -d @enrollment.json \
+  |python3 -m json.tool
+```
+
+Response (201 Created):
+
+```json
+{
+    "id": 1,
+    "configuration": 1,
+    "osquery_release": "5.12.1",
+    "secret": {
+        "id": 5,
+        "secret": "z1DRxu4HJaN9mI4H5u097McsM2XqLSzvwtmDn2tx3PVUoTVBu6cZXDUdDJPWJbAD",
+        "meta_business_unit": 6,
+        "tags": [],
+        "serial_numbers": [
+            "012345678"
+        ],
+        "udids": null,
+        "quota": 10,
+        "request_count": 0
+    },
+    "version": 1,
+    "enrolled_machines_count": 0,
+    "package_download_url": "https://zentral.example.com/api/osquery/enrollments/1/package/",
+    "powershell_script_download_url": "https://zentral.example.com/api/osquery/enrollments/1/powershell_script/",
+    "script_download_url": "https://zentral.example.com/api/osquery/enrollments/1/script/",
+    "created_at": "2026-08-20T13:08:24.788735",
+    "updated_at": "2026-08-20T13:08:24.788737"
+}
+```
+
+### /api/osquery/enrollments/`<int:pk>`/
+
+#### Get an enrollment.
+
+* method: GET
+* Content-Type: application/json
+* PBAC action: `Osquery::Action::"viewEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+Example:
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/1/" \
+  |python3 -m json.tool
+```
+
+#### Update an enrollment.
+
+* method: PUT
+* Content-Type: application/json
+* PBAC action: `Osquery::Action::"updateEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+Updating an enrollment bumps its version, and the download endpoints below start serving the new artifacts. The secret itself is unchanged.
+
+Example:
+
+enrollment.json
+
+```json
+{
+  "configuration": 1,
+  "osquery_release": "5.12.1",
+  "secret": {
+    "meta_business_unit": 6,
+    "quota": 20,
+    "serial_numbers": ["012345678"]
+  }
+}
+```
+
+```bash
+$ curl -X PUT \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/1/" \
+  -d @enrollment.json \
+  |python3 -m json.tool
+```
+
+#### Delete an enrollment.
+
+* method: DELETE
+* PBAC action: `Osquery::Action::"deleteEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+An enrollment owned by a distributor — a [monolith](monolith.md) manifest enrollment package, for instance — cannot be deleted here; it is managed by that distributor. Enrolled machines do **not** block the deletion.
+
+Example:
+
+```bash
+$ curl -X DELETE \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/1/"
+```
+
+Response (204 No Content)
+
+### /api/osquery/enrollments/`<int:pk>`/package/
+
+#### Download the macOS enrollment package.
+
+* method: GET
+* PBAC action: `Osquery::Action::"viewEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+A macOS installer package that configures the Osquery agent and, when `osquery_release` is set, installs that release. This endpoint honours conditional requests — an `If-None-Match` or `If-Modified-Since` matching the current version gets a `304`.
+
+Example:
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/1/package/" \
+  --output zentral_osquery_enroll.pkg
+```
+
+### /api/osquery/enrollments/`<int:pk>`/script/
+
+#### Download the Linux enrollment script.
+
+* method: GET
+* PBAC action: `Osquery::Action::"viewEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+A bash script that configures the Osquery agent on Linux.
+
+Example:
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/1/script/" \
+  --output zentral_osquery_setup.sh
+```
+
+### /api/osquery/enrollments/`<int:pk>`/powershell_script/
+
+#### Download the Windows enrollment script.
+
+* method: GET
+* PBAC action: `Osquery::Action::"viewEnrollment"`
+* `<int:pk>`: the primary key of the enrollment.
+
+A PowerShell script that configures the Osquery agent on Windows.
+
+Example:
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/osquery/enrollments/1/powershell_script/" \
+  --output zentral_osquery_setup.ps1
+```
+
 ### /api/osquery/file_categories/
 
 #### List all FileCategories.

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -229,6 +229,9 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 
 ### /api/santa/rules/
 
+Terraform resource: [`zentral_santa_rule`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/santa_rule)  
+Terraform data source: [`zentral_santa_rule`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/santa_rule)
+
 #### List all Santa rules
 
 * method: GET
@@ -831,6 +834,9 @@ Nothing was changed:
 
 ### /api/santa/configurations/
 
+Terraform resource: [`zentral_santa_configuration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/santa_configuration)  
+Terraform data source: [`zentral_santa_configuration`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/santa_configuration)
+
 #### List all Santa configurations.
 
 * method: GET
@@ -1066,6 +1072,9 @@ $ curl -X DELETE \
 
 ### /api/santa/enrollments/
 
+Terraform resource: [`zentral_santa_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/santa_enrollment)  
+Terraform data source: [`zentral_santa_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/data-sources/santa_enrollment)
+
 #### List all Santa enrollments.
 
 * method: GET
@@ -1284,6 +1293,8 @@ $ curl -X DELETE \
 
 ### /api/santa/enrollments/`<int:pk>`/plist/
 
+The [`zentral_santa_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/santa_enrollment) Terraform resource exposes this URL as its read-only `plist_url` attribute.
+
 #### Download Santa enrollment plist file.
 
 * method: GET
@@ -1299,6 +1310,8 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 ```
 
 ### /api/santa/enrollments/`<int:pk>`/configuration_profile/
+
+The [`zentral_santa_enrollment`](https://registry.terraform.io/providers/zentralopensource/zentral/latest/docs/resources/santa_enrollment) Terraform resource exposes this URL as its read-only `configuration_profile_url` attribute.
 
 #### Download Santa enrollment configuration profile file.
 

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -1313,3 +1313,43 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
   https://$ZTL_FQDN/api/santa/enrollments/1/configuration_profile/ \
   --output com.example.zentral.santa_configuration.mobileconfig
 ```
+
+### /api/santa/targets/export/
+
+#### Trigger a Santa targets export task.
+
+* method: POST
+* PBAC action: `Santa::Action::"viewTarget"`
+* mandatory query parameter:
+    * `export_format`: `xlsx` or `zip`. Unlike the other export endpoints, this one has no default — a missing or unknown value is a `400`.
+* optional query parameters — the filters of the *Targets* search form:
+    * `q`: a search string, matched against the target identifier (SHA256, team ID, …) and the collected names.
+    * `target_type`: `BINARY`, `BUNDLE`, `CDHASH`, `CERTIFICATE`, `METABUNDLE`, `SIGNINGID` or `TEAMID`.
+    * `target_state`: the voting state, as an integer — `-100` (banned), `-50` (suspect), `0` (untrusted), `50` (partially allowlisted) or `100` (globally allowlisted).
+    * `configuration`: the primary key of a Santa configuration.
+    * `has_yes_votes`, `has_no_votes`, `todo`: booleans.
+    * `last_seen_days`: `1`, `3`, `7`, `14`, `30`, `45` or `90`.
+
+Use this endpoint to trigger a Santa targets export task. With `xlsx`, the result is a single spreadsheet; with `zip`, it is an archive of one file per target type.
+
+**NB:** the filters are passed in the query string, not in the request body.
+
+Example
+
+```bash
+$ curl -XPOST \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/santa/targets/export/?export_format=xlsx&target_type=TEAMID" \
+  |python3 -m json.tool
+```
+
+Response (201 Created)
+
+```json
+{
+  "task_id": "b1512b8d-1e17-4181-a1c3-93a7243fddd3",
+  "task_result_url": "/api/task_result/b1512b8d-1e17-4181-a1c3-93a7243fddd3/"
+}
+```
+
+Poll [`/api/task_result/<uuid:task_id>/`](core.md#apitask_resultuuidtask_id) for the status, and download the file from the `download_url` it returns once the task is done.


### PR DESCRIPTION
Audits every documented module's `/api/` surface against the real URL map, fills the gaps, and links the Terraform resources and data sources. One commit per module per concern, 13 in total.

## The audit

I dumped the actual URL resolver rather than reading `api_urls.py` files, so the baseline is what Django serves: **176 `/api/` routes across the documented modules, 104 of them documented.**

| Module | Routes | Documented | Missing |
|---|---|---|---|
| turbo | 14 | 14 | — |
| wsone | 3 | 3 | — |
| santa | 11 | 10 | 1 |
| munki | 7 | 5 | 2 |
| core | 5 | 3 | 2 |
| osquery | 19 | 14 | 5 |
| monolith | 24 | 17 | 7 |
| inventory | 26 | 17 | 9 |
| **mdm** | **67** | **21** | **46** |

Skipped as undocumented modules, per the brief: `google_workspace` (5), `intune` (3), `probes` (4), `stores` (2), `terraform` (2). `realms` (2) excluded. `/public/` endpoints out of scope.

## What was added

**santa** — the targets export. Two traps documented: its filters come from the query string, not the body, unlike the inventory exports it resembles; and `export_format` is mandatory here rather than defaulted.

**munki** — the script checks, the munki compliance-check mechanism. Notes that *any* change bumps the version and re-runs the check fleet-wide, and contrasts that with turbo scripts where only a source change does.

**core** — the OIDC issuer CRUD. Creating one fetches the OpenID configuration from `issuer_uri`, so the server must reach the provider; deleting an issuer does not revoke tokens it already minted.

**osquery** — the whole enrollment family, including the three platform artifacts. The package endpoint honours conditional requests; deletion is blocked only by a distributor, not by enrolled machines.

**monolith** — repository CRUD (only its sync trigger was documented), manifest enrollment packages, cache server registration, and the two enrollment downloads. Deleting a manifest enrollment package *keeps* the underlying enrollment.

**inventory** — meta business units, taxonomies, tags and JMESPath checks, plus the machine export. `api_enrollment_enabled` can be turned on but never off. Also fixes the machine-meta path parameter, which the page spelled `<url_safe_serial_number>` against a route of `<str:urlsafe_serial_number>`.

**mdm** — the 46, as grouped reference tables per the agreed format. Introspecting the view classes rather than guessing from URL names is what surfaced the interesting part: **push certificates, DEP virtual servers and locations accept GET only.** They are owned by Apple's side of the integration, and the tables now say so instead of implying full CRUD.

## Terraform links

Six modules got a links commit; each endpoint family points at its resource and, where one exists, its data source. The coverage pattern is itself informative and the docs now show it: artifact version types have a resource and no data source, while the read-only Apple-side objects have a data source and no resource — the mirror image, for the same reason.

Download endpoints with no object of their own point at the resource attribute that carries their URL (`plist_url`, `package_url`, `script_url`, …).

## Verification

- `mkdocs build --strict` exits 0.
- Every `href="#…"` in each rebuilt page resolves to an `id` on that page — checked by set-differencing the two out of the built HTML, since `--strict` reports broken anchors only at INFO.
- All **87** distinct registry URLs return 200.
- PBAC action names come from the engine's `legacy_perm_actions` map; methods and permissions from introspecting each view class; filter parameters from the filtersets — that is what caught three filter params I had assumed on the inventory list endpoints that do not exist.
- Payloads are real responses captured from the API, except the manifest-enrollment-package shape, which comes from its serializer (no computed fields).

## Two bugs found in passing

Filed as separate tasks, not fixed here:

- `ScriptCheckSerializer.update()` in munki compares `excluded_tags` against `tags` — a copy-paste slip that bumps the compliance-check version on every no-op PUT, re-running the check across the fleet.
- Several list endpoints declare no pagination class and return bare arrays (osquery enrollments, munki script checks, the inventory object lists, monolith repositories). Consistent with the existing "list endpoints must paginate" concern rather than new.
