### PR TITLE
inventory: delete the cleanup orphans and history in bounded batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Fixed the MDM devices list moving devices between its pages: it sorted on the la
 Fixed nine MDM API list endpoints ignoring the `ordering` query parameter — the enrolled devices one and the eight artifact ones. They declared the orderings they accept, but not the filter backend that reads them, so the parameter was dropped without a word. Worse, that left the queries with no `ORDER BY` at all, and the `limit`/`offset` pages came back in whatever order PostgreSQL found convenient: a client walking the pages could miss rows and see others twice. The seven endpoints hanging off an artifact version — cert assets, data assets, declarations, profiles, provisioning profiles, enterprise apps and store apps — have no timestamps of their own and were ordering on a column that does not exist; they order on the artifact version timestamps they expose now. Every one of them breaks ties on the primary key, so a page boundary falling inside a group of rows created in the same instant stays put.
 
 
+The inventory history cleanup deletes in bounded batches now. Each table was purged with a single unbounded statement, so one transaction could delete millions of rows — most of them through the cascades of the archived machine snapshots — and hand the whole backlog of dead tuples to autovacuum at once. The nightly job could keep the database at its capacity ceiling for as long as it ran. Every batch is a transaction of its own now, the cutoffs used to trim the machine snapshot commit history are computed once for the whole run instead of once per statement, and a batch that hits an integrity error is retried on its own instead of restarting the table. A table that could not be purged reports the rows it did delete.
+
+
 ## 2026.5
 
 

--- a/tests/inventory/test_cleanup.py
+++ b/tests/inventory/test_cleanup.py
@@ -1,0 +1,186 @@
+from datetime import timedelta
+from unittest.mock import patch
+from django.db import IntegrityError, connection
+from django.test import TestCase
+from django.utils import timezone
+from zentral.contrib.inventory.models import MachineSnapshot, MachineSnapshotCommit, OSXAppInstance
+from zentral.contrib.inventory.utils.cleanup import MAX_ATTEMPTS, cleanup_inventory
+from .utils import create_ms
+
+
+class CleanupCursor:
+    # a real cursor that records the deleted batches, and can raise an IntegrityError on the
+    # first executions of one table query to exercise the retries without a concurrent writer
+    def __init__(self, fail_on=None, times=0):
+        self.fail_on = fail_on
+        self.times = times
+        self.failures = 0
+        self.query = None
+        self.batches = []
+
+    def __enter__(self):
+        self.ctx = connection.cursor()
+        self.cursor = self.ctx.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self.ctx.__exit__(*args)
+
+    def execute(self, query, params=None):
+        self.query = query
+        if self.fail_on and f"DELETE FROM {self.fail_on} " in query and self.failures < self.times:
+            self.failures += 1
+            raise IntegrityError("boom")
+        return self.cursor.execute(query, params)
+
+    def fetchall(self):
+        rows = self.cursor.fetchall()
+        if "DELETE FROM inventory_machinesnapshotcommit" in self.query:
+            self.batches.append([row[0] for row in rows])
+        return rows
+
+
+class InventoryCleanupTest(TestCase):
+    def cleanup(self, days=30, batch_size=1000, cursor=None):
+        results = {}
+        max_date = timezone.now() - timedelta(days=days)
+        if cursor is not None:
+            duration = cleanup_inventory(cursor, results.__setitem__, max_date, batch_size=batch_size)
+        else:
+            with connection.cursor() as new_cursor:
+                duration = cleanup_inventory(new_cursor, results.__setitem__, max_date, batch_size=batch_size)
+        return results, duration
+
+    def force_orphan_osx_app_instances(self, count):
+        pks = []
+        for i in range(count):
+            osx_app_instance, _ = OSXAppInstance.objects.commit({
+                "bundle_path": f"/Applications/Yolo{i}.app",
+                "app": {"bundle_id": "io.zentral.yolo", "bundle_name": f"Yolo{i}", "bundle_version_str": "1.0"},
+            })
+            pks.append(osx_app_instance.pk)
+        return pks
+
+    def force_machine_snapshot_commits(self, count, days):
+        commit = MachineSnapshotCommit.objects.get()
+        commits = [commit]
+        for version in range(2, count + 2):
+            commits.append(
+                MachineSnapshotCommit.objects.create(
+                    serial_number=commit.serial_number,
+                    source=commit.source,
+                    version=version,
+                    machine_snapshot=commit.machine_snapshot,
+                    parent=commits[-1],
+                )
+            )
+        # created_at is auto_now_add, it can only be set with an update. Each commit needs
+        # a distinct one: the cutoff is a strict comparison with the newest of the group.
+        for idx, commit in enumerate(commits):
+            MachineSnapshotCommit.objects.filter(pk=commit.pk).update(
+                created_at=timezone.now() - timedelta(days=days, hours=len(commits) - idx)
+            )
+        return [c.pk for c in commits[:-1]], commits[-1].pk
+
+    # results
+
+    def test_cleanup_reports_every_table(self):
+        create_ms()
+        results, duration = self.cleanup()
+        self.assertIn("machine_snapshot_commit", results)
+        self.assertIn("inventory_osxappinstance", results)
+        self.assertEqual(len(results), 24)
+        self.assertTrue(all(r["status"] == 0 for r in results.values()))
+        self.assertTrue(all(r["attempts"] == 1 for r in results.values()))
+        self.assertTrue(all(r["rowcount"] >= 0 for r in results.values()))
+        self.assertTrue(all(r["duration"] >= 0 for r in results.values()))
+        self.assertTrue(duration >= 0)
+
+    # machine snapshot commits
+
+    def test_cleanup_keeps_the_last_commit_of_a_machine(self):
+        create_ms()
+        commit = MachineSnapshotCommit.objects.get()
+        MachineSnapshotCommit.objects.filter(pk=commit.pk).update(created_at=timezone.now() - timedelta(days=365))
+        results, _ = self.cleanup()
+        self.assertEqual(results["machine_snapshot_commit"]["rowcount"], 0)
+        self.assertTrue(MachineSnapshotCommit.objects.filter(pk=commit.pk).exists())
+
+    def test_cleanup_deletes_the_older_commits_in_batches(self):
+        create_ms()
+        older_commit_pks, last_commit_pk = self.force_machine_snapshot_commits(5, days=365)
+        results, _ = self.cleanup(batch_size=2)
+        self.assertEqual(results["machine_snapshot_commit"]["rowcount"], 5)
+        self.assertEqual(MachineSnapshotCommit.objects.filter(pk__in=older_commit_pks).count(), 0)
+        last_commit = MachineSnapshotCommit.objects.get()
+        self.assertEqual(last_commit.pk, last_commit_pk)
+        self.assertIsNone(last_commit.parent_id)
+
+    def test_cleanup_deletes_the_newest_commits_first(self):
+        create_ms()
+        older_commit_pks, _ = self.force_machine_snapshot_commits(5, days=365)
+        with CleanupCursor() as cursor:
+            results, _ = self.cleanup(batch_size=2, cursor=cursor)
+        self.assertEqual(results["machine_snapshot_commit"]["rowcount"], 5)
+        # the rows of a batch are not deleted in any particular order, but each batch
+        # takes the highest ids left
+        newest_first = sorted(older_commit_pks, reverse=True)
+        self.assertEqual([sorted(batch, reverse=True) for batch in cursor.batches],
+                         [newest_first[:2], newest_first[2:4], newest_first[4:]])
+
+    def test_cleanup_keeps_the_recent_commits(self):
+        create_ms()
+        self.force_machine_snapshot_commits(3, days=0)
+        results, _ = self.cleanup(batch_size=2)
+        self.assertEqual(results["machine_snapshot_commit"]["rowcount"], 0)
+        self.assertEqual(MachineSnapshotCommit.objects.count(), 4)
+
+    # orphans
+
+    def test_cleanup_deletes_the_orphans_in_batches(self):
+        create_ms()
+        pks = self.force_orphan_osx_app_instances(5)
+        results, _ = self.cleanup(batch_size=2)
+        self.assertEqual(results["inventory_osxappinstance"]["rowcount"], 5)
+        self.assertEqual(OSXAppInstance.objects.filter(pk__in=pks).count(), 0)
+
+    def test_cleanup_keeps_the_linked_objects(self):
+        create_ms()
+        linked_pks = list(OSXAppInstance.objects.values_list("pk", flat=True))
+        self.assertTrue(len(linked_pks) > 0)
+        results, _ = self.cleanup(batch_size=1)
+        self.assertEqual(results["inventory_osxappinstance"]["rowcount"], 0)
+        self.assertEqual(OSXAppInstance.objects.filter(pk__in=linked_pks).count(), len(linked_pks))
+
+    def test_cleanup_deletes_the_archived_machine_snapshots(self):
+        create_ms()
+        machine_snapshot_pk = MachineSnapshot.objects.get().pk
+        MachineSnapshotCommit.objects.all().delete()
+        results, _ = self.cleanup(batch_size=1)
+        self.assertEqual(results["inventory_machinesnapshot"]["rowcount"], 1)
+        self.assertEqual(MachineSnapshot.objects.filter(pk=machine_snapshot_pk).count(), 0)
+
+    # integrity errors
+
+    def test_cleanup_retries_a_batch_after_an_integrity_error(self):
+        create_ms()
+        self.force_orphan_osx_app_instances(1)
+        with patch("zentral.contrib.inventory.utils.cleanup.time.sleep") as sleep:
+            with CleanupCursor("inventory_osxappinstance", 1) as cursor:
+                results, _ = self.cleanup(cursor=cursor)
+        sleep.assert_called_once_with(1)
+        self.assertEqual(results["inventory_osxappinstance"]["attempts"], 2)
+        self.assertEqual(results["inventory_osxappinstance"]["status"], 0)
+        self.assertEqual(results["inventory_osxappinstance"]["rowcount"], 1)
+
+    def test_cleanup_gives_up_on_a_batch_after_max_attempts(self):
+        create_ms()
+        self.force_orphan_osx_app_instances(1)
+        with patch("zentral.contrib.inventory.utils.cleanup.time.sleep"):
+            with CleanupCursor("inventory_osxappinstance", MAX_ATTEMPTS) as cursor:
+                results, _ = self.cleanup(cursor=cursor)
+        self.assertEqual(results["inventory_osxappinstance"]["attempts"], MAX_ATTEMPTS)
+        self.assertEqual(results["inventory_osxappinstance"]["status"], 1)
+        self.assertEqual(results["inventory_osxappinstance"]["rowcount"], 0)
+        # the tables after the failed one are still cleaned up
+        self.assertEqual(results["inventory_payload"]["status"], 0)

--- a/zentral/contrib/inventory/utils/cleanup.py
+++ b/zentral/contrib/inventory/utils/cleanup.py
@@ -16,18 +16,48 @@ __all__ = [
 logger = logging.getLogger("zentral.contrib.inventory.utils.cleanup")
 
 
-DELETE_MACHINE_SNAPSHOT_COMMIT_QUERY = """
-DELETE FROM inventory_machinesnapshotcommit AS msc
-USING (
-    SELECT serial_number, source_id,
-           LEAST(MAX(created_at), timestamp with time zone %s) as max_created_at
-    FROM inventory_machinesnapshotcommit
-    GROUP BY serial_number, source_id
-) AS msc_agg
-WHERE
-    msc.serial_number = msc_agg.serial_number
-    AND msc.source_id = msc_agg.source_id
-    AND msc.created_at < msc_agg.max_created_at;
+DELETE_BATCH_SIZE = 1000
+MAX_ATTEMPTS = 3
+
+
+MSC_CUTOFFS_TABLE = "msc_cleanup_cutoffs"
+
+DROP_MSC_CUTOFFS_QUERY = f"DROP TABLE IF EXISTS {MSC_CUTOFFS_TABLE}"
+
+# the cutoffs are computed once and reused by every batch. A snapshot commit
+# added while the batches are running only makes the frozen cutoff older than
+# the one a fresh aggregate would give, so the newest commit of a machine is
+# still never deleted.
+CREATE_MSC_CUTOFFS_QUERY = f"""
+CREATE TEMPORARY TABLE {MSC_CUTOFFS_TABLE} AS
+SELECT serial_number, source_id,
+       LEAST(MAX(created_at), timestamp with time zone %s) AS max_created_at
+FROM inventory_machinesnapshotcommit
+GROUP BY serial_number, source_id
+"""
+
+INDEX_MSC_CUTOFFS_QUERY = f"CREATE INDEX ON {MSC_CUTOFFS_TABLE} (serial_number, source_id)"
+
+ANALYZE_MSC_CUTOFFS_QUERY = f"ANALYZE {MSC_CUTOFFS_TABLE}"
+
+# the batches go from the highest id down. A commit is always more recent than its parent,
+# so deleting the children first spares the ON DELETE SET NULL updates that the parents
+# would otherwise trigger on rows deleted by a later batch anyway.
+DELETE_MACHINE_SNAPSHOT_COMMIT_QUERY = f"""
+WITH batch AS (
+    SELECT msc.id
+    FROM inventory_machinesnapshotcommit msc
+    JOIN {MSC_CUTOFFS_TABLE} cutoffs
+      ON msc.serial_number = cutoffs.serial_number
+     AND msc.source_id = cutoffs.source_id
+    WHERE msc.id < %s
+      AND msc.created_at < cutoffs.max_created_at
+    ORDER BY msc.id DESC
+    LIMIT %s
+)
+DELETE FROM inventory_machinesnapshotcommit
+WHERE id IN (SELECT id FROM batch)
+RETURNING id
 """
 
 
@@ -133,44 +163,77 @@ def get_cleanup_max_date(days=None):
     return timezone.now() - timedelta(days=days)
 
 
-def cleanup_inventory(cursor, result_callback, max_date):
-    # delete older machine snapshot commits
+def build_orphans_query(table, attr, links):
+    wheres = []
+    for idx, (fk_attr, fk_table) in enumerate(links):
+        # we use an alias for the fk_table to avoid collision with the table
+        # inventory_certificate references inventory_certificate for example
+        wheres.append(
+            f"NOT EXISTS (SELECT 1 FROM {fk_table} fkt{idx} WHERE {table}.{attr} = fkt{idx}.{fk_attr})"
+        )
+    wheres = " AND ".join(wheres)
+    return (
+        f"WITH batch AS ("
+        f" SELECT id FROM {table} WHERE id > %s AND {wheres} ORDER BY id LIMIT %s"
+        f") DELETE FROM {table} WHERE id IN (SELECT id FROM batch) RETURNING id"
+    )
+
+
+def run_batched_delete(cursor, query, batch_size, descending=False):
+    rowcount = attempts = 0
+    # bigger than any id, whatever the width of the column
+    last_id = 2 ** 63 - 1 if descending else 0
+    next_id = min if descending else max
+    while True:
+        batch = None
+        for attempt in range(MAX_ATTEMPTS):
+            if attempt:
+                time.sleep(attempt)
+            try:
+                cursor.execute(query, [last_id, batch_size])
+            except IntegrityError:
+                # rows can be linked again while we are deleting
+                logger.warning("Integrity error on delete batch, attempt %s/%s", attempt + 1, MAX_ATTEMPTS)
+            else:
+                batch = cursor.fetchall()
+                break
+        attempts = max(attempts, attempt + 1)
+        if batch is None:
+            return rowcount, attempts, False
+        rowcount += len(batch)
+        if len(batch) < batch_size:
+            return rowcount, attempts, True
+        # the deleted rows are not returned in any particular order
+        last_id = next_id(row[0] for row in batch)
+
+
+def cleanup_table(cursor, result_callback, key, query, batch_size, descending=False):
     start_t = time.time()
-    cursor.execute(DELETE_MACHINE_SNAPSHOT_COMMIT_QUERY, [max_date])
-    result_callback("machine_snapshot_commit", {"rowcount": cursor.rowcount,
-                                                "duration": time.time() - start_t,
-                                                "status": 0})
+    rowcount, attempts, ok = run_batched_delete(cursor, query, batch_size, descending)
+    if not ok:
+        logger.error("Could not purge table %s because of an integrity error", key)
+    result_callback(key, {"attempts": attempts,
+                          "rowcount": rowcount,
+                          "duration": time.time() - start_t,
+                          "status": 0 if ok else 1})
+
+
+def cleanup_inventory(cursor, result_callback, max_date, batch_size=DELETE_BATCH_SIZE):
+    start_t = time.time()
+
+    # delete older machine snapshot commits
+    cursor.execute(DROP_MSC_CUTOFFS_QUERY)
+    cursor.execute(CREATE_MSC_CUTOFFS_QUERY, [max_date])
+    cursor.execute(INDEX_MSC_CUTOFFS_QUERY)
+    cursor.execute(ANALYZE_MSC_CUTOFFS_QUERY)
+    try:
+        cleanup_table(cursor, result_callback, "machine_snapshot_commit",
+                      DELETE_MACHINE_SNAPSHOT_COMMIT_QUERY, batch_size, descending=True)
+    finally:
+        cursor.execute(DROP_MSC_CUTOFFS_QUERY)
 
     # orphans
     for table, attr, links in ORPHANS:
-        wheres = []
-        for idx, (fk_attr, fk_table) in enumerate(links):
-            # we use an alias for the fk_table to avoid collision with the table
-            # inventory_certificate references inventory_certificate for example
-            wheres.append(
-                f"NOT EXISTS (SELECT 1 FROM {fk_table} fkt{idx} WHERE {table}.{attr} = fkt{idx}.{fk_attr})"
-            )
-        wheres = " AND ".join(wheres)
-        query = f"DELETE FROM {table} WHERE {wheres}"
+        cleanup_table(cursor, result_callback, table, build_orphans_query(table, attr, links), batch_size)
 
-        # 3 attempts. Things could be added in the linked table while we are deleting.
-        # TODO: better?
-        for i in range(3):
-            if i:
-                print(f"Retry in {i}s…")
-                time.sleep(i)
-            orphan_start_t = time.time()
-            try:
-                cursor.execute(query)
-            except IntegrityError:
-                print(f"Could not purge table {table} because of an integrity error")
-            else:
-                result_callback(table, {"attempts": i + 1,
-                                        "rowcount": cursor.rowcount,
-                                        "duration": time.time() - orphan_start_t,
-                                        "status": 0})
-                break
-        else:
-            result_callback(table, {"attempts": i + 1,
-                                    "status": 1})
     return time.time() - start_t


### PR DESCRIPTION
The nightly inventory history cleanup purged every table with a single unbounded `DELETE`, so one transaction could remove millions of rows and hand the whole backlog of dead tuples to autovacuum at once. On a large installation the job became the peak database load of the day, saturating the cluster for its whole run.

Most of that volume is invisible in the statements. `DELETE FROM inventory_machinesnapshot` removes comparatively few rows, but the table has twelve `ON DELETE CASCADE` children, and the largest of them is orders of magnitude bigger than the snapshots themselves — so the statement that looks small is the one generating the write amplification, through deferred referential triggers that never show up in a query plan.

## What changed

Every delete is now a keyset-batched loop, bounded by `DELETE_BATCH_SIZE`:

```sql
WITH batch AS (SELECT id FROM {table} WHERE id > %s AND {wheres} ORDER BY id LIMIT %s)
DELETE FROM {table} WHERE id IN (SELECT id FROM batch) RETURNING id
```

The `id > %s` keyset matters: a plain `LIMIT n` loop would re-run the anti join from the top of the table on every iteration, which is quadratic and worse than what it replaces. Resuming on the primary key visits each row once across the whole loop, so the total read work is unchanged while each transaction stays bounded and autovacuum can keep pace between batches. All the tables in `ORPHANS` have an `id` primary key, checked against the schema rather than the migrations — most of the through tables are auto-created many-to-many tables whose indexes never appear there.

The machine snapshot commit history needed a different shape. Its plan scans the commit table twice, once for the aggregate that computes the per machine cutoff and once as the outer side of the join, so batching the statement as written would have repeated both scans per batch. The cutoffs are computed once into an indexed temporary table and the batches join against that — one aggregate pass instead of two. Freezing the cutoffs is safe under concurrency: a commit arriving mid run only makes the stored cutoff older than a fresh aggregate would give, so a machine's newest commit still cannot be deleted.

That history is deleted from the highest id down. A commit is always more recent than its parent, so deleting the children first spares the `ON DELETE SET NULL` updates that would otherwise fire on rows a later batch deletes anyway — each one a new row version plus entries in all seven of that table's indexes.

## Retries and reporting

The three attempt retry still earns its place, and the race is sharper than it looks: Django's foreign keys are `DEFERRABLE INITIALLY DEFERRED`, so a row linked again mid delete surfaces at commit rather than at the statement. The retry now applies to the batch instead of restarting the table, and reports through the logger instead of `print()`, which bypassed the management command's quiet flag.

The `result_callback` contract is unchanged — `rowcount` sums across batches, `duration` covers the table, and `attempts` still means "1 = no retries anywhere". Two small improvements: `attempts` is reported for the history trim too, and a table that could not be purged now reports the rows it did delete instead of dropping `rowcount` and `duration`.

## Notes

Indexing was ruled out first, on plans rather than assumption: the anti joins already use an index on every affected table, and the one covering index candidate for the history trim was refused by the planner.

`DELETE_BATCH_SIZE` is a single module constant. `inventory_machinesnapshot` is the table where it is arguably still coarse, since each row cascades several hundred children; a per table override would be an easy follow up if that proves necessary.

## Tests

New `tests/inventory/test_cleanup.py` covers the batch boundaries, the keyset resume, retention of linked rows and of each machine's newest commit, the descending order of the history batches, and both retry outcomes. Full suite green, 100% coverage on the changed lines.