### PR TITLE
santa: serialize the sync operations of a machine on its row lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Fixed Santa machines being reported out of sync when a rule sent during the curr
 Fixed a Santa rule that was added and removed during the same sync session being recorded as held by the machine when the session was lost: the discarded session turned the staged removal into a rule the client never received. If the rule was then created again, it matched the phantom ledger entry and was never sent, and the machine stayed out of sync until a clean sync. The removal of a rule staged during the same session is now dropped with the session it belongs to.
 
 
+The Santa sync operations of a machine are serialized on its enrolled machine row lock now. Santa retries a rule download after 30 seconds with the same cursor, and the retry could overlap the transaction of the original request, miss the batch it was staging, and skip it for good: the ledger counted rules the client never received. The rule downloads also pick up the sync session started by a concurrent preflight, instead of staging rules under a stale one.
+
+
 ## 2026.5
 
 

--- a/tests/santa/test_rule_engine.py
+++ b/tests/santa/test_rule_engine.py
@@ -1,6 +1,9 @@
+import threading
 import uuid
+from django.db import connection, connections, transaction
 from django.db.models import F
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit, Tag
 from zentral.contrib.santa.models import (Configuration, EnrolledMachine, Enrollment,
@@ -917,3 +920,153 @@ class SantaRuleEngineTestCase(TestCase):
         self.assertEqual(counts, {"rules_committed": 1, "removals_confirmed": 1, "rules_dropped": 0})
         self.assertEqual(MachineRule.objects.filter(enrolled_machine=enrolled_machine,
                                                     target=replaced_target).count(), 0)
+
+    def assertMachineLockTaken(self, ctx, taken=True):
+        lock_queries = [
+            q["sql"] for q in ctx.captured_queries
+            if "santa_enrolledmachine" in q["sql"] and "FOR UPDATE" in q["sql"]
+        ]
+        if taken:
+            self.assertTrue(lock_queries)
+        else:
+            self.assertEqual(lock_queries, [])
+
+    def test_get_next_rule_batch_takes_the_machine_lock(self):
+        self.create_rule()
+        with CaptureQueriesContext(connection) as ctx:
+            MachineRule.objects.get_next_rule_batch(self.enrolled_machine, [])
+        self.assertMachineLockTaken(ctx)
+
+    def test_commit_session_takes_the_machine_lock(self):
+        self.create_rule()
+        MachineRule.objects.get_next_rule_batch(self.enrolled_machine, [])
+        self.enrolled_machine.refresh_from_db()
+        with CaptureQueriesContext(connection) as ctx:
+            MachineRule.objects.commit_session(self.enrolled_machine, False)
+        self.assertMachineLockTaken(ctx)
+
+    def test_discard_session_takes_the_machine_lock(self):
+        with CaptureQueriesContext(connection) as ctx:
+            MachineRule.objects.discard_session(self.enrolled_machine)
+        self.assertMachineLockTaken(ctx)
+
+    def test_reconcile_sync_session_takes_the_machine_lock(self):
+        self.enrolled_machine.start_sync_session(False)
+        with CaptureQueriesContext(connection) as ctx:
+            self.enrolled_machine.reconcile_sync_session()
+        self.assertMachineLockTaken(ctx)
+
+    def test_reconcile_without_session_does_not_take_the_machine_lock(self):
+        # the common preflight path, without a dangling session, must stay lock free
+        with CaptureQueriesContext(connection) as ctx:
+            self.enrolled_machine.reconcile_sync_session()
+        self.assertMachineLockTaken(ctx, taken=False)
+
+    def test_rule_download_stages_under_the_current_row_session(self):
+        target, rule, serialized_rule = self.create_and_serialize_rule()
+        # a concurrent preflight started a session after the request loaded the machine
+        sync_session = get_random_string(8)
+        EnrolledMachine.objects.filter(pk=self.enrolled_machine.pk).update(
+            sync_session=sync_session, sync_session_clean=False
+        )
+        self.assertIsNone(self.enrolled_machine.sync_session)
+        rule_batch, response_cursor = MachineRule.objects.get_next_rule_batch(self.enrolled_machine, [])
+        self.assertEqual(rule_batch, [serialized_rule])
+        self.assertIsNone(response_cursor)
+        machine_rule = self.enrolled_machine.machinerule_set.get()
+        self.assertEqual(machine_rule.sync_session, sync_session)
+        # the row session was adopted, not replaced
+        self.enrolled_machine.refresh_from_db()
+        self.assertEqual(self.enrolled_machine.sync_session, sync_session)
+
+
+class SantaRuleEngineConcurrencyTestCase(TransactionTestCase):
+    def setUp(self):
+        self.configuration = Configuration.objects.create(name=get_random_string(256), batch_size=2)
+        self.meta_business_unit = MetaBusinessUnit.objects.create(name=get_random_string(64))
+        self.enrollment_secret = EnrollmentSecret.objects.create(meta_business_unit=self.meta_business_unit)
+        self.enrollment = Enrollment.objects.create(configuration=self.configuration,
+                                                    secret=self.enrollment_secret)
+        self.enrolled_machine = EnrolledMachine.objects.create(enrollment=self.enrollment,
+                                                               hardware_uuid=uuid.uuid4(),
+                                                               serial_number=get_random_string(64),
+                                                               client_mode=Configuration.MONITOR_MODE,
+                                                               santa_version="2024.5")
+        self.identifiers = set()
+        for _ in range(5):
+            target = Target.objects.create(type=Target.Type.BINARY, identifier=new_sha256())
+            Rule.objects.create(configuration=self.configuration, target=target, policy=Rule.Policy.ALLOWLIST)
+            self.identifiers.add(target.identifier)
+
+    def test_duplicate_rule_download_regenerates_the_in_flight_batch(self):
+        # santa retries a rule download with the same cursor after 30s. The retry must wait for
+        # the in-flight request and send its batch again: without the machine lock, it could not
+        # see the uncommitted staging, and skipped the batch for good.
+        with transaction.atomic():
+            batch1, cursor1 = MachineRule.objects.get_next_rule_batch(self.enrolled_machine, [])
+        self.assertEqual(len(batch1), 2)
+        staged = threading.Event()
+        release = threading.Event()
+        results = {}
+
+        def original_request():
+            # the in-flight request for cursor1, stalled after staging the second batch
+            try:
+                enrolled_machine = EnrolledMachine.objects.get(pk=self.enrolled_machine.pk)
+                with transaction.atomic():
+                    results["original"] = MachineRule.objects.get_next_rule_batch(enrolled_machine, [], cursor1)
+                    staged.set()
+                    release.wait(timeout=10)
+            except Exception as exception:
+                results["original_error"] = exception
+            finally:
+                staged.set()
+                connections.close_all()
+
+        def retried_request():
+            # the client timed out on the original request, and retries it with the same cursor
+            try:
+                staged.wait(timeout=10)
+                enrolled_machine = EnrolledMachine.objects.get(pk=self.enrolled_machine.pk)
+                with transaction.atomic():
+                    results["retry"] = MachineRule.objects.get_next_rule_batch(enrolled_machine, [], cursor1)
+            except Exception as exception:
+                results["retry_error"] = exception
+            finally:
+                connections.close_all()
+
+        original = threading.Thread(target=original_request)
+        retry = threading.Thread(target=retried_request)
+        original.start()
+        retry.start()
+        # give the retry the time to block on the machine lock before releasing the original
+        retry.join(timeout=1)
+        self.assertTrue(retry.is_alive(), "the retry did not wait for the in-flight request")
+        release.set()
+        original.join(timeout=10)
+        retry.join(timeout=10)
+        self.assertFalse(original.is_alive())
+        self.assertFalse(retry.is_alive())
+        self.assertIsNone(results.get("original_error"))
+        self.assertIsNone(results.get("retry_error"))
+        original_batch, _ = results["original"]
+        retry_batch, retry_cursor = results["retry"]
+        # the retry sent the second batch again, it did not skip to the third one
+        self.assertEqual([r["identifier"] for r in retry_batch],
+                         [r["identifier"] for r in original_batch])
+        self.assertIsNotNone(retry_cursor)
+        with transaction.atomic():
+            batch3, cursor3 = MachineRule.objects.get_next_rule_batch(self.enrolled_machine, [], retry_cursor)
+        self.assertEqual(len(batch3), 1)
+        self.assertIsNone(cursor3)
+        # the client received every rule exactly once
+        received = [r["identifier"] for r in batch1 + retry_batch + batch3]
+        self.assertEqual(len(received), 5)
+        self.assertEqual(set(received), self.identifiers)
+        self.enrolled_machine.refresh_from_db()
+        with transaction.atomic():
+            session_result = MachineRule.objects.commit_session(self.enrolled_machine, False)
+        self.assertEqual(session_result["rules_committed"], 5)
+        machine_rule_qs = self.enrolled_machine.machinerule_set.all()
+        self.assertEqual(machine_rule_qs.count(), 5)
+        self.assertEqual(machine_rule_qs.filter(cursor__isnull=True, sync_session__isnull=True).count(), 5)

--- a/zentral/contrib/santa/models.py
+++ b/zentral/contrib/santa/models.py
@@ -950,6 +950,17 @@ class EnrolledMachine(models.Model):
             )
         return ok
 
+    def acquire_sync_lock(self):
+        """Serialize the sync ledger operations of the machine on its own row lock.
+
+        Santa retries a sync request after 30s, so a duplicate request can overlap the
+        transaction of the original one, miss its uncommitted staging, and skip a batch
+        for good. Only the one machine row is ever locked, the lock is held until the
+        end of the request transaction. Returns the current row: the wait can outlast
+        a concurrent session change.
+        """
+        return EnrolledMachine.objects.select_for_update().get(pk=self.pk)
+
     def start_sync_session(self, clean, preflight_at=None, sync_ok=None):
         self.sync_session = get_random_string(8)
         self.sync_session_clean = clean
@@ -981,6 +992,9 @@ class EnrolledMachine(models.Model):
         """
         if self.sync_session is None:
             return {"sync_ok": self.sync_ok(), "lost_clean_session": False, "previous_session": None}
+        # the reads deciding the outcome of the session must not interleave with an
+        # in-flight rule download still staging rules for it
+        self.acquire_sync_lock()
         previous_session = {"id": self.sync_session, "clean": self.sync_session_clean}
 
         def discard():
@@ -1306,6 +1320,7 @@ class MachineRuleManager(models.Manager):
         The statements select rows on the state they had on entry, and no entry state is
         selected by more than one of them, so that none depends on the others.
         """
+        enrolled_machine.acquire_sync_lock()
         qs = self.filter(enrolled_machine=enrolled_machine, sync_session__isnull=False)
         rules_discarded, _ = qs.filter(staged_removal=False, committed_policy__isnull=True).delete()
         removals_discarded, _ = qs.filter(staged_removal=True, committed_policy__isnull=True).delete()
@@ -1325,6 +1340,7 @@ class MachineRuleManager(models.Manager):
 
         Returns what the session did to the ledger, for the postflight event.
         """
+        enrolled_machine.acquire_sync_lock()
         qs = self.filter(enrolled_machine=enrolled_machine)
         session_qs = qs.filter(sync_session=enrolled_machine.sync_session)
         rules_dropped = 0
@@ -1339,10 +1355,15 @@ class MachineRuleManager(models.Manager):
                 "rules_dropped": rules_dropped}
 
     def get_next_rule_batch(self, enrolled_machine, tags, cursor=None):
+        locked_machine = enrolled_machine.acquire_sync_lock()
+        # the wait for the lock can outlast a concurrent preflight, the rules have to be
+        # staged under the session it started, not under the one loaded with the request
+        enrolled_machine.sync_session = locked_machine.sync_session
+        enrolled_machine.sync_session_clean = locked_machine.sync_session_clean
         if enrolled_machine.sync_session is None:
             # a rule download without a preflight, the rules still have to be staged
             enrolled_machine.start_sync_session(False)
-        qs = self.filter(enrolled_machine=enrolled_machine).select_for_update()
+        qs = self.filter(enrolled_machine=enrolled_machine)
 
         # fresh start from the last known OK state: unstage the batches that have not been
         # acknowledged, they will be sent again


### PR DESCRIPTION
The `select_for_update()` in `get_next_rule_batch` was dead code: the queryset was only ever consumed through `.update()` and `.delete()`, which never emit `FOR UPDATE`, and the batch query is raw SQL without one. Nothing serialized concurrent sync requests for one machine.

## The failure

Santa gives a rule download 30 seconds before it retries it with the same cursor, so a server transaction that stalls past that is overlapped by a duplicate of the request it is still serving. The retry cannot see the batch the original transaction has staged but not committed: its cleanup rolls back nothing, its acknowledgment update matches zero rows once the original's row locks are released, and its batch query — running after the original committed — treats the staged batch as already sent and returns the next one. The client's download buffer never holds the skipped batch, but the postflight commits the whole session, so the ledger permanently counts up to `batch_size` rules the client never received. The machine then reports fewer rules than the ledger on every preflight, and nothing short of a clean sync converges it. This is one concrete mechanism behind the over-counting direction #1627 left out of scope.

## The fix

New `EnrolledMachine.acquire_sync_lock()` takes `select_for_update()` on the machine's own row — never more than that one row — and `ATOMIC_REQUESTS` holds the lock until the end of the request. It is taken at the top of `get_next_rule_batch`, `commit_session` and `discard_session`, and in `reconcile_sync_session` once it holds a session to settle. The common preflight path, with no dangling session, stays lock free, and a test pins that.

The rule download also adopts the sync session found on the locked row: the wait for the lock can outlast a concurrent preflight, and staging under the session loaded with the request would put rules under a session no postflight can commit. `commit_session` deliberately does not adopt — the client's postflight confirms the session it downloaded, not one a concurrent preflight just started.

## Tests

A `TransactionTestCase` replays the overlap with two threads: the original request stalls after staging the second batch, and the retry must wait on the row lock, receive the second batch again, and hand the client every rule exactly once across the batches it kept. It fails without the lock — the retry skips to the third batch. The lock emission of each entry point, the lock-free preflight path and the session adoption are pinned by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
