### PR TITLE
Fix the MDM data asset ingestion bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Fixed a blueprint serializing its artifacts differently from one update to the n
 The file of a deleted data asset is removed from the storage now. The enterprise apps and the packages have always deleted theirs, but the data assets never did, so every version that was deleted — or deleted along with its artifact — left its file in the storage for good.
 
 
+Fixed a data asset update being rejected when it kept the same file: the check that the new file differs from the latest version of the artifact counted the version being updated, so an update that changed only a platform, a shard or a tag compared the asset with itself and came back with "This file is not different from the latest one".
+
+
 ## 2026.5
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ Fixed a data asset update being rejected when it kept the same file: the check t
 The data asset API only accepts XML property lists now, the way the upload form already did. `plistlib` reads either format, so a binary property list was accepted, and then stored and advertised to the devices as `text/xml`. An upload that was relying on this is rejected now.
 
 
+A malformed base 64 source on the MDM profile and provisioning profile API endpoints is answered with a 400 now. Decoding it raised, nothing caught it, and the request ended in a 500.
+
+
 ## 2026.5
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ The inventory history cleanup deletes in bounded batches now. Each table was pur
 Fixed a blueprint serializing its artifacts differently from one update to the next, over the very same data: the artifacts a blueprint holds, the artifacts an artifact requires and the artifacts a declaration references were all read without an order, and PostgreSQL is free to return them in whichever order suits it. That order was the order the devices saw — the sequence in which they installed artifacts that do not depend on each other, and the order of the declaration items they were handed. The required and referenced artifacts are sorted by name now, and the artifacts of a blueprint keep the order in which they were added to it.
 
 
+The file of a deleted data asset is removed from the storage now. The enterprise apps and the packages have always deleted theirs, but the data assets never did, so every version that was deleted — or deleted along with its artifact — left its file in the storage for good.
+
+
 ## 2026.5
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The file of a deleted data asset is removed from the storage now. The enterprise
 Fixed a data asset update being rejected when it kept the same file: the check that the new file differs from the latest version of the artifact counted the version being updated, so an update that changed only a platform, a shard or a tag compared the asset with itself and came back with "This file is not different from the latest one".
 
 
+The data asset API only accepts XML property lists now, the way the upload form already did. `plistlib` reads either format, so a binary property list was accepted, and then stored and advertised to the devices as `text/xml`. An upload that was relying on this is rejected now.
+
+
 ## 2026.5
 
 

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import os
+import plistlib
 import tempfile
 from unittest.mock import Mock, patch
 from django.contrib.auth.models import Group
@@ -342,6 +343,36 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
             tmp_data_asset_file.write(plistfile_content)
             tmp_data_asset_file.close()
         self.assertTrue(os.path.exists(tmp_data_asset_file.name))
+        file_sha256 = hashlib.sha256(plistfile_content).hexdigest()
+        download_s3_external_resource.return_value = plistfile
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "file_uri": "s3://yolo/fomo.plist",
+                                   "file_sha256": file_sha256,
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'file_uri': ['Invalid PLIST file']}
+        )
+        self.assertFalse(os.path.exists(tmp_data_asset_file.name))
+
+    @patch("zentral.utils.external_resources.download_s3_external_resource")
+    def test_create_data_asset_binary_plist_error(self, download_s3_external_resource):
+        _, artifact, (av,) = force_blueprint_artifact(
+            artifact_type=Artifact.Type.DATA_ASSET
+        )
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_data_asset_file:
+            plistfile = io.BytesIO()
+            plistlib.dump({"un": 2}, plistfile, fmt=plistlib.FMT_BINARY)
+            plistfile.name = tmp_data_asset_file.name
+            plistfile.seek(0)
+            plistfile_content = plistfile.getvalue()
+            tmp_data_asset_file.write(plistfile_content)
+            tmp_data_asset_file.close()
         file_sha256 = hashlib.sha256(plistfile_content).hexdigest()
         download_s3_external_resource.return_value = plistfile
         self.set_permissions("mdm.add_dataasset")

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -360,6 +360,22 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
         )
         self.assertFalse(os.path.exists(tmp_data_asset_file.name))
 
+    def test_create_data_asset_file_sha256_extra_characters_error(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "ZIP",
+                                   "file_uri": "s3://yolo/fomo.zip",
+                                   "file_sha256": 64 * "0" + "yolo",
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'file_sha256': ['This value does not match the required pattern.']}
+        )
+
     @patch("zentral.utils.external_resources.download_s3_external_resource")
     def test_create_data_asset_binary_plist_error(self, download_s3_external_resource):
         _, artifact, (av,) = force_blueprint_artifact(

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -659,6 +659,34 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
         self.assertEqual(blueprint.serialized_artifacts[str(artifact.pk)]["versions"][0]["excluded_tags"],
                          [excluded_tag.pk])
 
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    @patch("zentral.utils.external_resources.download_s3_external_resource")
+    def test_update_data_asset_same_file(self, download_s3_external_resource, post_event):
+        artifact, (ea_av,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        data_asset = ea_av.data_asset
+        data_asset.file.open("rb")
+        content = data_asset.file.read()
+        data_asset.file.close()
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_data_asset_file:
+            tmp_data_asset_file.write(content)
+            tmp_data_asset_file.close()
+        zipfile_buffer = io.BytesIO(content)
+        zipfile_buffer.name = tmp_data_asset_file.name
+        download_s3_external_resource.return_value = zipfile_buffer
+        self.set_permissions("mdm.change_dataasset")
+        response = self.put(reverse("mdm_api:data_asset", args=(ea_av.pk,)),
+                            data={"artifact": str(artifact.pk),
+                                  "type": "ZIP",
+                                  "file_uri": "s3://yolo/fomo.zip",
+                                  "file_sha256": data_asset.file_sha256,
+                                  "macos": True,
+                                  "macos_min_version": "14.0",
+                                  "version": ea_av.version})
+        self.assertEqual(response.status_code, 200)
+        ea_av.refresh_from_db()
+        self.assertEqual(ea_av.macos_min_version, "14.0")
+        self.assertEqual(ea_av.data_asset.file_sha256, data_asset.file_sha256)
+
     # delete data asset
 
     def test_delete_data_asset_unauthorized(self):

--- a/tests/mdm/test_api_profiles_views.py
+++ b/tests/mdm/test_api_profiles_views.py
@@ -126,6 +126,17 @@ class MDMProfilesAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrdering
                                    "macos": True})
         self.assertEqual(response.status_code, 403)
 
+    def test_create_profile_invalid_base64_source(self):
+        artifact, _ = force_artifact()
+        self.set_permissions("mdm.add_profile")
+        response = self.post(reverse("mdm_api:profiles"),
+                             data={"artifact": str(artifact.pk),
+                                   "source": "YQ",  # length not a multiple of four
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"source": ["Invalid base64-encoded value"]})
+
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_profile(self, post_event):
         blueprint_artifact, artifact, (profile_av,) = force_blueprint_artifact()

--- a/tests/mdm/test_management_data_asset.py
+++ b/tests/mdm/test_management_data_asset.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from unittest.mock import patch
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
@@ -72,6 +73,22 @@ class MDMDataAssetManagementViewsTestCase(TestCase, LoginCase):
             data_asset.get_export_filename(),
             f"{slug}_{data_asset.pk}_v{artifact_version.version}.zip"
         )
+
+    def test_post_delete_data_asset_deletes_file(self):
+        _, (artifact_version,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        data_asset = artifact_version.data_asset
+        storage, name = data_asset.file.storage, data_asset.file.name
+        self.assertTrue(storage.exists(name))
+        data_asset.delete()
+        self.assertFalse(storage.exists(name))
+
+    def test_post_delete_data_asset_swallows_storage_failure(self):
+        _, (artifact_version,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        data_asset = artifact_version.data_asset
+        with patch("django.db.models.fields.files.FieldFile.delete", side_effect=OSError("storage gone")):
+            with self.assertLogs("zentral.contrib.mdm.models", level="ERROR") as captured:
+                data_asset.delete()
+        self.assertTrue(any("Could not delete data asset file" in r for r in captured.output))
 
     # upload data asset GET
 

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3091,6 +3091,14 @@ class DataAsset(models.Model):
         return f"{slug}_{self.pk}_v{self.artifact_version.version}{ext}"
 
 
+@receiver(post_delete, sender=DataAsset)
+def post_delete_data_asset(sender, instance, *args, **kwargs):
+    try:
+        instance.file.delete(save=False)
+    except Exception:
+        logger.exception("Could not delete data asset file")
+
+
 class Profile(models.Model):
     artifact_version = models.OneToOneField(ArtifactVersion, related_name="profile", on_delete=models.CASCADE)
     source = models.BinaryField()

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -1047,7 +1047,10 @@ class B64EncodedBinaryField(serializers.Field):
         return base64.b64encode(value).decode("ascii")
 
     def to_internal_value(self, data):
-        return base64.b64decode(data)
+        try:
+            return base64.b64decode(data)
+        except Exception:
+            raise serializers.ValidationError("Invalid base64-encoded value")
 
 
 class ProfileSerializer(ArtifactVersionSerializer):

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -881,7 +881,7 @@ class CertAssetSerializer(ArtifactVersionSerializer):
 class DataAssetSerializer(ArtifactVersionSerializer):
     type = serializers.ChoiceField(required=True, choices=DataAsset.Type.choices)
     file_uri = serializers.CharField(required=True, write_only=True)
-    file_sha256 = serializers.RegexField(r"[0-9a-f]{64}", required=True)
+    file_sha256 = serializers.RegexField(r"^[0-9a-f]{64}$", required=True)
     file_size = serializers.IntegerField(read_only=True)
     filename = serializers.CharField(read_only=True)
 

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -906,7 +906,7 @@ class DataAssetSerializer(ArtifactVersionSerializer):
         # verify file type
         if data_asset_type == DataAsset.Type.PLIST:
             try:
-                plistlib.load(tmp_file)
+                plistlib.load(tmp_file, fmt=plistlib.FMT_XML)
             except Exception:
                 tmp_file.close()
                 os.unlink(tmp_file.name)

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -917,11 +917,12 @@ class DataAssetSerializer(ArtifactVersionSerializer):
                 os.unlink(tmp_file.name)
                 raise serializers.ValidationError({"file_uri": "Invalid ZIP file"})
         # verify last version
-        latest_data_asset = (
-            DataAsset.objects.filter(artifact_version__artifact=data["artifact_version"]["artifact"])
-                             .order_by("-artifact_version__version")
-                             .first()
+        latest_data_asset_qs = DataAsset.objects.filter(
+            artifact_version__artifact=data["artifact_version"]["artifact"]
         )
+        if self.instance is not None:
+            latest_data_asset_qs = latest_data_asset_qs.exclude(artifact_version=self.instance.artifact_version)
+        latest_data_asset = latest_data_asset_qs.order_by("-artifact_version__version").first()
         if latest_data_asset and latest_data_asset.file_sha256 == data["file_sha256"]:
             raise serializers.ValidationError({"file_uri": "This file is not different from the latest one"})
         # add data asset info


### PR DESCRIPTION
Five fixes on the ingestion side of the MDM artifact API, one commit each. No model or storage change.

### The file of a deleted data asset was never removed

`EnterpriseApp` and `Package` both delete their file from the storage on `post_delete`. `DataAsset` had no such receiver, so every version that was deleted — or deleted along with its artifact — left its file behind for good, with no row left to find it from. Adds the receiver, mirroring `post_delete_package`.

Note that this does not clean up files already orphaned; that would be a separate sweep.

### A data asset update that kept the same file was rejected

The check that a new file differs from the latest version of the artifact looked at every version, including the one being updated, so a `PUT` that kept the file and changed only a platform, a shard or a tag compared the asset with itself and came back with `This file is not different from the latest one`. The version conflict check immediately above it already excludes the instance under update.

Any client doing full-object updates — the terraform provider does — hit this whenever it touched the scope of a data asset without touching its file. It was untested in both directions: the API test uploads a fresh random file, so it never exercised the same-file path.

### The API accepted binary property lists, the upload form did not

`BaseDataAssetForm` pins `plistlib` to `FMT_XML`, with a comment saying why: the stored file is served with the content type derived from its extension, and `.plist` is registered as `text/xml`. The serializer called `plistlib.load` with no format, so it took a binary property list too, and stored it to be advertised to the devices as `text/xml` — a claim about bytes that were not XML.

**This rejects uploads that previously succeeded.** Existing stored assets are not revalidated.

### A malformed base 64 source returned a 500

`base64.b64decode` raises `binascii.Error` when the input length is not a multiple of four, and `TypeError` on a non-string. `B64EncodedBinaryField.to_internal_value` let both escape, and DRF only turns `ValidationError` into a response, so a truncated or mistyped `source` on the profile and provisioning profile endpoints ended in a 500 rather than a 400.

### The data asset `file_sha256` pattern was unanchored

`RegexField` matches with `re.search`, so any value *containing* 64 hexadecimal characters was accepted — a digest with something appended, or a line of text with one in the middle. It was then rejected later by the hash comparison, with a message about a mismatch rather than about the field. No CHANGELOG entry: this only changes which error rejects input that was already rejected.

### Verification

Full suite, as CI runs it: **7935 tests, OK**. Every added line in `zentral/` is covered — verified by intersecting the `coverage json` missing lines with the `git diff -U0` hunks (19 added production lines, 0 uncovered).

Each of the five tests fails without its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
