### PR TITLE
Paginate the remaining API list endpoints

### DIFF
--- a/docs/apps/core.md
+++ b/docs/apps/core.md
@@ -108,6 +108,31 @@ Issuers can also be managed over the API, at `/api/accounts/token_issuers/oidc/`
 
 ## HTTP API
 
+### Pagination
+
+Every list endpoint is paginated. The response is an object with the total `count`, a `next` and a `previous` URL, and the `results` array:
+
+```json
+{
+    "count": 137,
+    "next": "https://zentral.example.com/api/inventory/tags/?limit=50&offset=50",
+    "previous": null,
+    "results": [
+        {"...": "..."}
+    ]
+}
+```
+
+Use the `limit` and `offset` query parameters to page through the results. `limit` defaults to `50` and is capped at `500`. `next` is `null` on the last page, so a client can follow it until it runs out:
+
+```bash
+$ curl -H "Authorization: Token $ZTL_API_TOKEN" \
+  "https://$ZTL_FQDN/api/inventory/tags/?limit=100&offset=100" \
+  |python3 -m json.tool
+```
+
+Filter parameters combine with the pagination ones, and `count` then reports the number of filtered results.
+
 ### `/api/task_result/<uuid:task_id>/`
 
 * method: GET

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -118,6 +118,10 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 
 * `Content-Type: application/json`
 
+#### Pagination
+
+The list endpoints are paginated. See [Pagination](core.md#pagination) for the response envelope and the `limit` and `offset` query parameters.
+
 ### /api/monolith/repositories/`<int:pk>`/sync/
 
 #### Fetch the package infos, the icons, the client resources from the repository
@@ -211,14 +215,19 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-  "id": 1,
-  "name": "default",
-  "meta_business_unit": 1,
-  "version": 1,
-  "created_at": "2023-01-30T09:39:35.965003",
-  "updated_at": "2023-01-30T09:39:35.965004"
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+    "id": 1,
+    "name": "default",
+    "meta_business_unit": 1,
+    "version": 1,
+    "created_at": "2023-01-30T09:39:35.965003",
+    "updated_at": "2023-01-30T09:39:35.965004"
+  }]
+}
 ```
 
 #### Add a manifest
@@ -371,14 +380,19 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-  "id": 1,
-  "repository": 1,
-  "name": "production",
-  "created_at": "2023-01-30T09:39:35.965003",
-  "updated_at": "2023-01-30T09:39:35.965004",
-  "archived_at": null
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+    "id": 1,
+    "repository": 1,
+    "name": "production",
+    "created_at": "2023-01-30T09:39:35.965003",
+    "updated_at": "2023-01-30T09:39:35.965004",
+    "archived_at": null
+  }]
+}
 ```
 
 #### Add a catalog
@@ -532,13 +546,18 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-  "id": 1,
-  "name": "laptop",
-  "predicate": "machine_type == \"laptop\"",
-  "created_at": "2023-01-30T09:39:35.965003",
-  "updated_at": "2023-01-30T09:39:35.965004",
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+    "id": 1,
+    "name": "laptop",
+    "predicate": "machine_type == \"laptop\"",
+    "created_at": "2023-01-30T09:39:35.965003",
+    "updated_at": "2023-01-30T09:39:35.965004"
+  }]
+}
 ```
 
 #### Add a condition
@@ -688,28 +707,33 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-  {
-    "id": 1,
-    "manifest": 2,
-    "enrolled_machines_count": 0,
-    "secret": {
-      "secret": "AzZhxoWDXDqpUr06O8SQG53eE7fkiOy0U02uOghjQG3zowXMlJqpblSFXvkk05ak",
-      "request_count": 0,
-      "id": 3,
-      "serial_numbers": [],
-      "meta_business_unit": 1,
-      "quota": null,
-      "tags": [],
-      "udids": []
-    },
-    "version": 1,
-    "configuration_profile_download_url": "https://zentral.example.com/api/monolith/enrollments/1/configuration_profile/",
-    "plist_download_url": "https://zentral.example.com/api/monolith/enrollments/1/plist/",
-    "created_at": "2023-01-10T11:02:51.831544",
-    "updated_at": "2023-01-10T11:02:51.831553"
-  }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "manifest": 2,
+      "enrolled_machines_count": 0,
+      "secret": {
+        "secret": "AzZhxoWDXDqpUr06O8SQG53eE7fkiOy0U02uOghjQG3zowXMlJqpblSFXvkk05ak",
+        "request_count": 0,
+        "id": 3,
+        "serial_numbers": [],
+        "meta_business_unit": 1,
+        "quota": null,
+        "tags": [],
+        "udids": []
+      },
+      "version": 1,
+      "configuration_profile_download_url": "https://zentral.example.com/api/monolith/enrollments/1/configuration_profile/",
+      "plist_download_url": "https://zentral.example.com/api/monolith/enrollments/1/plist/",
+      "created_at": "2023-01-10T11:02:51.831544",
+      "updated_at": "2023-01-10T11:02:51.831553"
+    }
+  ]
+}
 ```
 
 #### Add an enrollment
@@ -912,12 +936,17 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-  "id": 1,
-  "manifest": 1,
-  "catalog": 2,
-  "tags": []
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+    "id": 1,
+    "manifest": 1,
+    "catalog": 2,
+    "tags": []
+  }]
+}
 ```
 
 #### Add a manifest catalog
@@ -1073,12 +1102,17 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-  "id": 1,
-  "manifest": 1,
-  "sub_manifest": 2,
-  "tags": []
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+    "id": 1,
+    "manifest": 1,
+    "sub_manifest": 2,
+    "tags": []
+  }]
+}
 ```
 
 #### Add a manifest sub manifest
@@ -1227,14 +1261,19 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-  "id": 1,
-  "name": "Browsers",
-  "description": "The supported browsers",
-  "meta_business_unit": null,
-  "created_at": "2023-01-30T09:49:35.965003",
-  "updated_at": "2023-01-30T09:49:35.965004"
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+    "id": 1,
+    "name": "Browsers",
+    "description": "The supported browsers",
+    "meta_business_unit": null,
+    "created_at": "2023-01-30T09:49:35.965003",
+    "updated_at": "2023-01-30T09:49:35.965004"
+  }]
+}
 ```
 
 #### Add a sub manifest
@@ -1388,29 +1427,34 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[{
-    "id": 1,
-    "sub_manifest": 1,
-    "key": "managed_installs",
-    "featured_item": false,
-    "condition": null,
-    "pkg_info_name": "Nudge",
-    "shard_modulo": 100,
-    "default_shard": 0,
-    "excluded_tags": [],
-    "tag_shards": [
-        {
-            "tag": 2,
-            "shard": 10
-        },
-        {
-            "tag": 1,
-            "shard": 20
-        }
-    ],
-    "created_at": "2023-03-06T09:19:21.342194",
-    "updated_at": "2023-03-06T09:19:21.342209"
-}]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [{
+      "id": 1,
+      "sub_manifest": 1,
+      "key": "managed_installs",
+      "featured_item": false,
+      "condition": null,
+      "pkg_info_name": "Nudge",
+      "shard_modulo": 100,
+      "default_shard": 0,
+      "excluded_tags": [],
+      "tag_shards": [
+          {
+              "tag": 2,
+              "shard": 10
+          },
+          {
+              "tag": 1,
+              "shard": 20
+          }
+      ],
+      "created_at": "2023-03-06T09:19:21.342194",
+      "updated_at": "2023-03-06T09:19:21.342209"
+  }]
+}
 ```
 
 #### Add a sub manifest pkg info

--- a/docs/apps/munki.md
+++ b/docs/apps/munki.md
@@ -33,6 +33,10 @@ Authorization: Token the_token_string
 
 See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
+#### Pagination
+
+The list endpoints are paginated. See [Pagination](core.md#pagination) for the response envelope and the `limit` and `offset` query parameters.
+
 ### /api/munki/configurations/
 
 
@@ -62,31 +66,36 @@ curl \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "name": "Default",
-        "description": "",
-        "inventory_apps_full_info_shard": 100,
-        "principal_user_detection_sources": [
-            "logged_in_user"
-        ],
-        "principal_user_detection_domains": [
-            "zentral.io"
-        ],
-        "collected_condition_keys": [
-            "arch",
-            "machine_type"
-        ],
-        "managed_installs_sync_interval_days": 7,
-        "script_checks_run_interval_seconds": 86400,
-        "auto_reinstall_incidents": true,
-        "auto_failed_install_incidents": false,
-        "version": 6,
-        "created_at": "2021-03-17T10:14:00.493868",
-        "updated_at": "2023-02-08T06:57:49.358674"
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "name": "Default",
+          "description": "",
+          "inventory_apps_full_info_shard": 100,
+          "principal_user_detection_sources": [
+              "logged_in_user"
+          ],
+          "principal_user_detection_domains": [
+              "zentral.io"
+          ],
+          "collected_condition_keys": [
+              "arch",
+              "machine_type"
+          ],
+          "managed_installs_sync_interval_days": 7,
+          "script_checks_run_interval_seconds": 86400,
+          "auto_reinstall_incidents": true,
+          "auto_failed_install_incidents": false,
+          "version": 6,
+          "created_at": "2021-03-17T10:14:00.493868",
+          "updated_at": "2023-02-08T06:57:49.358674"
+      }
+  ]
+}
 ```
 
 #### Add a configuration
@@ -321,27 +330,32 @@ curl \
 Response:
 
 ```json
-[
-    {
-        "configuration": 1,
-        "created_at": "2020-06-16T14:10:32.322536",
-        "enrolled_machines_count": 5,
-        "id": 1,
-        "package_download_url": "https://$ZTL_FQDN/api/munki/enrollments/1/package/",
-        "secret": {
-            "id": 11,
-            "meta_business_unit": 1,
-            "quota": null,
-            "request_count": 5,
-            "secret": "CtX89oaZJeoXAkEDatwRdDX2y5Ubr3fl9rRUDCtkLFXovdFvFjXz37g4rFm0mQy7",
-            "serial_numbers": [],
-            "tags": [],
-            "udids": []
-        },
-        "updated_at": "2021-03-17T10:14:00.496743",
-        "version": 1
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "configuration": 1,
+          "created_at": "2020-06-16T14:10:32.322536",
+          "enrolled_machines_count": 5,
+          "id": 1,
+          "package_download_url": "https://$ZTL_FQDN/api/munki/enrollments/1/package/",
+          "secret": {
+              "id": 11,
+              "meta_business_unit": 1,
+              "quota": null,
+              "request_count": 5,
+              "secret": "CtX89oaZJeoXAkEDatwRdDX2y5Ubr3fl9rRUDCtkLFXovdFvFjXz37g4rFm0mQy7",
+              "serial_numbers": [],
+              "tags": [],
+              "udids": []
+          },
+          "updated_at": "2021-03-17T10:14:00.496743",
+          "version": 1
+      }
+  ]
+}
 ```
 
 #### Add an enrollment

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -28,6 +28,10 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 * `Content-Type: application/x-osquery-conf`
 * `Content-Type: application/yaml`
 
+#### Pagination
+
+The list endpoints are paginated. See [Pagination](core.md#pagination) for the response envelope and the `limit` and `offset` query parameters.
+
 ### /api/osquery/atcs/
 
 #### List all ATCs.
@@ -58,28 +62,33 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "name": "Santa rules",
-        "description": "Access the Google Santa rules.db",
-        "table_name": "santa_rules",
-        "query": "SELECT * FROM rules;",
-        "path": "/var/db/santa/rules.db",
-        "columns": [
-            "identifier",
-            "state",
-            "type",
-            "custommsg",
-            "timestamp"
-        ],
-        "platforms": [
-            "darwin"
-        ],
-        "created_at": "2023-01-30T09:39:35.965003",
-        "updated_at": "2023-01-30T09:39:35.965011"
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "name": "Santa rules",
+          "description": "Access the Google Santa rules.db",
+          "table_name": "santa_rules",
+          "query": "SELECT * FROM rules;",
+          "path": "/var/db/santa/rules.db",
+          "columns": [
+              "identifier",
+              "state",
+              "type",
+              "custommsg",
+              "timestamp"
+          ],
+          "platforms": [
+              "darwin"
+          ],
+          "created_at": "2023-01-30T09:39:35.965003",
+          "updated_at": "2023-01-30T09:39:35.965011"
+      }
+  ]
+}
 ```
 
 #### Add a new ATC.
@@ -300,26 +309,31 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "name": "example",
-        "description": "",
-        "inventory": true,
-        "inventory_apps": true,
-        "inventory_ec2": false,
-        "inventory_interval": 600,
-        "options": {
-            "config_refresh": 120
-        },
-        "created_at": "2023-01-06T13:05:02.535763",
-        "updated_at": "2023-01-30T09:40:23.912582",
-        "file_categories": [],
-        "automatic_table_constructions": [
-            1
-        ]
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "name": "example",
+          "description": "",
+          "inventory": true,
+          "inventory_apps": true,
+          "inventory_ec2": false,
+          "inventory_interval": 600,
+          "options": {
+              "config_refresh": 120
+          },
+          "created_at": "2023-01-06T13:05:02.535763",
+          "updated_at": "2023-01-30T09:40:23.912582",
+          "file_categories": [],
+          "automatic_table_constructions": [
+              1
+          ]
+      }
+  ]
+}
 ```
 
 #### Add a new Configuration.
@@ -536,16 +550,21 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "configuration": 2,
-        "pack": 2,
-        "tags": [
-            1
-        ]
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "configuration": 2,
+          "pack": 2,
+          "tags": [
+              1
+          ]
+      }
+  ]
+}
 ```
 
 #### Add a new Configuration Pack.
@@ -720,20 +739,25 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "name": "example",
-        "slug": "example",
-        "description": "example description",
-        "file_paths": [],
-        "exclude_paths": [],
-        "file_paths_queries": [],
-        "access_monitoring": false,
-        "created_at": "2023-01-31T11:48:53.014319",
-        "updated_at": "2023-01-31T11:48:53.014332"
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "name": "example",
+          "slug": "example",
+          "description": "example description",
+          "file_paths": [],
+          "exclude_paths": [],
+          "file_paths_queries": [],
+          "access_monitoring": false,
+          "created_at": "2023-01-31T11:48:53.014319",
+          "updated_at": "2023-01-31T11:48:53.014332"
+      }
+  ]
+}
 ```
 
 #### Add a new FileCategory.
@@ -931,19 +955,24 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "name": "Default",
-        "slug": "default",
-        "description": "",
-        "discovery_queries": [],
-        "shard": null,
-        "event_routing_key": "",
-        "created_at": "2023-01-13T07:06:51.000733",
-        "updated_at": "2023-01-13T07:06:51.000743"
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "name": "Default",
+          "slug": "default",
+          "description": "",
+          "discovery_queries": [],
+          "shard": null,
+          "event_routing_key": "",
+          "created_at": "2023-01-13T07:06:51.000733",
+          "updated_at": "2023-01-13T07:06:51.000743"
+      }
+  ]
+}
 ```
 
 #### Add a new Pack.
@@ -1329,23 +1358,28 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "compliance_check_enabled": false,
-        "compliance_check_id": null,
-        "name": "GetApps",
-        "sql": "SELECT * FROM apps;",
-        "platforms": [],
-        "scheduling": null,
-        "minimum_osquery_version": null,
-        "description": "Get list of Apps",
-        "value": "",
-        "version": 2,
-        "created_at": "2023-01-13T07:10:12.571288",
-        "updated_at": "2023-01-13T09:24:39.779067"
-    }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "compliance_check_enabled": false,
+          "compliance_check_id": null,
+          "name": "GetApps",
+          "sql": "SELECT * FROM apps;",
+          "platforms": [],
+          "scheduling": null,
+          "minimum_osquery_version": null,
+          "description": "Get list of Apps",
+          "value": "",
+          "version": 2,
+          "created_at": "2023-01-13T07:10:12.571288",
+          "updated_at": "2023-01-13T09:24:39.779067"
+      }
+  ]
+}
 ```
 
 #### Add a new query.

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -227,6 +227,10 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 * `Content-Type: application/json`
 * `Content-Type: application/yaml`
 
+#### Pagination
+
+The list endpoints are paginated. See [Pagination](core.md#pagination) for the response envelope and the `limit` and `offset` query parameters.
+
 ### /api/santa/rules/
 
 #### List all Santa rules
@@ -260,50 +264,55 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-    {
-        "id": 1,
-        "target_type": "TEAMID",
-        "target_identifier": "9BNSXJN65R",
-        "ruleset": null,
-        "version": 1,
-        "policy": 1,
-        "custom_msg": "",
-        "description": "",
-        "serial_numbers": [],
-        "excluded_serial_numbers": [],
-        "primary_users": [],
-        "excluded_primary_users": [],
-        "created_at": "2023-01-17T13:08:19.503831",
-        "updated_at": "2023-01-17T13:08:19.503837",
-        "configuration": 1,
-        "tags": [
-            2
-        ],
-        "excluded_tags": [
-            1
-        ]
-    },
-    {
-        "id": 2,
-        "target_type": "TEAMID",
-        "target_identifier": "1234567890",
-        "ruleset": null,
-        "version": 1,
-        "policy": 1,
-        "custom_msg": "",
-        "description": "",
-        "serial_numbers": [],
-        "excluded_serial_numbers": [],
-        "primary_users": [],
-        "excluded_primary_users": [],
-        "created_at": "2023-01-20T06:10:15.059545",
-        "updated_at": "2023-01-20T06:10:15.059556",
-        "configuration": 1,
-        "tags": [],
-        "excluded_tags": []
-    }
-]
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": 1,
+          "target_type": "TEAMID",
+          "target_identifier": "9BNSXJN65R",
+          "ruleset": null,
+          "version": 1,
+          "policy": 1,
+          "custom_msg": "",
+          "description": "",
+          "serial_numbers": [],
+          "excluded_serial_numbers": [],
+          "primary_users": [],
+          "excluded_primary_users": [],
+          "created_at": "2023-01-17T13:08:19.503831",
+          "updated_at": "2023-01-17T13:08:19.503837",
+          "configuration": 1,
+          "tags": [
+              2
+          ],
+          "excluded_tags": [
+              1
+          ]
+      },
+      {
+          "id": 2,
+          "target_type": "TEAMID",
+          "target_identifier": "1234567890",
+          "ruleset": null,
+          "version": 1,
+          "policy": 1,
+          "custom_msg": "",
+          "description": "",
+          "serial_numbers": [],
+          "excluded_serial_numbers": [],
+          "primary_users": [],
+          "excluded_primary_users": [],
+          "created_at": "2023-01-20T06:10:15.059545",
+          "updated_at": "2023-01-20T06:10:15.059556",
+          "configuration": 1,
+          "tags": [],
+          "excluded_tags": []
+      }
+  ]
+}
 ```
 
 #### Add new Santa rule
@@ -856,27 +865,32 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-  {
-    "id": 1,
-    "name": "Default",
-    "client_mode": 1,
-    "client_certificate_auth": false,
-    "batch_size": 50,
-    "full_sync_interval": 600,
-    "enable_bundles": true,
-    "enable_transitive_rules": false,
-    "allowed_path_regex": "",
-    "blocked_path_regex": "",
-    "block_usb_mount": false,
-    "remount_usb_mode": [],
-    "allow_unknown_shard": 100,
-    "enable_all_event_upload_shard": 0,
-    "sync_incident_severity": 0,
-    "created_at": "2023-01-06T13:07:23.768829",
-    "updated_at": "2023-01-12T12:15:30.457577"
-  }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "name": "Default",
+      "client_mode": 1,
+      "client_certificate_auth": false,
+      "batch_size": 50,
+      "full_sync_interval": 600,
+      "enable_bundles": true,
+      "enable_transitive_rules": false,
+      "allowed_path_regex": "",
+      "blocked_path_regex": "",
+      "block_usb_mount": false,
+      "remount_usb_mode": [],
+      "allow_unknown_shard": 100,
+      "enable_all_event_upload_shard": 0,
+      "sync_incident_severity": 0,
+      "created_at": "2023-01-06T13:07:23.768829",
+      "updated_at": "2023-01-12T12:15:30.457577"
+    }
+  ]
+}
 ```
 
 #### Add new Santa configuration.
@@ -1091,31 +1105,36 @@ $ curl -H "Authorization: Token $ZTL_API_TOKEN" \
 Response:
 
 ```json
-[
-  {
-    "secret": {
-      "secret": "AzZhxoWDXDqpUr06O8SQG53eE7fkiOy0U02uOghjQG3zowXMlJqpblSFXvkk05ak",
-      "request_count": 0,
-      "id": 3,
-      "serial_numbers": [
-      ],
-      "meta_business_unit": 1,
-      "quota": null,
-      "tags": [
-      ],
-      "udids": [
-      ]
-    },
-    "id": 2,
-    "configuration_profile_download_url": "https://zentral.example.com/api/santa/enrollments/1/configuration_profile/",
-    "created_at": "2023-01-10T11:02:51.831544",
-    "configuration": 1,
-    "enrolled_machines_count": 0,
-    "version": 1,
-    "updated_at": "2023-01-10T11:02:51.831553",
-    "plist_download_url": "https://zentral.example.com/api/santa/enrollments/1/plist/"
-  }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "secret": {
+        "secret": "AzZhxoWDXDqpUr06O8SQG53eE7fkiOy0U02uOghjQG3zowXMlJqpblSFXvkk05ak",
+        "request_count": 0,
+        "id": 3,
+        "serial_numbers": [
+        ],
+        "meta_business_unit": 1,
+        "quota": null,
+        "tags": [
+        ],
+        "udids": [
+        ]
+      },
+      "id": 2,
+      "configuration_profile_download_url": "https://zentral.example.com/api/santa/enrollments/1/configuration_profile/",
+      "created_at": "2023-01-10T11:02:51.831544",
+      "configuration": 1,
+      "enrolled_machines_count": 0,
+      "version": 1,
+      "updated_at": "2023-01-10T11:02:51.831553",
+      "plist_download_url": "https://zentral.example.com/api/santa/enrollments/1/plist/"
+    }
+  ]
+}
 ```
 
 #### Add new Santa enrollment.

--- a/docs/apps/wsone.md
+++ b/docs/apps/wsone.md
@@ -54,6 +54,10 @@ Authorization: Token the_token_string
 
 See [API authentication](core.md#api-authentication) for how to create a service account, issue a token for it and set an expiry.
 
+#### Pagination
+
+The list endpoints are paginated. See [Pagination](core.md#pagination) for the response envelope and the `limit` and `offset` query parameters.
+
 ### `/api/wsone/instances/`
 
 * method: GET
@@ -74,18 +78,23 @@ curl \
 Response:
 
 ```json
-[
-  {
-    "id": 1,
-    "business_unit": 1,
-    "client_id": "d2186IFnISnulzGIIwHOAJ68opAWUnFc",
-    "server_url": "https://cn000.awmdm.com",
-    "excluded_groups": ["iPads"],
-    "version": 12,
-    "created_at": "2022-01-18T16:07:59.826640",
-    "updated_at": "2022-01-19T09:25:20.530703"
-  }
-]
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "business_unit": 1,
+      "client_id": "d2186IFnISnulzGIIwHOAJ68opAWUnFc",
+      "server_url": "https://cn000.awmdm.com",
+      "excluded_groups": ["iPads"],
+      "version": 12,
+      "created_at": "2022-01-18T16:07:59.826640",
+      "updated_at": "2022-01-19T09:25:20.530703"
+    }
+  ]
+}
 ```
 
 ### `/api/wsone/instances/{id}/`

--- a/ee/zentral/contrib/intune/api_views.py
+++ b/ee/zentral/contrib/intune/api_views.py
@@ -4,7 +4,8 @@ from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
-                               ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit)
+                               ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .models import Tenant
 from .serializers import TenantSerializer
 from .tasks import sync_inventory
@@ -17,6 +18,7 @@ class TenantList(ListCreateAPIViewWithAudit):
     queryset = Tenant.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = TenantSerializer
+    pagination_class = MaxLimitOffsetPagination
 
 
 class TenantDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/ee/zentral/contrib/intune/api_views.py
+++ b/ee/zentral/contrib/intune/api_views.py
@@ -14,7 +14,7 @@ class TenantList(ListCreateAPIViewWithAudit):
     """
     List or Create Tenants
     """
-    queryset = Tenant.objects.all()
+    queryset = Tenant.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = TenantSerializer
 

--- a/ee/zentral/contrib/wsone/api_views.py
+++ b/ee/zentral/contrib/wsone/api_views.py
@@ -14,7 +14,7 @@ class InstanceList(generics.ListAPIView):
     """
     List all Instances
     """
-    queryset = Instance.objects.all()
+    queryset = Instance.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = InstanceSerializer
 

--- a/ee/zentral/contrib/wsone/api_views.py
+++ b/ee/zentral/contrib/wsone/api_views.py
@@ -4,7 +4,8 @@ from rest_framework import generics, status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from zentral.core.events.base import EventRequest
-from zentral.utils.drf import DefaultDjangoModelPermissions, DjangoPermissionRequired
+from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
+                               MaxLimitOffsetPagination)
 from .models import Instance
 from .serializers import InstanceSerializer
 from .tasks import sync_inventory
@@ -17,6 +18,7 @@ class InstanceList(generics.ListAPIView):
     queryset = Instance.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = InstanceSerializer
+    pagination_class = MaxLimitOffsetPagination
 
 
 class InstanceDetail(generics.RetrieveAPIView):

--- a/server/realms/api_views.py
+++ b/server/realms/api_views.py
@@ -1,6 +1,6 @@
 from django_filters import rest_framework as filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
-from zentral.utils.drf import DefaultDjangoModelPermissions
+from zentral.utils.drf import DefaultDjangoModelPermissions, MaxLimitOffsetPagination
 from .models import Realm
 from .serializers import RealmSerializer
 
@@ -11,6 +11,7 @@ class RealmList(ListAPIView):
     serializer_class = RealmSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class RealmDetail(RetrieveAPIView):

--- a/server/realms/api_views.py
+++ b/server/realms/api_views.py
@@ -6,7 +6,7 @@ from .serializers import RealmSerializer
 
 
 class RealmList(ListAPIView):
-    queryset = Realm.objects.all()
+    queryset = Realm.objects.all().order_by("name", "-created_at", "pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = RealmSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/tests/core_probes/test_api_action_views.py
+++ b/tests/core_probes/test_api_action_views.py
@@ -60,7 +60,7 @@ class ProbeActionAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("probes.view_action")
         response = self.get(reverse("probes_api:actions") + f"?name={action.name}")
         self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = response.json()["results"]
         self.assertEqual(
             data,
             [{'id': str(action.pk),

--- a/tests/core_probes/test_api_probe_views.py
+++ b/tests/core_probes/test_api_probe_views.py
@@ -60,7 +60,7 @@ class ProbeAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("probes.view_probesource")
         response = self.get(reverse("probes_api:probes") + f"?name={probe_source.name}")
         self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = response.json()["results"]
         self.assertEqual(
             data,
             [{'id': probe_source.pk,

--- a/tests/core_stores/test_api_store_views.py
+++ b/tests/core_stores/test_api_store_views.py
@@ -59,7 +59,7 @@ class StoreAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("stores.view_store")
         response = self.get(reverse("stores_api:stores") + f"?name={store.name}")
         self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = response.json()["results"]
         self.assertEqual(
             data,
             [{'admin_console': False,
@@ -86,7 +86,7 @@ class StoreAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("stores.view_store")
         response = self.get(reverse("stores_api:stores"))
         self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = response.json()["results"]
         self.assertEqual(
             data,
             [{'admin_console': False,

--- a/tests/google_workspace/test_api_views.py
+++ b/tests/google_workspace/test_api_views.py
@@ -122,8 +122,9 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
                 'updated_at': connection.updated_at.isoformat()
             }
 
-    def _connection_to_list(self, connection: Connection):
-        return [self._connection_to_dict(connection)]
+    def _connection_to_page(self, connection: Connection):
+        return {'count': 1, 'next': None, 'previous': None,
+                'results': [self._connection_to_dict(connection)]}
 
     def _group_tag_mapping_to_dict(self, group_tag_mapping: GroupTagMapping):
         return {
@@ -135,8 +136,9 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
             'updated_at': group_tag_mapping.updated_at.isoformat()
         }
 
-    def _group_tag_mapping_to_list(self, group_tag_mapping: GroupTagMapping):
-        return [self._group_tag_mapping_to_dict(group_tag_mapping)]
+    def _group_tag_mapping_to_page(self, group_tag_mapping: GroupTagMapping):
+        return {'count': 1, 'next': None, 'previous': None,
+                'results': [self._group_tag_mapping_to_dict(group_tag_mapping)]}
 
     def _group_tag_mapping_request(self, connection_pk: uuid, group_email: str, tag_pk: int):
         return {
@@ -197,13 +199,13 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            self._connection_to_list(connection))
+            self._connection_to_page(connection))
 
     def test_list_connections_by_name_no_results(self):
         self.set_permissions("google_workspace.view_connection")
         response = self.get(reverse("google_workspace_api:connections") + f"?name={get_random_string(12)}")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_list_connections_by_name(self):
         self.set_permissions("google_workspace.view_connection")
@@ -212,7 +214,7 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            self._connection_to_list(connection))
+            self._connection_to_page(connection))
 
     # ConnectionDetail
 
@@ -302,9 +304,11 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        actual_mappings = response.json()
-        self.assertEqual(len(actual_mappings), len(expected_mappings))
-        self.assertTrue(all(expected in actual_mappings for expected in expected_mappings))
+        payload = response.json()
+        self.assertEqual(payload["count"], len(expected_mappings))
+        self.assertIsNone(payload["next"])
+        self.assertIsNone(payload["previous"])
+        self.assertTrue(all(expected in payload["results"] for expected in expected_mappings))
 
     def test_list_group_tag_mappings_by_group_email_no_result(self):
         self.set_permissions("google_workspace.view_grouptagmapping")
@@ -312,7 +316,7 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
             reverse("google_workspace_api:group_tag_mappings") + f"?group_email={get_random_string(12)}")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_list_group_tag_mappings_by_group_email(self):
         self.set_permissions("google_workspace.view_grouptagmapping")
@@ -327,7 +331,7 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
             reverse("google_workspace_api:group_tag_mappings") + f"?group_email={group_tag_mapping.group_email}")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), self._group_tag_mapping_to_list(group_tag_mapping))
+        self.assertEqual(response.json(), self._group_tag_mapping_to_page(group_tag_mapping))
 
     def test_list_group_tag_mappings_by_connection_no_result(self):
         self.set_permissions("google_workspace.view_grouptagmapping")
@@ -335,7 +339,7 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("google_workspace_api:group_tag_mappings") + f"?connection_id={connection.id}")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_list_group_tag_mappings_by_connection(self):
         self.set_permissions("google_workspace.view_grouptagmapping")
@@ -350,7 +354,7 @@ class ApiViewsTestCase(TestCase, LoginCase, RequestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.json(), self._group_tag_mapping_to_list(group_tag_mapping))
+        self.assertEqual(response.json(), self._group_tag_mapping_to_page(group_tag_mapping))
 
     def test_list_group_tag_mappings__method_not_allowed(self):
         self.set_permissions("google_workspace.delete_grouptagmapping")

--- a/tests/intune/test_api_views.py
+++ b/tests/intune/test_api_views.py
@@ -70,6 +70,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("intune.view_tenant")
         response = self.get(reverse("intune_api:tenants"))
         self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertIsNone(payload["next"])
+        self.assertIsNone(payload["previous"])
         self.assertIn(
             {'id': tenant.pk,
              'business_unit': tenant.business_unit.pk,
@@ -81,7 +85,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'version': tenant.version,
              'created_at': tenant.created_at.isoformat(),
              'updated_at': tenant.updated_at.isoformat()},
-            response.json()
+            payload["results"]
         )
 
     # get tenant

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -695,7 +695,7 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.set_permissions("inventory.view_metabusinessunit")
         response = self.get(url, {"name": meta_business_unit.name})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data,
+        self.assertEqual(response.data["results"],
                          [{"id": meta_business_unit.pk,
                            "name": meta_business_unit.name,
                            "api_enrollment_enabled": meta_business_unit.api_enrollment_enabled(),
@@ -960,9 +960,9 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.set_permissions("inventory.view_tag")
         response = self.get(reverse('inventory_api:tags'), {"name": tag.name})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data["count"], 1)
         self.assertEqual(
-            response.data[0],
+            response.data["results"][0],
             {"id": tag.pk,
              "taxonomy": taxonomy.pk,
              "meta_business_unit": meta_business_unit.pk,
@@ -970,6 +970,26 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
              "slug": tag.slug,
              "color": tag.color}
         )
+
+    def test_list_tag_pages(self):
+        tags = [Tag.objects.create(name=f"{get_random_string(12)}-{i:02d}") for i in range(3)]
+        self.set_permissions("inventory.view_tag")
+        seen = []
+        url = reverse('inventory_api:tags') + "?limit=2"
+        while url:
+            response = self.get(url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], Tag.objects.count())
+            seen.extend(t["id"] for t in response.data["results"])
+            url = response.data["next"]
+        self.assertEqual(len(seen), len(set(seen)))
+        self.assertTrue(set(t.pk for t in tags) <= set(seen))
+
+    def test_list_tag_max_limit(self):
+        self.set_permissions("inventory.view_tag")
+        response = self.get(reverse('inventory_api:tags'), {"limit": 10000})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertLessEqual(len(response.data["results"]), 500)
 
     # create taxonomy
 
@@ -1222,9 +1242,9 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         self.set_permissions("inventory.view_taxonomy")
         response = self.get(reverse('inventory_api:taxonomies'), {"name": taxonomy.name})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data["count"], 1)
         self.assertEqual(
-            response.data[0],
+            response.data["results"][0],
             {"id": taxonomy.pk,
              "meta_business_unit": meta_business_unit.pk,
              "name": taxonomy.name,

--- a/tests/inventory/test_compliance_checks_api.py
+++ b/tests/inventory/test_compliance_checks_api.py
@@ -342,7 +342,7 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         response = self.get(reverse('inventory_api:jmespath_checks'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{"id": jpcc.pk,
               "name": jpcc.compliance_check.name,
               "description": jpcc.compliance_check.description,
@@ -364,7 +364,7 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         response = self.get(reverse('inventory_api:jmespath_checks'), data={"name": jpcc.compliance_check.name})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{"id": jpcc.pk,
               "name": jpcc.compliance_check.name,
               "description": jpcc.compliance_check.description,

--- a/tests/monolith/test_api_views.py
+++ b/tests/monolith/test_api_views.py
@@ -99,7 +99,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_repository")
         response = self.get(reverse("monolith_api:repositories"), {"name": "foo"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_repositories_filter_by_name(self):
         force_repository()
@@ -107,7 +107,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_repository")
         response = self.get(reverse("monolith_api:repositories"), {"name": repository.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': repository.pk,
             'provisioning_uid': None,
             'backend': 'VIRTUAL',
@@ -127,7 +127,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         repository = force_repository(mbu=self.mbu)
         response = self.get(reverse("monolith_api:repositories"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': repository.pk,
             'provisioning_uid': None,
             'backend': 'S3',
@@ -148,7 +148,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         repository = force_repository(mbu=self.mbu, provisioning_uid=provisioning_uid)
         response = self.get(reverse("monolith_api:repositories"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': repository.pk,
             'provisioning_uid': provisioning_uid,
             # no backend, azure_kwargs and s3_kwargs
@@ -829,7 +829,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_manifest")
         response = self.get(reverse("monolith_api:manifests"), {"name": "foo"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_manifests_filter_by_meta_business_unit_id_not_found(self):
         self.set_permissions("monolith.view_manifest")
@@ -846,7 +846,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         manifest = force_manifest()
         response = self.get(reverse("monolith_api:manifests"), {"name": manifest.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest.pk,
             'name': manifest.name,
             'version': 1,
@@ -861,7 +861,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifests"),
                             {"meta_business_unit_id": self.mbu.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest.pk,
             'name': manifest.name,
             'version': 1,
@@ -875,7 +875,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         manifest = force_manifest()
         response = self.get(reverse("monolith_api:manifests"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest.pk,
             'name': manifest.name,
             'version': 1,
@@ -1374,7 +1374,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_condition")
         response = self.get(reverse("monolith_api:conditions"), {"name": "foo"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_conditions_filter_by_name(self):
         force_condition()
@@ -1382,7 +1382,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_condition")
         response = self.get(reverse("monolith_api:conditions"), {"name": condition.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': condition.pk,
             'name': condition.name,
             'predicate': condition.predicate,
@@ -1395,7 +1395,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_condition")
         response = self.get(reverse("monolith_api:conditions"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': condition.pk,
             'name': condition.name,
             'predicate': condition.predicate,
@@ -1606,14 +1606,14 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         manifest = force_manifest()
         response = self.get(reverse("monolith_api:enrollments"), {"manifest_id": manifest.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_enrollments_filter_by_manifest_id(self):
         enrollment, tags = force_enrollment(mbu=self.mbu, tag_count=1)
         self.set_permissions("monolith.view_enrollment")
         response = self.get(reverse("monolith_api:enrollments"), {"manifest_id": enrollment.manifest.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': enrollment.pk,
             'manifest': enrollment.manifest.pk,
             'enrolled_machines_count': 0,
@@ -1645,7 +1645,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_enrollment")
         response = self.get(reverse("monolith_api:enrollments"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': enrollment.pk,
             'manifest': enrollment.manifest.pk,
             'enrolled_machines_count': 0,
@@ -1992,7 +1992,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         manifest = force_manifest()
         response = self.get(reverse("monolith_api:manifest_catalogs"), {"manifest_id": manifest.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_manifest_catalogs_filter_by_manifest_id(self):
         manifest1 = force_manifest()
@@ -2003,7 +2003,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifest_catalogs"),
                             {"manifest_id": manifest2.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest2.manifestcatalog_set.first().pk,
             'manifest': manifest2.id,
             'catalog': catalog.id,
@@ -2018,7 +2018,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifest_catalogs"),
                             {"catalog_id": catalog.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest.manifestcatalog_set.get(catalog=catalog).pk,
             'manifest': manifest.id,
             'catalog': catalog.id,
@@ -2031,7 +2031,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_manifestcatalog")
         response = self.get(reverse("monolith_api:manifest_catalogs"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest.manifestcatalog_set.first().pk,
             'manifest': manifest.id,
             'catalog': catalog.id,
@@ -2261,7 +2261,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         manifest = force_manifest()
         response = self.get(reverse("monolith_api:manifest_sub_manifests"), {"manifest_id": manifest.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_manifest_sub_manifests_filter_by_manifest_id(self):
         manifest = force_manifest()
@@ -2271,7 +2271,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifest_sub_manifests"),
                             {"manifest_id": manifest.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest.manifestsubmanifest_set.filter(sub_manifest=sub_manifest).first().pk,
             'manifest': manifest.id,
             'sub_manifest': sub_manifest.id,
@@ -2287,7 +2287,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifest_sub_manifests"),
                             {"sub_manifest_id": sub_manifest.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest_sub_manifest.pk,
             'manifest': manifest.id,
             'sub_manifest': sub_manifest.id,
@@ -2301,7 +2301,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_manifestsubmanifest")
         response = self.get(reverse("monolith_api:manifest_sub_manifests"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': manifest_sub_manifest.pk,
             'manifest': manifest.id,
             'sub_manifest': sub_manifest.id,
@@ -2533,7 +2533,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_submanifest")
         response = self.get(reverse("monolith_api:sub_manifests"), {"name": get_random_string(12)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_sub_manifests_filter_by_name(self):
         force_sub_manifest()
@@ -2542,7 +2542,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:sub_manifests"),
                             {"name": sub_manifest.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': sub_manifest.pk,
             'name': sub_manifest.name,
             'description': sub_manifest.description,
@@ -2556,7 +2556,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_submanifest")
         response = self.get(reverse("monolith_api:sub_manifests"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': sub_manifest.pk,
             'name': sub_manifest.name,
             'description': sub_manifest.description,
@@ -2776,7 +2776,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         sub_manifest = force_sub_manifest()
         response = self.get(reverse("monolith_api:sub_manifest_pkg_infos"), {"sub_manifest_id": sub_manifest.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_sub_manifest_pkg_infos_filter_by_sub_manifest_id(self):
         force_sub_manifest_pkg_info()
@@ -2785,7 +2785,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:sub_manifest_pkg_infos"),
                             {"sub_manifest_id": sub_manifest_pkg_info.sub_manifest.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': sub_manifest_pkg_info.pk,
             'sub_manifest': sub_manifest_pkg_info.sub_manifest.pk,
             'key': 'managed_installs',
@@ -2805,7 +2805,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_submanifestpkginfo")
         response = self.get(reverse("monolith_api:sub_manifest_pkg_infos"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': sub_manifest_pkg_info.pk,
             'sub_manifest': sub_manifest_pkg_info.sub_manifest.pk,
             'key': 'managed_installs',

--- a/tests/monolith/test_monolith_enrollment_package_api_views.py
+++ b/tests/monolith/test_monolith_enrollment_package_api_views.py
@@ -66,7 +66,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         force_manifest_enrollment_package()
         response = self.get(reverse("monolith_api:manifest_enrollment_packages"), {"manifest_id": manifest.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_manifest_enrollment_packages_filter_by_manifest_id(self):
         mep1 = force_manifest_enrollment_package()
@@ -78,7 +78,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifest_enrollment_packages"),
                             {"manifest_id": manifest1.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': mep1.pk,
             'manifest': manifest1.id,
             'builder': 'zentral.contrib.munki.osx_package.builder.MunkiZentralEnrollPkgBuilder',
@@ -101,7 +101,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("monolith_api:manifest_enrollment_packages"),
                             {"builder": mep2.builder})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': mep2.pk,
             'manifest': manifest2.id,
             'builder': 'zentral.contrib.munki.osx_package.builder.MunkiZentralEnrollPkgBuilder',
@@ -117,7 +117,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.view_manifestenrollmentpackage")
         response = self.get(reverse("monolith_api:manifest_enrollment_packages"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             'id': mep.pk,
             'manifest': mep.manifest.id,
             'builder': 'zentral.contrib.munki.osx_package.builder.MunkiZentralEnrollPkgBuilder',

--- a/tests/munki/test_api_views.py
+++ b/tests/munki/test_api_views.py
@@ -110,7 +110,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'principal_user_detection_sources': [],
              'updated_at': configuration.updated_at.isoformat(),
              'version': 0},
-            response.json()
+            response.json()["results"]
         )
 
     def test_get_configurations_by_name(self):
@@ -120,7 +120,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("munki_api:configurations"), {"name": configuration.name})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{'auto_failed_install_incidents': False,
               'auto_reinstall_incidents': False,
               'collected_condition_keys': [],
@@ -495,7 +495,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         fqdn = settings["api"]["fqdn"]
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{'id': enrollment.pk,
               'configuration': enrollment.configuration.pk,
               'enrolled_machines_count': 0,
@@ -513,7 +513,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
               'package_download_url': f'https://{fqdn}/api/munki/enrollments/{enrollment.pk}/package/',
               'created_at': enrollment.created_at.isoformat(),
               'updated_at': enrollment.updated_at.isoformat()}],
-            response.json()
+            response.json()["results"]
         )
 
     def test_get_enrollments(self):
@@ -540,7 +540,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'package_download_url': f'https://{fqdn}/api/munki/enrollments/{enrollment.pk}/package/',
              'created_at': enrollment.created_at.isoformat(),
              'updated_at': enrollment.updated_at.isoformat()},
-            response.json()
+            response.json()["results"]
         )
 
     # create enrollment
@@ -834,7 +834,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse('munki_api:script_checks'), {"name": sc.compliance_check.name})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{'id': sc.pk,
               'compliance_check_id': sc.compliance_check.pk,
               'description': sc.compliance_check.description,
@@ -862,7 +862,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse('munki_api:script_checks'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            sorted(response.json(), key=lambda d: d["id"]),
+            sorted(response.json()["results"], key=lambda d: d["id"]),
             [{'id': sc.pk,
               'compliance_check_id': sc.compliance_check.pk,
               'description': sc.compliance_check.description,

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -202,7 +202,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'), data={"name": get_random_string(24)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_atcs_filter_by_configuration_id_not_found(self):
         self.set_permissions("osquery.view_automatictableconstruction")
@@ -218,8 +218,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'), data={"name": atc.name})
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "platforms": ["darwin", "windows"],
             "updated_at": atc.updated_at.isoformat(),
             "columns": ["un", "deux"],
@@ -239,8 +239,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'), data={"configuration_id": configuration.id})
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "platforms": ["darwin", "windows"],
             "updated_at": atc.updated_at.isoformat(),
             "columns": ["un", "deux"],
@@ -258,8 +258,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'))
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "platforms": ["darwin", "windows"],
             "updated_at": atc.updated_at.isoformat(),
             "columns": ["un", "deux"],
@@ -519,7 +519,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_filecategory")
         response = self.get(reverse('osquery_api:file_categories'), data={"name": get_random_string(35)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_file_categories_filter_by_configuration_id_not_found(self):
         self.set_permissions("osquery.view_filecategory")
@@ -535,7 +535,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_filecategory")
         response = self.get(reverse('osquery_api:file_categories'), data={"name": file_category.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "name": file_category.name,
             "slug": file_category.slug,
             "id": file_category.id,
@@ -556,7 +556,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse('osquery_api:file_categories'),
                             data={"configuration_id": configuration.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "name": file_category.name,
             "slug": file_category.slug,
             "id": file_category.id,
@@ -574,8 +574,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_filecategory")
         response = self.get(reverse('osquery_api:file_categories'))
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "name": file_category.name,
             "slug": file_category.slug,
             "id": file_category.id,
@@ -835,7 +835,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_configuration")
         response = self.get(reverse("osquery_api:configurations"), {"name": get_random_string(32)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_configurations_filter_by_name(self):
         for _ in range(3):
@@ -844,7 +844,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_configuration")
         response = self.get(reverse("osquery_api:configurations"), {"name": configuration.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration.id,
             "name": configuration.name,
             "description": "",
@@ -864,7 +864,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_configuration")
         response = self.get(reverse('osquery_api:configurations'))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, [{
+        self.assertEqual(response.data["results"], [{
             "id": configuration.pk,
             "name": configuration.name,
             'description': "",
@@ -1250,7 +1250,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'script_download_url': f'https://{fqdn}/api/osquery/enrollments/{enrollment.pk}/script/',
              'created_at': enrollment.created_at.isoformat(),
              'updated_at': enrollment.updated_at.isoformat()},
-            response.json()
+            response.json()["results"]
         )
 
     # get enrollment
@@ -1577,7 +1577,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"), {"name": get_random_string(12)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_packs_filter_by_configuration_id_not_found(self):
         self.set_permissions("osquery.view_pack")
@@ -1593,7 +1593,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration = self.force_configuration()
         response = self.get(reverse("osquery_api:packs"), {"configuration_id": configuration.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_packs_filter_by_name(self):
         for _ in range(3):
@@ -1602,7 +1602,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"), {"name": pack.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": pack.pk,
             "name": pack.name,
             "slug": slugify(pack.name),
@@ -1621,7 +1621,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"), {"configuration_id": configuration.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": pack.pk,
             "name": pack.name,
             "slug": slugify(pack.name),
@@ -1638,7 +1638,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": pack.pk,
             "name": pack.name,
             "slug": slugify(pack.name),
@@ -2476,7 +2476,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_query")
         response = self.get(reverse("osquery_api:queries"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(),
+        self.assertEqual(response.json()["results"],
                          [{"id": query.pk,
                            "name": query.name,
                            "version": 1,
@@ -2508,7 +2508,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_query")
         response = self.get(reverse("osquery_api:queries"), {"name": query.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(),
+        self.assertEqual(response.json()["results"],
                          [{"id": query.pk,
                            "name": query.name,
                            "version": 1,
@@ -2533,7 +2533,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_query")
         response = self.get(reverse("osquery_api:queries"), {"pack_id": pack.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(),
+        self.assertEqual(response.json()["results"],
                          [{"id": query.pk,
                            "name": query.name,
                            "version": 1,
@@ -3297,7 +3297,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration, pack, configuration_pack = self.force_configuration(force_pack=True)
         response = self.get(reverse("osquery_api:configuration_packs"), {"configuration_id": configuration.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration_pack.pk,
             "configuration": configuration.pk,
             "tags": [],
@@ -3312,7 +3312,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration, pack, configuration_pack = self.force_configuration(force_pack=True)
         response = self.get(reverse("osquery_api:configuration_packs"), {"pack_id": pack.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration_pack.pk,
             "configuration": configuration.pk,
             "tags": [],
@@ -3325,7 +3325,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration_pack = self.force_configuration_pack()
         response = self.get(reverse("osquery_api:configuration_packs"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration_pack.pk,
             "configuration": configuration_pack.configuration.pk,
             "tags": [],

--- a/tests/santa/test_api_views.py
+++ b/tests/santa/test_api_views.py
@@ -779,7 +779,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.client.get(reverse("santa_api:rules"),
                                    HTTP_AUTHORIZATION=f"Token {self.api_key}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        rules = response.json()
+        rules = response.json()["results"]
         rules.sort(key=lambda r: r["id"])
         self.assertEqual(len(rules), 2)
         self.assertEqual(rules[0]["target_type"], "BINARY")
@@ -795,7 +795,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                                    data={"target_type": "CERTIFICATE"},
                                    HTTP_AUTHORIZATION=f"Token {self.api_key}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        rules = response.json()
+        rules = response.json()["results"]
         self.assertEqual(len(rules), 1)
         self.assertEqual(rules[0]["id"], rule2.pk)
 
@@ -820,7 +820,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                                    data={"target_identifier": rule2.target.identifier},
                                    HTTP_AUTHORIZATION=f"Token {self.api_key}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        rules = response.json()
+        rules = response.json()["results"]
         self.assertEqual(len(rules), 1)
         self.assertEqual(rules[0]["id"], rule2.pk)
 
@@ -832,7 +832,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                                    data={"configuration_id": self.configuration2.pk},
                                    HTTP_AUTHORIZATION=f"Token {self.api_key}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        rules = response.json()
+        rules = response.json()["results"]
         self.assertEqual(len(rules), 1)
         self.assertEqual(rules[0]["id"], rule2.pk)
 
@@ -1871,7 +1871,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("santa.view_configuration")
         response = self.get(reverse('santa_api:configurations'), data={"name": config.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data,
+        self.assertEqual(response.data["results"],
                          [{"id": config.pk,
                            "name": config.name,
                            'client_mode': 1,
@@ -2216,7 +2216,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                                    f'{reverse("santa_api:enrollment_plist", args=(enrollment.pk,))}',
              'created_at': enrollment.created_at.isoformat(),
              'updated_at': enrollment.updated_at.isoformat()},
-            response.json()
+            response.json()["results"]
         )
 
     # filter enrollments
@@ -2228,7 +2228,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("santa.view_enrollment")
         response = self.get(reverse('santa_api:enrollments'), {'configuration_id': enrollment2.configuration.pk})
         self.assertEqual(response.status_code, 200)
-        for enrollment in response.json():
+        for enrollment in response.json()["results"]:
             self.assertNotEqual(enrollment['configuration'], enrollment1.configuration.pk)
             self.assertEqual(enrollment['configuration'], enrollment2.configuration.pk)
             self.assertNotEqual(enrollment['configuration'], enrollment3.configuration.pk)

--- a/tests/server_base/test_api_pagination.py
+++ b/tests/server_base/test_api_pagination.py
@@ -1,0 +1,142 @@
+from django.contrib.auth.models import Group
+from django.test import SimpleTestCase, TestCase
+from django.urls import get_resolver, URLPattern, URLResolver
+from django.utils.crypto import get_random_string
+from rest_framework import generics, mixins
+from rest_framework.generics import GenericAPIView
+from rest_framework.viewsets import GenericViewSet
+
+from accounts.models import APIToken, User
+from tests.zentral_test_utils.login_case import LoginCase
+from tests.zentral_test_utils.request_case import RequestCase
+
+
+# List endpoints whose queryset has no ordering. LIMIT/OFFSET over an unordered
+# queryset lets a row move between pages, so a client walking the pages can see
+# it twice and miss another one. Shrink this list, never grow it.
+UNORDERED_LIST_ENDPOINTS = [
+    "api/accounts/token_issuers/oidc/",
+    "api/mdm/artifacts/",
+    "api/mdm/cert_assets/",
+    "api/mdm/data_assets/",
+    "api/mdm/declarations/",
+    "api/mdm/dep/virtual_servers/",
+    "api/mdm/dep_enrollment_custom_views/",
+    "api/mdm/devices/",
+    "api/mdm/enrollment_custom_views/",
+    "api/mdm/enterprise_apps/",
+    "api/mdm/profiles/",
+    "api/mdm/provisioning_profiles/",
+    "api/mdm/store_apps/",
+]
+
+
+def iter_url_patterns(resolver, prefix=""):
+    for url_pattern in resolver.url_patterns:
+        pattern = prefix + str(url_pattern.pattern)
+        if isinstance(url_pattern, URLResolver):
+            yield from iter_url_patterns(url_pattern, pattern)
+        elif isinstance(url_pattern, URLPattern):
+            yield pattern, url_pattern.callback
+
+
+def iter_api_list_views():
+    for pattern, callback in iter_url_patterns(get_resolver()):
+        if not pattern.startswith("api/"):
+            continue
+        view_class = getattr(callback, "cls", None) or getattr(callback, "view_class", None)
+        if view_class is None or not issubclass(view_class, (GenericAPIView, GenericViewSet)):
+            continue
+        actions = getattr(callback, "actions", None)
+        if actions:
+            # router generated viewset view, the method map tells us what it serves
+            if "list" not in actions.values():
+                continue
+        elif not issubclass(view_class, (mixins.ListModelMixin, generics.ListAPIView)):
+            continue
+        yield pattern, view_class
+
+
+class APIPaginationTestCase(SimpleTestCase):
+    maxDiff = None
+
+    def test_api_list_views_are_paginated(self):
+        checked = 0
+        unpaginated = []
+        for pattern, view_class in sorted(iter_api_list_views(), key=lambda t: t[0]):
+            checked += 1
+            if view_class.pagination_class is None:
+                unpaginated.append(f"{pattern} {view_class.__module__}.{view_class.__qualname__}")
+        self.assertEqual(unpaginated, [])
+        # a scan that finds nothing would pass without checking anything
+        self.assertGreater(checked, 50)
+
+    def test_api_list_view_querysets_are_ordered(self):
+        checked = 0
+        unordered = []
+        for pattern, view_class in sorted(iter_api_list_views(), key=lambda t: t[0]):
+            queryset = getattr(view_class, "queryset", None)
+            if queryset is None:
+                continue
+            checked += 1
+            if not queryset.query.order_by and not queryset.model._meta.ordering:
+                unordered.append(pattern)
+        self.assertEqual(unordered, UNORDERED_LIST_ENDPOINTS)
+        self.assertGreater(checked, 50)
+
+
+class APIListEnvelopeTestCase(TestCase, LoginCase, RequestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.service_account = User.objects.create(
+            username=get_random_string(12),
+            email="{}@zentral.com".format(get_random_string(12)),
+            is_service_account=True
+        )
+        cls.group = Group.objects.create(name=get_random_string(12))
+        cls.service_account.groups.set([cls.group])
+        _, cls.api_key = APIToken.objects.create_for_user(cls.service_account)
+
+    # LoginCase implementation
+
+    def _get_user(self):
+        return self.service_account
+
+    def _get_group(self):
+        return self.group
+
+    def _get_url_namespace(self):
+        return "base_api"
+
+    # RequestCase implementation
+
+    def _get_api_key(self):
+        return self.api_key
+
+    def view_permissions(self, view_class):
+        permissions = getattr(view_class, "permission_required", None)
+        if permissions:
+            if not isinstance(permissions, (list, tuple)):
+                permissions = [permissions]
+            return list(permissions)
+        model = view_class.queryset.model
+        return [f"{model._meta.app_label}.view_{model._meta.model_name}"]
+
+    def test_api_list_views_answer_with_a_page(self):
+        checked = 0
+        for pattern, view_class in sorted(iter_api_list_views(), key=lambda t: t[0]):
+            with self.subTest(pattern):
+                self.set_permissions(*self.view_permissions(view_class))
+                response = self.get(f"/{pattern}")
+                self.assertEqual(response.status_code, 200)
+                payload = response.json()
+                self.assertEqual(set(payload), {"count", "next", "previous", "results"})
+                self.assertIsInstance(payload["results"], list)
+                # everything the test database holds fits on the first page
+                self.assertEqual(payload["count"], len(payload["results"]))
+                self.assertIsNone(payload["next"])
+                self.assertIsNone(payload["previous"])
+            checked += 1
+        self.assertGreater(checked, 50)

--- a/tests/server_realms/test_api_views.py
+++ b/tests/server_realms/test_api_views.py
@@ -57,7 +57,7 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("realms_api:realms"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{'uuid': str(realm.pk),
               'name': realm.name,
               'backend': 'ldap',
@@ -91,7 +91,7 @@ class RealmsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("realms_api:realms"), data={"name": realm.name})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
+            response.json()["results"],
             [{'uuid': str(realm.pk),
               'name': realm.name,
               'backend': 'saml',

--- a/tests/wsone/test_api_views.py
+++ b/tests/wsone/test_api_views.py
@@ -80,6 +80,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("wsone.view_instance")
         response = self.get(reverse("wsone_api:instances"))
         self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertIsNone(payload["next"])
+        self.assertIsNone(payload["previous"])
         self.assertIn(
             {'id': instance.pk,
              'business_unit': instance.business_unit.pk,
@@ -89,7 +93,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              "excluded_groups": [instance.excluded_groups[0]],
              'created_at': instance.created_at.isoformat(),
              'updated_at': instance.updated_at.isoformat()},
-            response.json()
+            payload["results"]
         )
 
     # get instance

--- a/zentral/contrib/google_workspace/api_views.py
+++ b/zentral/contrib/google_workspace/api_views.py
@@ -8,7 +8,7 @@ from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from accounts.api_authentication import APITokenAuthentication
-from zentral.utils.drf import DjangoPermissionRequired, DefaultDjangoModelPermissions
+from zentral.utils.drf import DjangoPermissionRequired, DefaultDjangoModelPermissions, MaxLimitOffsetPagination
 from zentral.contrib.google_workspace.models import Connection, GroupTagMapping
 from zentral.contrib.google_workspace.serializers import (
     ConnectionSerializer,
@@ -46,6 +46,7 @@ class ConnectionList(ListAPIView):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConnectionDetail(RetrieveAPIView):
@@ -58,6 +59,7 @@ class GroupTagMappingList(ListCreateAPIViewWithAudit):
     queryset = GroupTagMapping.objects.all().order_by("pk")
     serializer_class = GroupTagMappingSerializer
     filterset_fields = ('connection_id', 'group_email')
+    pagination_class = MaxLimitOffsetPagination
 
 
 class GroupTagMappingDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/google_workspace/api_views.py
+++ b/zentral/contrib/google_workspace/api_views.py
@@ -41,7 +41,7 @@ class SyncTagsView(APIView):
 
 
 class ConnectionList(ListAPIView):
-    queryset = Connection.objects.all()
+    queryset = Connection.objects.all().order_by("name")
     serializer_class = ConnectionSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
@@ -55,7 +55,7 @@ class ConnectionDetail(RetrieveAPIView):
 
 
 class GroupTagMappingList(ListCreateAPIViewWithAudit):
-    queryset = GroupTagMapping.objects.all()
+    queryset = GroupTagMapping.objects.all().order_by("pk")
     serializer_class = GroupTagMappingSerializer
     filterset_fields = ('connection_id', 'group_email')
 

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -12,7 +12,8 @@ from rest_framework.views import APIView
 from accounts.api_authentication import APITokenAuthentication
 from zentral.core.events.base import EventRequest
 from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
-                               ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit)
+                               ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import JMESPathCheckCreated, JMESPathCheckDeleted, JMESPathCheckUpdated
 from .forms import AndroidAppSearchForm, DebPackageSearchForm, IOSAppSearchForm, MacOSAppSearchForm, ProgramsSearchForm
 from .models import (CurrentMachineSnapshot,
@@ -424,6 +425,7 @@ class JMESPathCheckList(generics.ListCreateAPIView):
     serializer_class = JMESPathCheckSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = JMESPathCheckFilter
+    pagination_class = MaxLimitOffsetPagination
 
     def perform_create(self, serializer):
         serializer.save()
@@ -457,6 +459,7 @@ class MetaBusinessUnitList(ListCreateAPIViewWithAudit):
     queryset = MetaBusinessUnit.objects.all()
     serializer_class = MetaBusinessUnitSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class MetaBusinessUnitDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -480,6 +483,7 @@ class TagList(ListCreateAPIViewWithAudit):
     queryset = Tag.objects.all()
     serializer_class = TagSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class TagDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -497,6 +501,7 @@ class TaxonomyList(ListCreateAPIViewWithAudit):
     queryset = Taxonomy.objects.all()
     serializer_class = TaxonomySerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class TaxonomyDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -419,7 +419,7 @@ class JMESPathCheckList(generics.ListCreateAPIView):
     """
     List, search by name or create JMESPath compliance checks.
     """
-    queryset = JMESPathCheck.objects.select_related("compliance_check").all()
+    queryset = JMESPathCheck.objects.select_related("compliance_check").all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = JMESPathCheckSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/zentral/contrib/monolith/api_views.py
+++ b/zentral/contrib/monolith/api_views.py
@@ -163,7 +163,7 @@ class CatalogDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class ConditionList(generics.ListCreateAPIView):
-    queryset = Condition.objects.all()
+    queryset = Condition.objects.all().order_by("name")
     serializer_class = ConditionSerializer
     permission_classes = (DefaultDjangoModelPermissions,)
     filter_backends = (filters.DjangoFilterBackend,)
@@ -188,7 +188,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     """
     List all Enrollments or create a new Enrollment
     """
-    queryset = Enrollment.objects.all()
+    queryset = Enrollment.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -273,7 +273,7 @@ class ManifestDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class ManifestCatalogList(ListCreateAPIViewWithAudit):
-    queryset = ManifestCatalog.objects.all()
+    queryset = ManifestCatalog.objects.all().order_by("catalog__name", "pk")
     serializer_class = ManifestCatalogSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
@@ -293,7 +293,7 @@ class ManifestCatalogDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class ManifestEnrollmentPackageList(generics.ListCreateAPIView):
-    queryset = ManifestEnrollmentPackage.objects.all()
+    queryset = ManifestEnrollmentPackage.objects.all().order_by("pk")
     serializer_class = ManifestEnrollmentPackageSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
@@ -315,7 +315,7 @@ class ManifestEnrollmentPackageDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class ManifestSubManifestList(ListCreateAPIViewWithAudit):
-    queryset = ManifestSubManifest.objects.all()
+    queryset = ManifestSubManifest.objects.all().order_by("sub_manifest__name", "pk")
     serializer_class = ManifestSubManifestSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
@@ -338,7 +338,7 @@ class ManifestSubManifestDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class SubManifestList(ListCreateAPIViewWithAudit):
-    queryset = SubManifest.objects.all()
+    queryset = SubManifest.objects.all().order_by("name", "pk")
     serializer_class = SubManifestSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
@@ -355,7 +355,7 @@ class SubManifestDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class SubManifestPkgInfoList(ListCreateAPIViewWithAudit):
-    queryset = SubManifestPkgInfo.objects.all()
+    queryset = SubManifestPkgInfo.objects.all().order_by("pkg_info_name", "pk")
     serializer_class = SubManifestPkgInfoSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)

--- a/zentral/contrib/monolith/api_views.py
+++ b/zentral/contrib/monolith/api_views.py
@@ -113,6 +113,7 @@ class RepositoryList(ListCreateAPIViewWithAudit):
     queryset = Repository.objects.all()
     serializer_class = RepositorySerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
     def on_commit_callback_extra(self, instance):
         notifier.send_notification("monolith.repository", str(instance.pk))
@@ -168,6 +169,7 @@ class ConditionList(generics.ListCreateAPIView):
     permission_classes = (DefaultDjangoModelPermissions,)
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConditionDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -193,6 +195,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     serializer_class = EnrollmentSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('manifest_id',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -261,6 +264,7 @@ class ManifestList(ListCreateAPIViewWithAudit):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("meta_business_unit_id", "name")
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ManifestDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -278,6 +282,7 @@ class ManifestCatalogList(ListCreateAPIViewWithAudit):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("manifest_id", "catalog_id")
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ManifestCatalogDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -298,6 +303,7 @@ class ManifestEnrollmentPackageList(generics.ListCreateAPIView):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("manifest_id", "builder")
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ManifestEnrollmentPackageDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -320,6 +326,7 @@ class ManifestSubManifestList(ListCreateAPIViewWithAudit):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("manifest_id", "sub_manifest_id")
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ManifestSubManifestDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -343,6 +350,7 @@ class SubManifestList(ListCreateAPIViewWithAudit):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class SubManifestDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -360,6 +368,7 @@ class SubManifestPkgInfoList(ListCreateAPIViewWithAudit):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('sub_manifest_id',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class SubManifestPkgInfoDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/munki/api_views.py
+++ b/zentral/contrib/munki/api_views.py
@@ -15,7 +15,7 @@ from .serializers import ConfigurationSerializer, EnrollmentSerializer, ScriptCh
 
 
 class ConfigurationList(ListCreateAPIViewWithAudit):
-    queryset = Configuration.objects.all()
+    queryset = Configuration.objects.all().order_by("name")
     serializer_class = ConfigurationSerializer
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
@@ -32,7 +32,7 @@ class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class EnrollmentList(generics.ListCreateAPIView):
-    queryset = Enrollment.objects.all()
+    queryset = Enrollment.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -67,7 +67,7 @@ class ScriptCheckFilter(filters.FilterSet):
 
 
 class ScriptCheckList(ListCreateAPIViewWithAudit):
-    queryset = ScriptCheck.objects.select_related("compliance_check").all()
+    queryset = ScriptCheck.objects.select_related("compliance_check").all().order_by("pk")
     serializer_class = ScriptCheckSerializer
     filterset_class = ScriptCheckFilter
 

--- a/zentral/contrib/munki/api_views.py
+++ b/zentral/contrib/munki/api_views.py
@@ -5,7 +5,8 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.views import APIView
 from accounts.api_authentication import APITokenAuthentication
 from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
-                               ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit)
+                               ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .models import Configuration, Enrollment, ScriptCheck
 from .osx_package.builder import MunkiZentralEnrollPkgBuilder
 from .serializers import ConfigurationSerializer, EnrollmentSerializer, ScriptCheckSerializer
@@ -20,6 +21,7 @@ class ConfigurationList(ListCreateAPIViewWithAudit):
     permission_classes = [DefaultDjangoModelPermissions]
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("name",)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -37,6 +39,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     serializer_class = EnrollmentSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("configuration_id",)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -70,6 +73,7 @@ class ScriptCheckList(ListCreateAPIViewWithAudit):
     queryset = ScriptCheck.objects.select_related("compliance_check").all().order_by("pk")
     serializer_class = ScriptCheckSerializer
     filterset_class = ScriptCheckFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ScriptCheckDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -11,7 +11,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_yaml.parsers import YAMLParser
 from accounts.api_authentication import APITokenAuthentication
-from zentral.utils.drf import DefaultDjangoModelPermissions, DjangoPermissionRequired
+from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
+                               MaxLimitOffsetPagination)
 from .events import post_osquery_pack_update_events
 from .models import Configuration, ConfigurationPack, Enrollment, Pack, Query, AutomaticTableConstruction, FileCategory
 from .linux_script.builder import OsqueryZentralEnrollScriptBuilder
@@ -38,6 +39,7 @@ class AutomaticTableConstructionList(generics.ListCreateAPIView):
     serializer_class = AutomaticTableConstructionSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = AutomaticTableConstructionFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class AutomaticTableConstructionDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -58,6 +60,7 @@ class ConfigurationList(generics.ListCreateAPIView):
     serializer_class = ConfigurationSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConfigurationDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -82,6 +85,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     queryset = Enrollment.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
+    pagination_class = MaxLimitOffsetPagination
 
 
 class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -160,6 +164,7 @@ class FileCategoryList(generics.ListCreateAPIView):
     serializer_class = FileCategorySerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = FileCategoryFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class FileCategoryDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -262,6 +267,7 @@ class PackList(generics.ListCreateAPIView):
     serializer_class = PackSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = PackFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class PackDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -284,6 +290,7 @@ class QueryList(generics.ListCreateAPIView):
     serializer_class = QuerySerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = QueryFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class QueryDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -306,6 +313,7 @@ class ConfigurationPackList(generics.ListCreateAPIView):
     serializer_class = ConfigurationPackSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = ConfigurationPackFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConfigurationPackDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -33,7 +33,7 @@ class AutomaticTableConstructionList(generics.ListCreateAPIView):
     """
     List all AutomaticTableConstructions or create a new AutomaticTableConstruction
     """
-    queryset = AutomaticTableConstruction.objects.all()
+    queryset = AutomaticTableConstruction.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = AutomaticTableConstructionSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -53,7 +53,7 @@ class ConfigurationList(generics.ListCreateAPIView):
     """
     List all Configurations, search Configuration by name, or create a new Configuration.
     """
-    queryset = Configuration.objects.all()
+    queryset = Configuration.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = ConfigurationSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -79,7 +79,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     """
     List all Enrollments or create a new Enrollment
     """
-    queryset = Enrollment.objects.all()
+    queryset = Enrollment.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
 
@@ -155,7 +155,7 @@ class FileCategoryList(generics.ListCreateAPIView):
     """
     List, Create file categories, search by name or configuration_id
     """
-    queryset = FileCategory.objects.all()
+    queryset = FileCategory.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = FileCategorySerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -257,7 +257,7 @@ class PackFilter(filters.FilterSet):
 
 
 class PackList(generics.ListCreateAPIView):
-    queryset = Pack.objects.all()
+    queryset = Pack.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = PackSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -279,7 +279,7 @@ class QueryFilter(filters.FilterSet):
 
 
 class QueryList(generics.ListCreateAPIView):
-    queryset = Query.objects.all()
+    queryset = Query.objects.all().order_by("name")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = QuerySerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -301,7 +301,7 @@ class ConfigurationPackFilter(filters.FilterSet):
 
 
 class ConfigurationPackList(generics.ListCreateAPIView):
-    queryset = ConfigurationPack.objects.all()
+    queryset = ConfigurationPack.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = ConfigurationPackSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/zentral/contrib/santa/api_views.py
+++ b/zentral/contrib/santa/api_views.py
@@ -28,7 +28,7 @@ class ConfigurationList(ListCreateAPIViewWithAudit):
     """
     List all Configurations, search Configuration by name, or create a new Configuration.
     """
-    queryset = Configuration.objects.all()
+    queryset = Configuration.objects.all().order_by("name")
     serializer_class = ConfigurationSerializer
     filterset_fields = ('name',)
 
@@ -51,7 +51,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     """
     List all Enrollments or create a new Enrollment
     """
-    queryset = Enrollment.objects.all()
+    queryset = Enrollment.objects.all().order_by("pk")
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -173,7 +173,7 @@ class RuleList(generics.ListCreateAPIView):
     """
     List, Create or search rules.
     """
-    queryset = Rule.objects.select_related("configuration", "ruleset", "target")
+    queryset = Rule.objects.select_related("configuration", "ruleset", "target").order_by("pk")
     permission_classes = (DefaultDjangoModelPermissions,)
     serializer_class = RuleSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/zentral/contrib/santa/api_views.py
+++ b/zentral/contrib/santa/api_views.py
@@ -16,7 +16,8 @@ from accounts.api_authentication import APITokenAuthentication
 from zentral.contrib.inventory.models import File, Tag
 from zentral.contrib.santa.utils import build_configuration_plist, build_configuration_profile
 from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
-                               ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit)
+                               ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import post_santa_ruleset_update_events, post_santa_rule_update_event
 from .models import Configuration, Rule, RuleSet, Target, Enrollment
 from .serializers import (RuleSerializer, RuleSetUpdateSerializer, ConfigurationSerializer,
@@ -31,6 +32,7 @@ class ConfigurationList(ListCreateAPIViewWithAudit):
     queryset = Configuration.objects.all().order_by("name")
     serializer_class = ConfigurationSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -56,6 +58,7 @@ class EnrollmentList(generics.ListCreateAPIView):
     serializer_class = EnrollmentSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('configuration_id',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
@@ -178,6 +181,7 @@ class RuleList(generics.ListCreateAPIView):
     serializer_class = RuleSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = RuleFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class RuleDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/zentral/core/probes/api_views.py
+++ b/zentral/core/probes/api_views.py
@@ -1,5 +1,6 @@
 from rest_framework.exceptions import ValidationError
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .models import Action, ProbeSource
 from .serializers import ActionSerializer, ProbeSourceSerializer
 from .sync import signal_probe_change
@@ -22,6 +23,7 @@ class ActionList(ListCreateAPIViewWithAudit):
     queryset = Action.objects.all().order_by("name")
     serializer_class = ActionSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
     def on_commit_callback_extra(self, instance):
         signal_probe_change()
@@ -36,3 +38,4 @@ class ProbeList(ListCreateAPIViewWithAudit):
     queryset = ProbeSource.objects.all()
     serializer_class = ProbeSourceSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination

--- a/zentral/core/probes/api_views.py
+++ b/zentral/core/probes/api_views.py
@@ -19,7 +19,7 @@ class ActionDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class ActionList(ListCreateAPIViewWithAudit):
-    queryset = Action.objects.all()
+    queryset = Action.objects.all().order_by("name")
     serializer_class = ActionSerializer
     filterset_fields = ('name',)
 

--- a/zentral/core/stores/api_views.py
+++ b/zentral/core/stores/api_views.py
@@ -1,6 +1,7 @@
 from rest_framework.exceptions import ValidationError
 from zentral.core.queues import queues
-from zentral.utils.drf import ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit
+from zentral.utils.drf import (ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .conf import stores
 from .models import Store
 from .serializers import StoreSerializer
@@ -39,6 +40,7 @@ class StoreList(ListCreateAPIViewWithAudit):
     queryset = Store.objects.all().order_by("name")
     serializer_class = StoreSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
     def on_commit_callback_extra(self, instance):
         signal_store_change(instance)

--- a/zentral/core/stores/api_views.py
+++ b/zentral/core/stores/api_views.py
@@ -36,7 +36,7 @@ class StoreDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 
 
 class StoreList(ListCreateAPIViewWithAudit):
-    queryset = Store.objects.all()
+    queryset = Store.objects.all().order_by("name")
     serializer_class = StoreSerializer
     filterset_fields = ('name',)
 


### PR DESCRIPTION
Zentral sets no `DEFAULT_PAGINATION_CLASS`, so DRF pagination is opt-in per view. 34 list endpoints never opted in and answered with every row in a bare JSON array.

The audit that started this had spot-checked 8 of them. I walked every `/api/` route, resolved the view class and checked `pagination_class` on everything that serves a list — the real count is 34. The other 51 `/api/` routes that are not DRF generic list views are detail views, actions and exports, none of which returns a bare list.

## ⚠️ This needs a goztl release before it ships

`goztl` v0.1.79 — the version the terraform provider pins — already routes every list method (and every `GetByName`/`GetBySlug`, which share the same private `list` helper) through `resolveAllPages`, and `maybePaginatedResults` accepts both the bare array and the envelope. So the shape change itself is handled.

**But following `next` is broken for the base URL the provider documents.** `resolveAllPages` strips the leading slash off the `next` URL and resolves the remainder against `Client.BaseURL`. With the documented `base_url = "https://zentral.example.com/api/"` that is a relative-path reference, so RFC 3986 merges it onto the base directory:

```
base       https://zentral.example.com/api/
next       https://zentral.example.com/api/inventory/tags/?limit=50&offset=50
resolved   https://zentral.example.com/api/api/inventory/tags/?limit=50&offset=50   <-- 404
```

Verified against Go 1.25 `(*url.URL).Parse`. goztl's own tests miss it because `setup()` builds the client from an `httptest` server URL, which has no path prefix — the merge is a no-op there. Dropping the `strings.TrimPrefix(next, "/")` fixes it (keeping the leading slash makes it an absolute-path reference, which replaces the base path and also keeps the configured host).

This bug is **already live** for the 36 endpoints that were paginated before this PR, for anyone holding more than one page of MDM artifacts, blueprints, DEP devices or turbo objects. This PR does not cause it — but it widens the blast radius onto exactly the high-count objects (tags, santa rules, osquery queries), so:

- fix + release goztl, bump the provider, **then** merge this
- or merge this and accept that `terraform plan` breaks against the affected endpoints past the first page

Nothing else consumes these endpoints as a bare list: no in-repo Python client, no frontend JS, and the provider only ever talks to the API through goztl.

## Pagination

All 34 views get `pagination_class = MaxLimitOffsetPagination`, the same 50/500 limits the other 36 list endpoints already use. The response shape changes:

```diff
-[{"id": 1, ...}]
+{"count": 1, "next": null, "previous": null, "results": [{"id": 1, ...}]}
```

None had to stay unpaginated.

## Ordering (why the first commit exists)

`LIMIT`/`OFFSET` over a queryset with no `ORDER BY` gives PostgreSQL no stability guarantee: a row can move between pages, so a client walking them sees it twice and misses another. 23 of the 34 had no ordering at all, and 5 more ordered on a non-unique column only, leaving ties to break arbitrarily across a page boundary. `resolveAllPages` walks every page, so this would have quietly produced wrong lists.

Adding `pagination_class` alone would therefore have shipped a half-broken result. The first commit gives all 28 a total ordering — the model's unique `name` where it has one, the primary key otherwise, and a `pk` tiebreaker appended to the partial ones. The querysets were previously unordered, so no promised order is being changed.

## Tests

- The list assertions across 15 existing test files move to the envelope: filter variants read `["results"]`, and the empty-result cases assert the whole `{count: 0, next: null, previous: null, results: []}`.
- New `tests/server_base/test_api_pagination.py`, in the same spirit as `test_template_perms.py` — it walks the URL conf rather than listing endpoints by hand, so it keeps working as endpoints are added:
    - one test fails if any `/api/` list view has no `pagination_class`, so the next one cannot land unpaginated by accident;
    - one calls **every** list endpoint (all 70, not just the 34 changed here), deriving the required permission from the view's model, and asserts the response carries exactly `count`/`next`/`previous`/`results` — an empty list still returns the envelope, so this needs no fixtures;
    - one holds the ratchet list of endpoints whose queryset is still unordered, so that list can only shrink.
- I checked all three actually bite, by un-paginating `TagList` and un-ordering `RuleList` and confirming each guard failed and named the endpoint.
- New `test_list_tag_pages` follows `next` to the end and asserts no row appears on two pages, plus `test_list_tag_max_limit` for the 500 cap. Nothing covered the `next` link before.

## Docs

The examples showed bare arrays. The envelope and the `limit`/`offset` parameters are now described once in the core app page, next to the API authentication section the app pages already link to, and the 20 list examples are wrapped. `/api/monolith/catalogs/` was already paginated and already documented wrong, so it is fixed here too, and two examples that carried a trailing comma are now valid JSON.

## Deliberately left out

- **13 endpoints are paginated but still unordered** (`/api/mdm/artifacts/`, `/api/mdm/devices/`, `/api/mdm/profiles/`, `/api/mdm/store_apps/`, … and `/api/accounts/token_issuers/oidc/`). Same defect as above, but pre-existing and live, and imposing an order on shipped endpoints is a separate decision. They are listed in `UNORDERED_LIST_ENDPOINTS` in the new guard test — shrink it, never grow it. Happy to do them in a follow-up.
- `docs/apps/mdm.md` documents pagination per endpoint with `limit`/`offset` bullets and `docs/apps/turbo.md` documents it once in prose. Both are accurate, so I left them alone rather than add a third pattern; they could later point at the core page like the others now do.
- A project-wide `DEFAULT_PAGINATION_CLASS` would make this fail safe instead of fail open. The new guard test covers the same ground without changing behaviour for every future view at once.

## Verification

Full suite green (`7804 tests, OK`), `ruff check` clean on every changed file, `mkdocs build --strict` exits 0, and 100% coverage on all 80 added non-test lines (checked by intersecting `coverage json` missing_lines with the `git diff -U0` hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
