### PR TITLE
inventory: cover the untested branches of the cleanup and the export tasks

### DIFF
--- a/tests/inventory/test_cleanup.py
+++ b/tests/inventory/test_cleanup.py
@@ -1,10 +1,13 @@
+from contextlib import contextmanager
 from datetime import timedelta
 from unittest.mock import patch
 from django.db import IntegrityError, connection
 from django.test import TestCase
 from django.utils import timezone
+from zentral.conf import ConfigDict
 from zentral.contrib.inventory.models import MachineSnapshot, MachineSnapshotCommit, OSXAppInstance
-from zentral.contrib.inventory.utils.cleanup import MAX_ATTEMPTS, cleanup_inventory
+from zentral.contrib.inventory.utils.cleanup import (MAX_ATTEMPTS, cleanup_inventory, get_cleanup_max_date,
+                                                    get_default_snapshot_retention_days)
 from .utils import create_ms
 
 
@@ -81,6 +84,53 @@ class InventoryCleanupTest(TestCase):
                 created_at=timezone.now() - timedelta(days=days, hours=len(commits) - idx)
             )
         return [c.pk for c in commits[:-1]], commits[-1].pk
+
+    @contextmanager
+    def inventory_conf(self, **conf):
+        # the retention is read from the zentral configuration, not from the django settings
+        with patch("zentral.contrib.inventory.utils.cleanup.settings") as settings:
+            settings.__getitem__.return_value = ConfigDict({"zentral.contrib.inventory": conf})
+            yield
+
+    def assertDaysAgo(self, max_date, days, not_before):
+        self.assertTrue(not_before - timedelta(days=days) <= max_date <= timezone.now() - timedelta(days=days))
+
+    # retention
+
+    def test_default_snapshot_retention_days(self):
+        with self.inventory_conf(snapshot_retention_days="7"):
+            self.assertEqual(get_default_snapshot_retention_days(), 7)
+
+    def test_default_snapshot_retention_days_absent(self):
+        with self.inventory_conf():
+            self.assertEqual(get_default_snapshot_retention_days(), 30)
+
+    def test_default_snapshot_retention_days_bad_value(self):
+        with self.inventory_conf(snapshot_retention_days="yolo"):
+            with self.assertLogs("zentral.contrib.inventory.utils.cleanup", level="ERROR") as cm:
+                self.assertEqual(get_default_snapshot_retention_days(), 30)
+        self.assertEqual(cm.records[0].getMessage(),
+                         "Wrong value set snapshot_retention_days, default of 30 used")
+
+    def test_default_snapshot_retention_days_minimum(self):
+        with self.inventory_conf(snapshot_retention_days="0"):
+            self.assertEqual(get_default_snapshot_retention_days(), 1)
+
+    # max date
+
+    def test_cleanup_max_date_defaults_to_the_configured_retention(self):
+        not_before = timezone.now()
+        with self.inventory_conf(snapshot_retention_days="7"):
+            max_date = get_cleanup_max_date()
+        self.assertDaysAgo(max_date, 7, not_before)
+
+    def test_cleanup_max_date_days(self):
+        not_before = timezone.now()
+        self.assertDaysAgo(get_cleanup_max_date(3), 3, not_before)
+
+    def test_cleanup_max_date_minimum_one_day(self):
+        not_before = timezone.now()
+        self.assertDaysAgo(get_cleanup_max_date(-5), 1, not_before)
 
     # results
 

--- a/tests/inventory/test_management_commands.py
+++ b/tests/inventory/test_management_commands.py
@@ -26,6 +26,17 @@ class InventoryManagementCommandsTest(TestCase):
         call_command('cleanup_inventory_history', '-v', '0', stdout=out)
         self.assertEqual("", out.getvalue())
 
+    def test_cleanup_inventory_history_table_error(self):
+        def cleanup_inventory(cursor, result_callback, max_date):
+            result_callback("inventory_link", {"attempts": 3, "rowcount": 17, "duration": 0.1, "status": 1})
+
+        out, err = StringIO(), StringIO()
+        with patch("zentral.contrib.inventory.management.commands.cleanup_inventory_history.cleanup_inventory",
+                   cleanup_inventory):
+            call_command('cleanup_inventory_history', stdout=out, stderr=err)
+        self.assertNotIn("inventory_link", out.getvalue())
+        self.assertIn("Could not cleanup table inventory_link", err.getvalue())
+
     # full export
 
     def test_export_full_inventory(self):

--- a/tests/inventory/test_tasks.py
+++ b/tests/inventory/test_tasks.py
@@ -65,6 +65,11 @@ class InventoryTasksTest(TestCase):
         result = export_inventory(query, "yolo_inv_tag.xlsx")
         self.assertEqual(result["filepath"], "exports/yolo_inv_tag.xlsx")
 
+    def test_export_inventory_unknown_file_ext(self):
+        with self.assertRaises(ValueError) as cm:
+            export_inventory("", "yolo_inv.fomo")
+        self.assertEqual(cm.exception.args[0], "Unknown file extension '.fomo'")
+
     def test_export_full_inventory(self):
         result = export_full_inventory()
         self.assertTrue(result["filepath"].startswith("exports/full_inventory_export-2"))


### PR DESCRIPTION
Two test-only commits, closing the coverage gaps left in the inventory cleanup path.

### The cleanup retention config and the unpurged table report

The batching work of #1631 was reported at 100% patch coverage, and that was right: every line it added was covered. The gaps were the pre-existing lines around it, which nothing flagged because they were not part of the patch.

- `utils/cleanup.py` — the `except (TypeError, ValueError)` branch taken for a `snapshot_retention_days` that is not an integer, and the implicit retention of `get_cleanup_max_date()`, which no caller ever asks for.
- `management/commands/cleanup_inventory_history.py` — the stderr branch for a table that could not be purged. That one is the reporting side of the failure path the batching introduced: a batch that keeps hitting integrity errors now gives up with `status: 1` instead of restarting the whole table. Nothing exercised it.

The tests pin the configured retention, the fallback of 30 days when the key is absent, the error logged for a bad value, the floor of one day of both helpers, and — through a fake cleanup result — the failing table the command never sees on a healthy database.

### The unknown file extension of the export task

`export_inventory` raises on a filename that is neither a zip nor a xlsx. The same guard on the app exports was already covered, this one was the last uncovered line of the module.

### Verification

`utils/cleanup.py`, `management/commands/cleanup_inventory_history.py` and `tasks.py` are at 100% now, statements and branches. The 594 tests of `tests.inventory` pass.

No production code changed, so no CHANGELOG entry.

One thing left alone, worth a decision on its own: `-q` silences the unpurged table too, because the result callback returns before it reaches the stderr branch, while the help of the flag reads *no output if no errors*. Pinning that with a test would have enshrined it, so the new test runs without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
