### PR TITLE
santa: bucket the enrolled machine metrics by the age of the last postflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ A clean sync — `CLEAN` or `CLEAN_ALL` — can be queued for an enrolled machin
 
 The enrolled machines are exposed on the new `/api/santa/enrolled_machines/` endpoint.
 
+The enrolled machines and sync state metrics are bucketed by the age of the last postflight now, the way the active machines metric already was. Nothing ever removes the row of a machine that does not come back, so a decommissioned machine kept its Santa version and its last rule comparison in the totals forever. The `le` label selects the machines that reported within 1, 7, 14, 30, 45 or 90 days, and `+Inf` counts all of them.
+
+
+### Backward incompatibilities
+
+
+#### 🧨 Santa enrolled machines metrics
+
+`zentral_santa_enrolled_machines_total` and `zentral_santa_enrolled_machines_sync_total` are gone, replaced by `zentral_santa_enrolled_machines_bucket` and `zentral_santa_enrolled_machines_sync_bucket`, which carry an `le` label. The `le="+Inf"` bucket holds what the two removed gauges published, so a dashboard or an alert is moved over by renaming the metric and selecting that bucket. A query that sums the buckets without selecting one counts every machine seven times.
+
 
 ### Bug fixes
 

--- a/tests/santa/test_metrics_views.py
+++ b/tests/santa/test_metrics_views.py
@@ -67,8 +67,8 @@ class SantaMetricsViewsTestCase(TestCase):
         mocked_fetchall = connection.cursor.return_value.__enter__.return_value.fetchall
         mocked_fetchall.side_effect = [
             [(1, "yolo", 42)],  # 1st call with bad mode
-            [],  # 2nd call for the enrolled machines gauge
-            [],  # 3rd call for the sync states gauge
+            [],  # 2nd call for the enrolled machines buckets
+            [],  # 3rd call for the sync states buckets
             [],  # 4th call for the active machines buckets
             [],  # 5th call for the rules gauge
             [],  # 6th call for the target states gauge
@@ -87,23 +87,27 @@ class SantaMetricsViewsTestCase(TestCase):
         warning.assert_called_once_with("Unknown santa configuration mode: %s", 42)
         self.assertEqual(mocked_fetchall.mock_calls, [call() for _ in range(7)])
 
-    def test_enrolled_machines(self):
-        em_m = force_enrolled_machine(lockdown=False, santa_version="2024.5")
-        em_l = force_enrolled_machine(lockdown=True, santa_version="2024.6")
+    def test_enrolled_machines_buckets(self):
+        em_m = force_enrolled_machine(lockdown=False, santa_version="2024.5",
+                                      last_postflight_at=naive_utcnow() - timedelta(days=2))
+        em_l = force_enrolled_machine(lockdown=True, santa_version="2024.6",
+                                      last_postflight_at=naive_utcnow() - timedelta(days=20))
         response = self._make_authenticated_request()
         for family in text_string_to_metric_families(response.content.decode("utf-8")):
-            if family.name != "zentral_santa_enrolled_machines_total":
+            if family.name != "zentral_santa_enrolled_machines_bucket":
                 continue
-            self.assertEqual(len(family.samples), 2)
+            self.assertEqual(len(family.samples), 14)
             for sample in family.samples:
-                self.assertEqual(sample.value, 1)
+                le = sample.labels["le"]
                 cfg_pk = int(sample.labels["cfg_pk"])
                 if cfg_pk == em_m.enrollment.configuration.pk:
                     self.assertEqual(sample.labels["mode"], "MONITOR")
                     self.assertEqual(sample.labels["santa_version"], "2024.5")
+                    self.assertEqual(sample.value, 0 if le == "1" else 1)
                 elif cfg_pk == em_l.enrollment.configuration.pk:
                     self.assertEqual(sample.labels["mode"], "LOCKDOWN")
                     self.assertEqual(sample.labels["santa_version"], "2024.6")
+                    self.assertEqual(sample.value, 1 if le in ("30", "45", "90", "+Inf") else 0)
                 else:
                     raise AssertionError("Unknown enrolled machine")
             break
@@ -114,11 +118,16 @@ class SantaMetricsViewsTestCase(TestCase):
     @patch("zentral.contrib.santa.metrics_views.connection")
     @patch("zentral.contrib.santa.metrics_views.logger.warning")
     def test_enrolled_machines_unknown_mode(self, warning, connection):
-        mocked_fetchall = connection.cursor.return_value.__enter__.return_value.fetchall
-        mocked_fetchall.side_effect = [
+        mocked_cursor = connection.cursor.return_value.__enter__.return_value
+        mocked_cursor.description = []
+        for name in ("cfg_pk", "client_mode", "santa_version", "1", "7", "14", "30", "45", "90", "+Inf"):
+            col = Mock()
+            col.name = name
+            mocked_cursor.description.append(col)
+        mocked_cursor.fetchall.side_effect = [
             [],  # 1st call for the configurations info gauge
-            [(1, 42, "2024.5", 1)],  # 2nd call for the enrolled machines gauge
-            [],  # 3rd call for the sync states gauge
+            [(1, 42, "2024.5", 1, 1, 1, 1, 1, 1, 1)],  # 2nd call with an unknown mode
+            [],  # 3rd call for the sync states buckets
             [],  # 4th call for the active machines buckets
             [],  # 5th call for the rules gauge
             [],  # 6th call for the target states gauge
@@ -128,28 +137,35 @@ class SantaMetricsViewsTestCase(TestCase):
         family_count = 0
         sample_count = 0
         for family in text_string_to_metric_families(response.content.decode("utf-8")):
-            if family.name != "zentral_santa_enrolled_machines_total":
+            if family.name != "zentral_santa_enrolled_machines_bucket":
                 continue
             family_count += 1
             sample_count += len(family.samples)
         self.assertEqual(family_count, 1)
         self.assertEqual(sample_count, 0)
         warning.assert_called_once_with("Unknown santa configuration mode: %s", 42)
-        self.assertEqual(mocked_fetchall.mock_calls, [call() for _ in range(7)])
+        self.assertEqual(mocked_cursor.fetchall.mock_calls, [call() for _ in range(7)])
 
-    def test_enrolled_machines_sync_states(self):
+    def test_enrolled_machines_sync_buckets(self):
         configuration = force_configuration()
-        for last_sync_ok in (True, False, None):
-            force_enrolled_machine(configuration=configuration, last_sync_ok=last_sync_ok)
+        for last_sync_ok in (True, False):
+            force_enrolled_machine(configuration=configuration, last_sync_ok=last_sync_ok,
+                                   last_postflight_at=naive_utcnow() - timedelta(days=2))
+        force_enrolled_machine(configuration=configuration, last_sync_ok=None)
         response = self._make_authenticated_request()
         for family in text_string_to_metric_families(response.content.decode("utf-8")):
-            if family.name != "zentral_santa_enrolled_machines_sync_total":
+            if family.name != "zentral_santa_enrolled_machines_sync_bucket":
                 continue
             samples = [s for s in family.samples if int(s.labels["cfg_pk"]) == configuration.pk]
-            self.assertEqual(len(samples), 3)
+            self.assertEqual(len(samples), 21)
             self.assertEqual({s.labels["state"] for s in samples}, {"ok", "mismatch", "unknown"})
             for sample in samples:
-                self.assertEqual(sample.value, 1)
+                le = sample.labels["le"]
+                if sample.labels["state"] == "unknown":
+                    # the machine that never confirmed a sync is only counted in the total
+                    self.assertEqual(sample.value, 1 if le == "+Inf" else 0)
+                else:
+                    self.assertEqual(sample.value, 0 if le == "1" else 1)
             break
         else:
             raise AssertionError("could not find expected metric family")
@@ -242,8 +258,8 @@ class SantaMetricsViewsTestCase(TestCase):
             mocked_cursor.description.append(col)
         mocked_cursor.fetchall.side_effect = [
             [],  # 1st call for the configurations info
-            [],  # 2nd call for the enrolled machines gauge
-            [],  # 3rd call for the sync states gauge
+            [],  # 2nd call for the enrolled machines buckets
+            [],  # 3rd call for the sync states buckets
             [],  # 4th call for the active machines buckets
             [(1, None, "BUNDLE", 42, False, True, False, False, False, 1)],  # 5th call with unknown policy
             [],  # 6th call for the target states gauge

--- a/zentral/contrib/santa/metrics_views.py
+++ b/zentral/contrib/santa/metrics_views.py
@@ -37,36 +37,67 @@ class MetricsView(BasePrometheusMetricsView):
                     continue
                 g.labels(**labels).set(1)
 
-    def add_enrolled_machines_gauge(self):
-        g = Gauge('zentral_santa_enrolled_machines_total', 'Zentral Santa Enrolled Machines',
-                  ['cfg_pk', 'mode', 'santa_version'], registry=self.registry)
+    def add_enrolled_machines_buckets(self):
+        g = Gauge('zentral_santa_enrolled_machines_bucket', 'Zentral Santa Enrolled Machines',
+                  ['cfg_pk', 'mode', 'santa_version', 'le'], registry=self.registry)
         query = (
-            "select e.configuration_id, m.client_mode, m.santa_version, count(*) "
-            "from santa_enrolledmachine as m "
-            "join santa_enrollment as e on (m.enrollment_id = e.id) "
-            "group by e.configuration_id, m.client_mode, m.santa_version"
+            # last_postflight_at, not updated_at: the latter is auto_now, so a machine that
+            # preflights forever without ever confirming a sync would stay in the youngest bucket.
+            # Such a machine has a null age and lands in +Inf alone, which is correct - it has
+            # never completed a sync.
+            "with enrolled_machines as ("
+            "  select e.configuration_id as cfg_pk, m.client_mode, m.santa_version,"
+            "  date_part('days', now() - m.last_postflight_at) as age"
+            "  from santa_enrolledmachine as m"
+            "  join santa_enrollment as e on (m.enrollment_id = e.id)"
+            ") select cfg_pk, client_mode, santa_version,"
+            'count(*) filter (where age < 1) as "1",'
+            'count(*) filter (where age < 7) as "7",'
+            'count(*) filter (where age < 14) as "14",'
+            'count(*) filter (where age < 30) as "30",'
+            'count(*) filter (where age < 45) as "45",'
+            'count(*) filter (where age < 90) as "90",'
+            'count(*) as "+Inf" '
+            "from enrolled_machines group by cfg_pk, client_mode, santa_version"
         )
         with connection.cursor() as cursor:
             cursor.execute(query)
-            for cfg_pk, mode, santa_version, count in cursor.fetchall():
-                labels = {"cfg_pk": cfg_pk,
-                          "santa_version": santa_version}
-                if not self._add_mode_to_labels(mode, labels):
+            columns = [c.name for c in cursor.description]
+            for row in cursor.fetchall():
+                row_d = dict(zip(columns, row))
+                labels = {"cfg_pk": row_d.pop("cfg_pk"),
+                          "santa_version": row_d.pop("santa_version")}
+                if not self._add_mode_to_labels(row_d.pop("client_mode"), labels):
                     continue
-                g.labels(**labels).set(count)
+                for le, count in row_d.items():
+                    g.labels(le=le, **labels).set(count)
 
-    def add_sync_states_gauge(self):
-        g = Gauge('zentral_santa_enrolled_machines_sync_total', 'Zentral Santa Enrolled Machines Sync States',
-                  ['cfg_pk', 'state'], registry=self.registry)
+    def add_sync_states_buckets(self):
+        g = Gauge('zentral_santa_enrolled_machines_sync_bucket', 'Zentral Santa Enrolled Machines Sync States',
+                  ['cfg_pk', 'state', 'le'], registry=self.registry)
         query = (
-            "select e.configuration_id, m.last_sync_ok, count(*) "
-            "from santa_enrolledmachine as m "
-            "join santa_enrollment as e on (m.enrollment_id = e.id) "
-            "group by e.configuration_id, m.last_sync_ok"
+            "with enrolled_machines as ("
+            "  select e.configuration_id as cfg_pk, m.last_sync_ok,"
+            "  date_part('days', now() - m.last_postflight_at) as age"
+            "  from santa_enrolledmachine as m"
+            "  join santa_enrollment as e on (m.enrollment_id = e.id)"
+            ") select cfg_pk, last_sync_ok,"
+            'count(*) filter (where age < 1) as "1",'
+            'count(*) filter (where age < 7) as "7",'
+            'count(*) filter (where age < 14) as "14",'
+            'count(*) filter (where age < 30) as "30",'
+            'count(*) filter (where age < 45) as "45",'
+            'count(*) filter (where age < 90) as "90",'
+            'count(*) as "+Inf" '
+            "from enrolled_machines group by cfg_pk, last_sync_ok"
         )
         with connection.cursor() as cursor:
             cursor.execute(query)
-            for cfg_pk, last_sync_ok, count in cursor.fetchall():
+            columns = [c.name for c in cursor.description]
+            for row in cursor.fetchall():
+                row_d = dict(zip(columns, row))
+                cfg_pk = row_d.pop("cfg_pk")
+                last_sync_ok = row_d.pop("last_sync_ok")
                 if last_sync_ok is None:
                     # no preflight since the machine enrolled, or a clean session was lost
                     state = "unknown"
@@ -74,14 +105,11 @@ class MetricsView(BasePrometheusMetricsView):
                     state = "ok"
                 else:
                     state = "mismatch"
-                g.labels(cfg_pk=cfg_pk, state=state).set(count)
+                for le, count in row_d.items():
+                    g.labels(cfg_pk=cfg_pk, state=state, le=le).set(count)
 
     def add_active_machines_buckets(self):
         query = (
-            # last_postflight_at, not updated_at: the latter is auto_now, so a machine that
-            # preflights forever without ever confirming a sync would stay in the youngest bucket.
-            # Such a machine has a null age and lands in +Inf alone, which is correct - it has
-            # never completed a sync.
             "with active_machines as ("
             "  select e.configuration_id as cfg_pk,"
             "  date_part('days', now() - m.last_postflight_at) as age"
@@ -203,8 +231,8 @@ class MetricsView(BasePrometheusMetricsView):
 
     def populate_registry(self):
         self.add_configurations_info()
-        self.add_enrolled_machines_gauge()
-        self.add_sync_states_gauge()
+        self.add_enrolled_machines_buckets()
+        self.add_sync_states_buckets()
         self.add_active_machines_buckets()
         self.add_rules_gauge()
         self.add_target_states_gauge()


### PR DESCRIPTION
`zentral_santa_enrolled_machines_total` and `zentral_santa_enrolled_machines_sync_total` are replaced by `zentral_santa_enrolled_machines_bucket` and `zentral_santa_enrolled_machines_sync_bucket`, both carrying an `le` label on the age of the last postflight — the convention every other machine-scoped metric in the repo already follows: munki, inventory, MDM, the compliance checks statuses, and Santa's own active machines gauge.

### Why

Nothing ever deletes the `EnrolledMachine` row of a machine that does not come back: the re-enrollment path only removes the rows sharing the same hardware UUID. Both gauges therefore counted the decommissioned forever, frozen on the Santa version and the rule comparison result they last reported. A version rollout panel has a tail that never drains, and `state="mismatch"` cannot distinguish the machines failing every preflight right now from the ones that died mid-mismatch — which is the number an alert on the sync state has to threshold.

### Breaking change

No dual publish, on purpose. The `le="+Inf"` bucket holds exactly what the two removed gauges published, so a dashboard or an alert is moved over by renaming the metric and selecting that bucket. A query that sums the buckets without selecting one counts every machine seven times. Announced under Backward incompatibilities in the CHANGELOG.

`zentral_santa_active_machines_bucket` is left alone: it is the rollup of the new enrolled machines buckets over mode and version, and it keeps the name munki and inventory publish too. The rules, target states and votes gauges are not machine-scoped and get no `le`.

Nothing to update in `docs/`: the Santa metrics are not documented there (unlike munki's, which explain the `le` label — worth a follow-up).

### Tests

`tests.santa` (802 tests) and the full suite pass, 100% patch coverage on the changed lines. The `unknown` sync state landing in `+Inf` alone — a machine that never confirmed a sync has a null age — is pinned by the new bucket test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
