### PR TITLE
mdm: order the paginated API list endpoints deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The Santa sync operations of a machine are serialized on its enrolled machine ro
 Fixed the Santa preflight writing away what another request committed on the same enrolled machine: it saved every column of a row read before the request did anything. Only the attributes the client reported are written now.
 
 
+Fixed nine MDM API list endpoints ignoring the `ordering` query parameter — the enrolled devices one and the eight artifact ones. They declared the orderings they accept, but not the filter backend that reads them, so the parameter was dropped without a word. Worse, that left the queries with no `ORDER BY` at all, and the `limit`/`offset` pages came back in whatever order PostgreSQL found convenient: a client walking the pages could miss rows and see others twice. The seven endpoints hanging off an artifact version — cert assets, data assets, declarations, profiles, provisioning profiles, enterprise apps and store apps — have no timestamps of their own and were ordering on a column that does not exist; they order on the artifact version timestamps they expose now. Every one of them breaks ties on the primary key, so a page boundary falling inside a group of rows created in the same instant stays put.
+
+
 ## 2026.5
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The Santa sync operations of a machine are serialized on its enrolled machine ro
 Fixed the Santa preflight writing away what another request committed on the same enrolled machine: it saved every column of a row read before the request did anything. Only the attributes the client reported are written now.
 
 
+Fixed the MDM devices list moving devices between its pages: it sorted on the last seen timestamp alone, and that timestamp is null until a device checks in, so every device that never did sorted equal and landed on whichever page the database felt like. The primary key breaks the ties now.
+
+
 Fixed nine MDM API list endpoints ignoring the `ordering` query parameter — the enrolled devices one and the eight artifact ones. They declared the orderings they accept, but not the filter backend that reads them, so the parameter was dropped without a word. Worse, that left the queries with no `ORDER BY` at all, and the `limit`/`offset` pages came back in whatever order PostgreSQL found convenient: a client walking the pages could miss rows and see others twice. The seven endpoints hanging off an artifact version — cert assets, data assets, declarations, profiles, provisioning profiles, enterprise apps and store apps — have no timestamps of their own and were ordering on a column that does not exist; they order on the artifact version timestamps they expose now. Every one of them breaks ties on the primary key, so a page boundary falling inside a group of rows created in the same instant stays put.
 
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -882,6 +882,13 @@ Response:
      * `excluded_tags`
      * `short_name`
      * `email`
+ * available orderings:
+     * `created_at`
+     * `last_seen_at`
+     * `updated_at`
+ * pagination:
+     * `limit` (max `500`, `50` by default)
+     * `offset`
 
 Use this endpoint to list the MDM enrolled devices.
 

--- a/tests/mdm/test_api_artifacts_views.py
+++ b/tests/mdm/test_api_artifacts_views.py
@@ -7,12 +7,13 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.mdm.models import Artifact
 from zentral.core.events.base import AuditEvent
 from .utils import force_artifact, force_blueprint_artifact
 
 
-class MDMArtifactsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMArtifactsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -106,6 +107,18 @@ class MDMArtifactsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': artifact.updated_at.isoformat()}
              ]}
         )
+
+    def test_list_artifacts_ordering(self):
+        artifacts = [force_artifact()[0] for _ in range(3)]
+        ascending_ids = self.given_ordered_rows([(a, str(a.pk)) for a in artifacts])
+        self.set_permissions("mdm.view_artifact")
+        self.assert_list_ordering(reverse("mdm_api:artifacts"), ascending_ids)
+
+    def test_list_artifacts_pagination_pages_every_artifact_once(self):
+        artifacts = [force_artifact()[0] for _ in range(3)]
+        ascending_ids = self.given_ordered_rows([(a, str(a.pk)) for a in artifacts])
+        self.set_permissions("mdm.view_artifact")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:artifacts"), ascending_ids)
 
     # get artifact
 

--- a/tests/mdm/test_api_cert_assets_views.py
+++ b/tests/mdm/test_api_cert_assets_views.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from zentral.contrib.mdm.models import (
     Artifact,
@@ -25,7 +26,7 @@ from .utils import (
 )
 
 
-class MDMCertAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMCertAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -114,6 +115,18 @@ class MDMCertAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   "version": 1}
               ]}
         )
+
+    def test_list_cert_assets_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.CERT_ASSET)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_certasset")
+        self.assert_list_ordering(reverse("mdm_api:cert_assets"), ascending_ids)
+
+    def test_list_cert_assets_pagination_pages_every_cert_asset_once(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.CERT_ASSET)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_certasset")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:cert_assets"), ascending_ids)
 
     # create cert asset
 

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from zentral.contrib.mdm.models import Artifact, ArtifactVersion, ArtifactVersionTag, DeviceArtifact, TargetArtifact
 from zentral.core.events.base import AuditEvent
@@ -18,7 +19,7 @@ from .utils import (build_plistfile, build_zipfile,
                     force_artifact, force_blueprint_artifact, force_dep_enrollment_session)
 
 
-class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -99,6 +100,18 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': ea_av.updated_at.isoformat()}
               ]}
         )
+
+    def test_list_data_assets_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.DATA_ASSET)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_dataasset")
+        self.assert_list_ordering(reverse("mdm_api:data_assets"), ascending_ids)
+
+    def test_list_data_assets_pagination_pages_every_data_asset_once(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.DATA_ASSET)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_dataasset")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:data_assets"), ascending_ids)
 
     # create data asset
 

--- a/tests/mdm/test_api_declarations_views.py
+++ b/tests/mdm/test_api_declarations_views.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from django.core.files.uploadedfile import SimpleUploadedFile
 from zentral.contrib.mdm.models import (Artifact, ArtifactVersion, ArtifactVersionTag,
@@ -16,7 +17,7 @@ from zentral.core.events.base import AuditEvent
 from .utils import force_artifact, force_blueprint_artifact, force_dep_enrollment_session
 
 
-class MDMDeclarationsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMDeclarationsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -100,6 +101,18 @@ class MDMDeclarationsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': av.updated_at.isoformat()}
               ]}
         )
+
+    def test_list_declarations_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.CONFIGURATION)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_declaration")
+        self.assert_list_ordering(reverse("mdm_api:declarations"), ascending_ids)
+
+    def test_list_declarations_pagination_pages_every_declaration_once(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.CONFIGURATION)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_declaration")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:declarations"), ascending_ids)
 
     # create declaration
 

--- a/tests/mdm/test_api_enrolled_devices_views.py
+++ b/tests/mdm/test_api_enrolled_devices_views.py
@@ -12,6 +12,7 @@ from django.utils.crypto import get_random_string
 
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MachineTag, MetaBusinessUnit, Tag
 from zentral.contrib.mdm.commands import (
     RotateFileVaultKey,
@@ -38,7 +39,7 @@ from .utils import (
 )
 
 
-class APIViewsTestCase(TestCase, LoginCase, RequestCase):
+class APIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -458,6 +459,24 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
+
+    def test_enrolled_devices_ordering(self):
+        enrolled_devices = [self.enrolled_device] + [
+            force_dep_enrollment_session(self.mbu, authenticated=True, completed=True)[0].enrolled_device
+            for _ in range(2)
+        ]
+        ascending_ids = self.given_ordered_rows([(d, d.id) for d in enrolled_devices])
+        self.set_permissions("mdm.view_enrolleddevice")
+        self.assert_list_ordering(reverse("mdm_api:enrolled_devices"), ascending_ids)
+
+    def test_enrolled_devices_pagination_pages_every_device_once(self):
+        enrolled_devices = [self.enrolled_device] + [
+            force_dep_enrollment_session(self.mbu, authenticated=True, completed=True)[0].enrolled_device
+            for _ in range(2)
+        ]
+        ascending_ids = self.given_ordered_rows([(d, d.id) for d in enrolled_devices])
+        self.set_permissions("mdm.view_enrolleddevice")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:enrolled_devices"), ascending_ids)
 
     # block enrolled device
 

--- a/tests/mdm/test_api_enterprise_apps_views.py
+++ b/tests/mdm/test_api_enterprise_apps_views.py
@@ -13,6 +13,7 @@ from django.utils.crypto import get_random_string
 from tests.utils.packages import build_dummy_package
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from zentral.contrib.mdm.models import Artifact, ArtifactVersion, ArtifactVersionTag, DeviceArtifact, TargetArtifact
 from zentral.core.events.base import AuditEvent
@@ -20,7 +21,7 @@ from zentral.core.events.base import AuditEvent
 from .utils import force_artifact, force_blueprint_artifact, force_dep_enrollment_session
 
 
-class MDMEnterpriseAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMEnterpriseAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -123,6 +124,18 @@ class MDMEnterpriseAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': ea_av.updated_at.isoformat()}
               ]}
         )
+
+    def test_list_enterprise_apps_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.ENTERPRISE_APP)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_enterpriseapp")
+        self.assert_list_ordering(reverse("mdm_api:enterprise_apps"), ascending_ids)
+
+    def test_list_enterprise_apps_pagination_pages_every_enterprise_app_once(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.ENTERPRISE_APP)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_enterpriseapp")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:enterprise_apps"), ascending_ids)
 
     # create enterprise app
 

--- a/tests/mdm/test_api_profiles_views.py
+++ b/tests/mdm/test_api_profiles_views.py
@@ -9,13 +9,14 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from zentral.contrib.mdm.models import ArtifactVersion, ArtifactVersionTag, DeviceArtifact, TargetArtifact
 from zentral.core.events.base import AuditEvent
 from .utils import build_mobileconfig_data, force_artifact, force_blueprint_artifact, force_dep_enrollment_session
 
 
-class MDMProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -93,6 +94,18 @@ class MDMProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': profile_av.updated_at.isoformat()}
               ]}
         )
+
+    def test_list_profiles_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_profile")
+        self.assert_list_ordering(reverse("mdm_api:profiles"), ascending_ids)
+
+    def test_list_profiles_pagination_pages_every_profile_once(self):
+        _, artifact_versions = force_artifact(version_count=3)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_profile")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:profiles"), ascending_ids)
 
     # create profile
 

--- a/tests/mdm/test_api_provisioning_profiles_views.py
+++ b/tests/mdm/test_api_provisioning_profiles_views.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from zentral.contrib.mdm.models import Artifact, ArtifactVersion, ArtifactVersionTag, DeviceArtifact, TargetArtifact
 from zentral.core.events.base import AuditEvent
@@ -17,7 +18,7 @@ from .utils import (build_provisioning_profile, build_provisioning_profile_conte
                     force_artifact, force_blueprint_artifact, force_dep_enrollment_session)
 
 
-class MDMProvisioningProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMProvisioningProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -95,6 +96,18 @@ class MDMProvisioningProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': av.updated_at.isoformat()}
               ]}
         )
+
+    def test_list_provisioning_profiles_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.PROVISIONING_PROFILE)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_provisioningprofile")
+        self.assert_list_ordering(reverse("mdm_api:provisioning_profiles"), ascending_ids)
+
+    def test_list_provisioning_profiles_pagination_pages_every_provisioning_profile_once(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.PROVISIONING_PROFILE)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_provisioningprofile")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:provisioning_profiles"), ascending_ids)
 
     # create provisioning profile
 

--- a/tests/mdm/test_api_store_apps_views.py
+++ b/tests/mdm/test_api_store_apps_views.py
@@ -7,13 +7,14 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from tests.zentral_test_utils.list_ordering_case import ListOrderingCase
 from zentral.contrib.inventory.models import MetaBusinessUnit, Tag
 from zentral.contrib.mdm.models import Artifact, ArtifactVersion, ArtifactVersionTag, DeviceArtifact, TargetArtifact
 from zentral.core.events.base import AuditEvent
 from .utils import force_artifact, force_blueprint_artifact, force_dep_enrollment_session, force_location_asset
 
 
-class MDMStoreAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
+class MDMStoreAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderingCase):
     maxDiff = None
 
     @classmethod
@@ -100,6 +101,18 @@ class MDMStoreAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase):
                   'updated_at': sa_av.updated_at.isoformat()}
               ]}
         )
+
+    def test_list_store_apps_ordering(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.STORE_APP)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_storeapp")
+        self.assert_list_ordering(reverse("mdm_api:store_apps"), ascending_ids)
+
+    def test_list_store_apps_pagination_pages_every_store_app_once(self):
+        _, artifact_versions = force_artifact(version_count=3, artifact_type=Artifact.Type.STORE_APP)
+        ascending_ids = self.given_ordered_rows([(av, str(av.pk)) for av in artifact_versions])
+        self.set_permissions("mdm.view_storeapp")
+        self.assert_list_pages_every_row_once(reverse("mdm_api:store_apps"), ascending_ids)
 
     # create store app
 

--- a/tests/mdm/test_api_store_apps_views.py
+++ b/tests/mdm/test_api_store_apps_views.py
@@ -283,7 +283,6 @@ class MDMStoreAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderin
                      'tvos_max_version': '',
                      'tvos_min_version': '',
                      'version': 17,
-                     'remove_on_unenroll': True,
                      'location_asset': {
                          'asset': {
                              'adam_id': location_asset.asset.adam_id,

--- a/tests/zentral_test_utils/list_ordering_case.py
+++ b/tests/zentral_test_utils/list_ordering_case.py
@@ -1,0 +1,45 @@
+from datetime import timedelta
+from urllib.parse import urlencode
+
+from django.utils import timezone
+
+
+class ListOrderingCase:
+    """Assertions for the ordered, LIMIT/OFFSET paginated API list endpoints."""
+
+    # Scrambled on purpose: the rows are inserted in an order that matches neither ordering
+    # direction, so an endpoint that drops ?ordering= on the floor fails both assertions of
+    # assert_list_ordering instead of passing one of them by luck.
+    _ORDERING_HOURS = (1, 3, 2)
+
+    def given_ordered_rows(self, rows):
+        """Backdate every row the endpoint returns, as (instance carrying created_at, response id)
+        pairs, and return the response ids in ascending created_at order."""
+        now = timezone.now()
+        stamped = []
+        for hours, (instance, row_id) in zip(self._ORDERING_HOURS, rows, strict=True):
+            instance.created_at = now - timedelta(hours=hours)
+            instance.save()
+            stamped.append((instance.created_at, row_id))
+        return [row_id for _, row_id in sorted(stamped)]
+
+    def assert_list_ordering(self, url, ascending_ids):
+        for ordering, expected in (("created_at", ascending_ids),
+                                   ("-created_at", ascending_ids[::-1])):
+            with self.subTest(ordering=ordering):
+                response = self.get(f"{url}?{urlencode({'ordering': ordering})}")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual([row["id"] for row in response.json()["results"]], expected)
+
+    def assert_list_pages_every_row_once(self, url, ascending_ids, limit=2):
+        seen = []
+        next_url = f"{url}?{urlencode({'limit': limit})}"
+        while next_url:
+            response = self.get(next_url)
+            self.assertEqual(response.status_code, 200)
+            page = response.json()
+            self.assertEqual(page["count"], len(ascending_ids))
+            seen.extend(row["id"] for row in page["results"])
+            next_url = page["next"]
+        # no ?ordering=, so this also pins the default ordering of the endpoint
+        self.assertEqual(seen, ascending_ids[::-1])

--- a/zentral/contrib/mdm/api_views/artifacts.py
+++ b/zentral/contrib/mdm/api_views/artifacts.py
@@ -1,5 +1,8 @@
 from django.db import transaction
+from django.db.models import F
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 from zentral.utils.drf import (ListCreateAPIViewWithAudit,
                                MaxLimitOffsetPagination,
                                RetrieveUpdateDestroyAPIViewWithAudit)
@@ -13,6 +16,25 @@ from zentral.contrib.mdm.serializers import (ArtifactSerializer, CertAssetSerial
                                              ProvisioningProfileSerializer, StoreAppSerializer)
 
 
+# artifact version satellites
+
+# CertAsset, DataAsset, Declaration, Profile, ProvisioningProfile, EnterpriseApp and StoreApp are
+# one-to-one satellites of ArtifactVersion and have no timestamps of their own. The ordering keys are
+# annotated from the artifact version, so that ?ordering= takes the names the serializers expose.
+class ArtifactVersionOrderingMixin:
+    filter_backends = (DjangoFilterBackend, OrderingFilter)
+    ordering_fields = ("created_at", "updated_at")
+    # LIMIT/OFFSET pagination is only stable on a total order, and created_at is not unique: without
+    # the pk tiebreaker a tie straddling a page boundary can skip rows and repeat others.
+    ordering = ["-created_at", "-pk"]
+
+    def get_queryset(self):
+        return super().get_queryset().annotate(
+            created_at=F("artifact_version__created_at"),
+            updated_at=F("artifact_version__updated_at"),
+        ).order_by(*self.ordering)
+
+
 # artifacts
 
 
@@ -20,10 +42,12 @@ class ArtifactList(ListCreateAPIViewWithAudit):
     """
     List all Artifacts, search Artifact by name, or create a new Artifact.
     """
-    queryset = Artifact.objects.all()
+    queryset = Artifact.objects.all().order_by("-created_at", "-pk")
     serializer_class = ArtifactSerializer
+    filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_fields = ('name',)
-    ordering = ['-created_at']
+    ordering_fields = ('created_at', 'updated_at')
+    ordering = ['-created_at', '-pk']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -53,7 +77,7 @@ class ArtifactDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # cert assets
 
 
-class CertAssetList(ListCreateAPIViewWithAudit):
+class CertAssetList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all CertAssets or create a new CertAsset
     """
@@ -64,7 +88,6 @@ class CertAssetList(ListCreateAPIViewWithAudit):
                                            "artifact_version__item_tags__tag__meta_business_unit",
                                            "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = CertAssetSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -104,7 +127,7 @@ class CertAssetDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # data assets
 
 
-class DataAssetList(ListCreateAPIViewWithAudit):
+class DataAssetList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all DataAssets or create a new DataAsset
     """
@@ -114,7 +137,6 @@ class DataAssetList(ListCreateAPIViewWithAudit):
                                            "artifact_version__item_tags__tag__meta_business_unit",
                                            "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = DataAssetSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -153,7 +175,7 @@ class DataAssetDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # declarations
 
 
-class DeclarationList(ListCreateAPIViewWithAudit):
+class DeclarationList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all Declarations or create a new Declaration.
     """
@@ -163,7 +185,6 @@ class DeclarationList(ListCreateAPIViewWithAudit):
                                              "artifact_version__item_tags__tag__meta_business_unit",
                                              "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = DeclarationSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -202,7 +223,7 @@ class DeclarationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # profiles
 
 
-class ProfileList(ListCreateAPIViewWithAudit):
+class ProfileList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all Profiles or create a new Profile
     """
@@ -212,7 +233,6 @@ class ProfileList(ListCreateAPIViewWithAudit):
                                          "artifact_version__item_tags__tag__meta_business_unit",
                                          "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = ProfileSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -251,7 +271,7 @@ class ProfileDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # provisioning profiles
 
 
-class ProvisioningProfileList(ListCreateAPIViewWithAudit):
+class ProvisioningProfileList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all Provisioning Profiles or create a new Provisioning Profile
     """
@@ -261,7 +281,6 @@ class ProvisioningProfileList(ListCreateAPIViewWithAudit):
                                                      "artifact_version__item_tags__tag__meta_business_unit",
                                                      "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = ProvisioningProfileSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -300,7 +319,7 @@ class ProvisioningProfileDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # enterprise apps
 
 
-class EnterpriseAppList(ListCreateAPIViewWithAudit):
+class EnterpriseAppList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all EnterpriseApps or create a new EnterpriseApp
     """
@@ -310,7 +329,6 @@ class EnterpriseAppList(ListCreateAPIViewWithAudit):
                                                "artifact_version__item_tags__tag__meta_business_unit",
                                                "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = EnterpriseAppSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests
@@ -348,7 +366,7 @@ class EnterpriseAppDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # store apps
 
 
-class StoreAppList(ListCreateAPIViewWithAudit):
+class StoreAppList(ArtifactVersionOrderingMixin, ListCreateAPIViewWithAudit):
     """
     List all StoreApps or create a new StoreApp
     """
@@ -358,7 +376,6 @@ class StoreAppList(ListCreateAPIViewWithAudit):
                                           "artifact_version__item_tags__tag__meta_business_unit",
                                           "artifact_version__item_tags__tag__taxonomy"))
     serializer_class = StoreAppSerializer
-    ordering = ['-created_at']
     pagination_class = MaxLimitOffsetPagination
 
     @transaction.non_atomic_requests

--- a/zentral/contrib/mdm/api_views/enrolled_devices.py
+++ b/zentral/contrib/mdm/api_views/enrolled_devices.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -140,13 +141,16 @@ class EnrolledDeviceList(ListAPIView):
                 output_field=JSONField(),
             )
         )
+        # LIMIT/OFFSET pagination is only stable on a total order, and created_at is not unique:
+        # without the pk tiebreaker a tie straddling a page boundary can skip rows and repeat others.
+        .order_by("-created_at", "-pk")
     )
     serializer_class = EnrolledDeviceSerializer
     permission_classes = [DefaultDjangoModelPermissions]
-    filter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (filters.DjangoFilterBackend, OrderingFilter)
     filterset_class = EnrolledDeviceFilter
     ordering_fields = ('created_at', 'last_seen_at', 'updated_at')
-    ordering = ['-created_at']
+    ordering = ['-created_at', '-pk']
     pagination_class = MaxLimitOffsetPagination
 
 

--- a/zentral/contrib/mdm/forms.py
+++ b/zentral/contrib/mdm/forms.py
@@ -271,7 +271,9 @@ class EnrolledDeviceSearchForm(forms.Form):
             artifact_choices.append((f"av_{artifact_version.pk}", str(artifact_version)))
 
     def get_queryset(self):
-        qs = EnrolledDevice.objects.all().order_by(F("last_seen_at").desc(nulls_last=True))
+        # the primary key breaks the ties: last_seen_at is null until a device checks in, so the
+        # devices that never did are all equal for the sort and would shuffle between the pages
+        qs = EnrolledDevice.objects.all().order_by(F("last_seen_at").desc(nulls_last=True), "-pk")
         # q
         q = self.cleaned_data.get("q")
         if q:


### PR DESCRIPTION
Nine MDM API list endpoints declared `ordering` / `ordering_fields` without `rest_framework.filters.OrderingFilter` in `filter_backends`. DRF only reads `view.ordering` from `OrderingFilter.get_default_ordering()`, so both attributes were dead code:

* `?ordering=` was silently dropped — no 400, the caller could not tell.
* The querysets reached the database with **no `ORDER BY` at all**, so `limit`/`offset` pages came back in whatever order PostgreSQL found convenient. A client walking the pages could miss rows and see others twice.

None of the nine models has a `Meta.ordering` to fall back on.

## The artifact version satellites were ordering on a column that does not exist

Seven of the eight artifact endpoints — cert assets, data assets, declarations, profiles, provisioning profiles, enterprise apps, store apps — are 1:1 satellites of `ArtifactVersion` and have **no `created_at` of their own**; their timestamps live on the artifact version. `CertAsset.objects.order_by("-created_at")` and friends raise `FieldError`. That went unnoticed precisely because the attribute was never read.

They now order on the artifact version timestamps, annotated under the names the serializers already return, so `?ordering=created_at` does not have to name the relation.

## Why per view and not the base class

Adding `OrderingFilter` to `ListCreateAPIViewWithAudit` would have fixed all eight artifact views in one line, but it would also have:

* turned the dead `ordering` on those seven views into a `FieldError` — an immediate **500 on every list request**; and
* opened `?ordering=` on every other list view built on the base class, resolved against serializer fields rather than a reviewed allow-list.

So the backend is added per view, and each view declares an explicit `ordering_fields`.

## Tiebreakers

Every endpoint breaks ties on the primary key — `created_at` is not unique, and a tie straddling a page boundary reintroduces the skip/duplicate. The tiebreaker is in the `ordering` attribute (because `OrderingFilter` replaces the queryset ordering wholesale, which would otherwise make a queryset-only tiebreaker dead in the default path) **and** on the queryset itself, so the endpoints stay deterministic if the backend is ever dropped again.

## Tests

18 new tests, two per endpoint, sharing a `ListOrderingCase` helper. The three rows are inserted in a scrambled `created_at` order so the natural row order matches neither direction: both `?ordering=created_at` and `?ordering=-created_at` fail without the fix, and so does the pagination test.

Reverting just the two view files and keeping the tests gives **14 failures**, including `[13, 14, 15] != [14, 15, 13]` on enrolled devices — pure insertion order, no `ORDER BY`.

## Verification

* Full suite as CI runs it: **7848 tests, OK**.
* Patch coverage: **0 uncovered** of 23 executable lines added to the two view modules.
* `ruff` and `flake8` clean; `mkdocs build --strict` passes.

## Known remaining gap

When a caller passes an explicit `?ordering=created_at`, `OrderingFilter` calls `order_by("created_at")` and drops the pk tiebreaker, so explicit orderings can still skip/duplicate at a page boundary. This predates the change and also affects the endpoints that already had the backend (`dep.py`, `dep_enrollments.py`, `accounts`). Closing it means an `OrderingFilter` subclass in `zentral/utils/drf.py` that appends a pk term to whatever ordering it resolves — shared code touching endpoints outside this fix, so it is left for a separate review.

## Second commit

An unrelated pre-existing nit in the same area: the expected store app audit event payload listed `remove_on_unenroll` twice. Both copies carried the same value so no assertion was wrong, but it was the last repeated dict key in the tree. Split into its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)