### PR TITLE
mdm: order the blueprint artifact serialization deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Fixed nine MDM API list endpoints ignoring the `ordering` query parameter — th
 The inventory history cleanup deletes in bounded batches now. Each table was purged with a single unbounded statement, so one transaction could delete millions of rows — most of them through the cascades of the archived machine snapshots — and hand the whole backlog of dead tuples to autovacuum at once. The nightly job could keep the database at its capacity ceiling for as long as it ran. Every batch is a transaction of its own now, the cutoffs used to trim the machine snapshot commit history are computed once for the whole run instead of once per statement, and a batch that hits an integrity error is retried on its own instead of restarting the table. A table that could not be purged reports the rows it did delete.
 
 
+Fixed a blueprint serializing its artifacts differently from one update to the next, over the very same data: the artifacts a blueprint holds, the artifacts an artifact requires and the artifacts a declaration references were all read without an order, and PostgreSQL is free to return them in whichever order suits it. That order was the order the devices saw — the sequence in which they installed artifacts that do not depend on each other, and the order of the declaration items they were handed. The required and referenced artifacts are sorted by name now, and the artifacts of a blueprint keep the order in which they were added to it.
+
+
 ## 2026.5
 
 

--- a/tests/mdm/test_artifacts.py
+++ b/tests/mdm/test_artifacts.py
@@ -272,6 +272,44 @@ class TestMDMArtifacts(TestCase):
         )
         self.assertEqual(set(artifact.platforms), set(Platform.values))
 
+    # blueprint serialized artifacts
+
+    def test_serialized_artifacts_requires_sorted(self):
+        required_artifact_1, _ = self._force_artifact()
+        required_artifact_2, _ = self._force_artifact()
+        _, artifact, _ = self._force_blueprint_artifact(requires=[required_artifact_1, required_artifact_2])
+        self.assertEqual(
+            self.blueprint1.serialized_artifacts[str(artifact.pk)]["requires"],
+            [str(ra.pk) for ra in sorted((required_artifact_1, required_artifact_2), key=lambda ra: ra.name)]
+        )
+
+    def test_serialized_artifacts_references_sorted(self):
+        referenced_artifact_1, _ = force_artifact(artifact_type=Artifact.Type.MANUAL_CONFIGURATION)
+        referenced_artifact_2, _ = force_artifact(artifact_type=Artifact.Type.MANUAL_CONFIGURATION)
+        _, artifact, _ = force_blueprint_artifact(
+            blueprint=self.blueprint1,
+            artifact_type=Artifact.Type.ACTIVATION,
+            decl_type="com.apple.activation.simple",
+            decl_payload={
+                "StandardConfigurations": [f"ztl:{referenced_artifact_1.pk}",
+                                           f"ztl:{referenced_artifact_2.pk}"],
+            }
+        )
+        self.assertEqual(
+            self.blueprint1.serialized_artifacts[str(artifact.pk)]["references"],
+            [str(ra.pk) for ra in sorted((referenced_artifact_1, referenced_artifact_2), key=lambda ra: ra.name)]
+        )
+
+    def test_serialized_artifacts_required_artifact_min_depth(self):
+        required_artifact, _ = self._force_artifact()
+        _, artifact, _ = self._force_blueprint_artifact(requires=required_artifact)
+        self.assertEqual(self.blueprint1.serialized_artifacts[str(required_artifact.pk)]["_depth"], 1)
+        # added to the blueprint after the artifact requiring it, it is reached again at a lower depth
+        BlueprintArtifact.objects.create(blueprint=self.blueprint1, artifact=required_artifact, macos=True)
+        update_blueprint_serialized_artifacts(self.blueprint1)
+        self.assertEqual(self.blueprint1.serialized_artifacts[str(artifact.pk)]["_depth"], 0)
+        self.assertEqual(self.blueprint1.serialized_artifacts[str(required_artifact.pk)]["_depth"], 0)
+
     # next_to_install
 
     def test_no_blueprint_nothing_to_install(self):

--- a/zentral/contrib/mdm/artifacts.py
+++ b/zentral/contrib/mdm/artifacts.py
@@ -86,7 +86,8 @@ def _add_artifact_to_serialization(artifact, artifacts, depth):
         if depth < present_artifact["_depth"]:
             present_artifact["_depth"] = depth
         return
-    required_artifacts = list(artifact.requires.all())
+    # sorted in python, to keep the prefetched requires cache
+    required_artifacts = sorted(artifact.requires.all(), key=lambda ra: (ra.name, ra.pk))
     referenced_artifacts = []
     artifact_type = artifact.get_type()
     if artifact_type.is_raw_declaration:
@@ -98,6 +99,7 @@ def _add_artifact_to_serialization(artifact, artifacts, depth):
         ):
             if ref.artifact not in referenced_artifacts:
                 referenced_artifacts.append(ref.artifact)
+        referenced_artifacts.sort(key=lambda ra: (ra.name, ra.pk))
     artifacts[artifact_pk] = {
         "_depth": depth,
         "pk": artifact_pk,
@@ -157,7 +159,8 @@ def update_blueprint_serialized_artifacts(blueprint, commit=True):
                                                            "excluded_tags",
                                                            "artifact__requires")
                                          .select_related("artifact")
-                                         .filter(blueprint=blueprint)):
+                                         .filter(blueprint=blueprint)
+                                         .order_by("pk")):
         artifact = bpa.artifact
         depth = 0
         _add_artifact_to_serialization(artifact, artifacts, depth)


### PR DESCRIPTION
`_add_artifact_to_serialization()` builds `Blueprint.serialized_artifacts` from querysets with no `ORDER BY`, so the same blueprint over the same data can serialize to two different documents:

- `artifact.requires.all()` — its order reaches the output verbatim as `"requires"`.
- the `DeclarationRef` loop below it — same, as `"references"`.
- `update_blueprint_serialized_artifacts()` walks the blueprint artifacts unordered too, which decides the top-level key order.

The `"versions"` key sitting between the first two is explicitly `.order_by("-version")`: the question had been asked for the versions and not for the rest.

The order is not cosmetic. `serialized_artifacts` is the dict `Target` walks, its keys feed the `TopologicalSorter`, and `get_ready()` hands back the artifacts whose dependencies are done in insertion order — so artifacts that do not depend on each other were installed in an order the database picked, and the declaration items were listed the same way.

It also left the `if depth < present_artifact["_depth"]` branch covered by luck: reaching it needs a diamond dependency traversed deep-first, which is exactly what the iteration order decided. Coveralls flagged the line as a regression on #1632, which never touched this file.

## Changes

`requires` and `references` are sorted on `(name, pk)`, in python rather than by the database — the blueprint artifacts are read with `artifact__requires` prefetched, and any clause added to that related manager throws the prefetched rows away. On a blueprint holding five artifacts with one requirement each, `order_by()` costs 11 queries where `sorted()` costs 6.

The blueprint artifacts are ordered on their primary key, the order in which they were added to the blueprint. That is what the database was already returning for rows nothing had updated yet, so the serializations in place keep their shape, and unlike the name it does not move when an artifact is renamed.

The min-depth logic is untouched — `_depth` takes the minimum, so it was already order-independent.

## Tests

Three new tests under a `# blueprint serialized artifacts` heading in `tests/mdm/test_artifacts.py`. No existing expectation needed updating: every `requires`/`references` assertion under `tests/mdm/` is on a zero- or one-element list, and no test passes more than one artifact to `requires=`.

The two ordering tests are real — with the fix reverted they fail intermittently, as expected for a coin flip. Six runs gave 2, 2, 0, 2, 1, 0 failures out of 2.

`test_serialized_artifacts_required_artifact_min_depth` pins the branch above: the requirement is added to the blueprint *after* the artifact requiring it, so it gets the higher `pk` and is visited second at depth 0 against a stored depth of 1. A coverage run over `tests.mdm` confirms lines 86-87 execute, and `missing_lines` over the whole 60-180 range is empty.

`tests.mdm` (2696) and the full suite (7910) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)