### PR TITLE
mdm: keep the declarations when no software update is available to enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ The data asset API only accepts XML property lists now, the way the upload form 
 A malformed base 64 source on the MDM profile and provisioning profile API endpoints is answered with a 400 now. Decoding it raised, nothing caught it, and the request ended in a 500.
 
 
+Fixed an MDM software update enforcement in latest mode taking a device out of management when it had no update to enforce on it. Finding none raised, and nothing caught that on the paths building the declaration manifest: the `tokens` and `declaration-items` check-ins and `/connect` all answered with a 500, and since the declarative management sync is scheduled before them, the device also stopped receiving its artifacts, its FileVault configuration, its recovery password and its extra inventory. A device whose OS was above the *Maximum target OS version* — because it was updated past it, or shipped above it — was enough to trigger it, and so was a deployment that had never synchronized the Apple software lookup service, which took out every device in scope at once. The configuration is left out of the declarations the device is served now, and Zentral logs an error, or an information for the devices that are simply already up to date or not inventoried yet. The device kept getting a no-op enforcement targeting the version it already ran, and it still does; only a target below what the device runs is dropped.
+
+
+Malformed MDM client capabilities no longer take a device out of management. They are stored exactly as the device reported them, so the lookup of the status items it supports could fail on a type rather than on a missing key, and that was not caught: the `tokens` and `declaration-items` check-ins and `/connect` answered with a 500, and the device stopped receiving anything at all. The status subscriptions fall back to the items supported by every client now, and Zentral logs a warning.
+
+
+An explicit null delay in days or local time is rejected on the MDM software update enforcement API when a maximum target OS version is set. Both fields are nullable for the one time enforcements, which have no use for them, and a latest enforcement without them has no target date to build a declaration with. Omitting them is unchanged and still falls back to 14 days and 09:30.
+
+
 ## 2026.5
 
 

--- a/docs/apps/mdm.md
+++ b/docs/apps/mdm.md
@@ -294,6 +294,8 @@ Zentral offers two variants for setting up a Software Update Enforcement configu
 
   This type automatically enforces the latest available OS version up to a **Maximum target OS version**. Zentral will use the *device identifier* and match information from the *Apple Software Lookup Service* to return the latest OS version (e.g., `16` to install all macOS 15 updates on your fleet, but to stop before installing 16). Set the **Delay in days** following the software release and a **Target local time** to configure the enforcement time (e.g.`7` for 7 days and `09:30:00` for 9:30 a.m.).
 
+    A device only receives the enforcement when Zentral finds an update for it. A device already running a version *newer* than the one Zentral picked - because it is past the *Maximum target OS version*, or because it shipped above it - is left out, and is enforced again as soon as a newer update below the maximum is published. This mode depends on the software updates being synchronized from the *Apple Software Lookup Service*: while none are known, no device can be enforced, and Zentral logs an error for each of them.
+
 In both types, if a user does not install the update by the specified deadline, it is automatically enforced. Enforcement times are based on the device's local time zone, allowing a single configuration to work seamlessly across different regions.
 
 To read more about Apple's logic for enforcing software updates, refer to the [Apple Platform Deployment Guide](https://support.apple.com/en-gb/guide/deployment/depd30715cbb/1/web/1.0).

--- a/tests/mdm/test_api_software_update_enforcements_views.py
+++ b/tests/mdm/test_api_software_update_enforcements_views.py
@@ -213,6 +213,32 @@ class MDMSoftwareUpdateEnforcementsAPIViewsTestCase(TestCase, LoginCase, Request
             {'non_field_errors': ['os_version or max_os_version are required']}
         )
 
+    def test_create_software_update_enforcement_latest_delay_days_null_error(self):
+        self.set_permissions("mdm.add_softwareupdateenforcement")
+        response = self.post(reverse("mdm_api:software_update_enforcements"),
+                             {"name": get_random_string(12),
+                              "platforms": ["macOS"],
+                              "max_os_version": "15",
+                              "delay_days": None})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'delay_days': ['This field cannot be null if max_os_version is used']}
+        )
+
+    def test_create_software_update_enforcement_latest_local_time_null_error(self):
+        self.set_permissions("mdm.add_softwareupdateenforcement")
+        response = self.post(reverse("mdm_api:software_update_enforcements"),
+                             {"name": get_random_string(12),
+                              "platforms": ["macOS"],
+                              "max_os_version": "15",
+                              "local_time": None})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {'local_time': ['This field cannot be null if max_os_version is used']}
+        )
+
     def test_create_software_update_enforcement_one_time_required_fields(self):
         self.set_permissions("mdm.add_softwareupdateenforcement")
         name = get_random_string(12)

--- a/tests/mdm/test_artifacts.py
+++ b/tests/mdm/test_artifacts.py
@@ -9,7 +9,8 @@ from django.utils.crypto import get_random_string
 
 from zentral.contrib.inventory.models import MachineTag, MetaBusinessUnit, Tag
 from zentral.contrib.mdm.artifacts import Target, update_blueprint_serialized_artifacts
-from zentral.contrib.mdm.declarations import get_artifact_version_server_token
+from zentral.contrib.mdm.declarations import (build_target_management_status_subscriptions,
+                                             get_artifact_version_server_token)
 from zentral.contrib.mdm.models import (
     Artifact,
     ArtifactVersion,
@@ -1211,6 +1212,60 @@ class TestMDMArtifacts(TestCase):
         self.assertIn(
             identifier,
             [c["Identifier"] for c in target.declaration_items["Declarations"]["Configurations"]],
+        )
+
+    # management status subscriptions with malformed client capabilities
+
+    DEFAULT_STATUS_ITEMS_SERVER_TOKEN = "0ed215547af3061ce18ea6cf7a69dac4a3d52f3f"
+
+    def test_management_status_subscriptions_client_capabilities_not_a_dict(self):
+        # stored as the device reported them, so anything can be in there
+        for client_capabilities in (["supported-payloads"], "supported-payloads", 42, True):
+            with self.subTest(client_capabilities=client_capabilities):
+                self.enrolled_device.client_capabilities = client_capabilities
+                target = Target(self.enrolled_device)
+                with self.assertLogs("zentral.contrib.mdm.declarations.management", level="WARNING") as cm:
+                    declaration = build_target_management_status_subscriptions(target)
+                self.assertEqual(
+                    cm.output,
+                    [f"WARNING:zentral.contrib.mdm.declarations.management:"
+                     f"Target {target}: client capabilities are not an object"],
+                )
+                self.assertEqual(declaration["ServerToken"], self.DEFAULT_STATUS_ITEMS_SERVER_TOKEN)
+
+    def test_management_status_subscriptions_supported_payloads_not_a_dict(self):
+        for supported_payloads in (["status-items"], "status-items", 42):
+            with self.subTest(supported_payloads=supported_payloads):
+                self.enrolled_device.client_capabilities = {"supported-payloads": supported_payloads}
+                target = Target(self.enrolled_device)
+                with self.assertLogs("zentral.contrib.mdm.declarations.management", level="WARNING"):
+                    declaration = build_target_management_status_subscriptions(target)
+                self.assertEqual(declaration["ServerToken"], self.DEFAULT_STATUS_ITEMS_SERVER_TOKEN)
+
+    def test_management_status_subscriptions_status_items_not_iterable(self):
+        self.enrolled_device.client_capabilities = {"supported-payloads": {"status-items": 42}}
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.management", level="WARNING"):
+            declaration = build_target_management_status_subscriptions(target)
+        self.assertEqual(declaration["ServerToken"], self.DEFAULT_STATUS_ITEMS_SERVER_TOKEN)
+
+    def test_management_status_subscriptions_status_item_not_a_string(self):
+        self.enrolled_device.client_capabilities = {
+            "supported-payloads": {"status-items": ["device.model.family", 42]}
+        }
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.management", level="WARNING"):
+            declaration = build_target_management_status_subscriptions(target)
+        self.assertEqual(declaration["ServerToken"], self.DEFAULT_STATUS_ITEMS_SERVER_TOKEN)
+
+    def test_declaration_items_client_capabilities_not_a_dict(self):
+        self.enrolled_device.client_capabilities = ["supported-payloads"]
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.management", level="WARNING"):
+            declarations = target.declaration_items["Declarations"]
+        self.assertEqual(
+            [c["ServerToken"] for c in declarations["Configurations"]],
+            [self.DEFAULT_STATUS_ITEMS_SERVER_TOKEN],
         )
 
     def test_device_declaration_items_config_and_dep_included(self):

--- a/tests/mdm/test_artifacts.py
+++ b/tests/mdm/test_artifacts.py
@@ -1067,6 +1067,152 @@ class TestMDMArtifacts(TestCase):
                          f"zentral.blueprint.{self.blueprint1.pk}.softwareupdate-enforcement-specific")
         self.assertEqual(configurations[1]["ServerToken"], "724edaf760e7d7282084dcf3eaef6467447accd1")
 
+    # software update enforcement not advertised
+
+    def _force_latest_software_update_enforcement(self, **kwargs):
+        kwargs.setdefault("max_os_version", "15")
+        kwargs.setdefault("local_time", time(9, 30))
+        kwargs.setdefault("delay_days", 15)
+        sue = force_software_update_enforcement(**kwargs)
+        self.blueprint1.software_update_enforcements.add(sue)
+        self.enrolled_device.client_capabilities = MACOS_14_CLIENT_CAPABILITIES
+        return sue
+
+    def _assert_software_update_enforcement_not_advertised(self, target):
+        """The activation and the declaration items must agree: a StandardConfigurations entry without a
+        matching declaration item makes the device reject the whole activation."""
+        identifier = f"zentral.blueprint.{self.blueprint1.pk}.softwareupdate-enforcement-specific"
+        self.assertNotIn(identifier, target.activation["Payload"]["StandardConfigurations"])
+        self.assertNotIn(
+            identifier,
+            [c["Identifier"] for c in target.declaration_items["Declarations"]["Configurations"]],
+        )
+
+    def test_device_software_update_enforcement_latest_empty_feed_not_advertised(self):
+        self._force_latest_software_update_enforcement()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="ERROR") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"ERROR:zentral.contrib.mdm.declarations.software_update:"
+             f"Enrolled device {self.enrolled_device.udid}: empty software update feed"],
+        )
+
+    def test_device_software_update_enforcement_latest_no_update_for_device_not_advertised(self):
+        force_software_update(device_id=get_random_string(8),
+                              version="14.1.0",
+                              build="23B74",
+                              posting_date=date(2023, 10, 25))
+        self._force_latest_software_update_enforcement()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="ERROR") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"ERROR:zentral.contrib.mdm.declarations.software_update:"
+             f"Enrolled device {self.enrolled_device.udid}: no software update available"],
+        )
+
+    def test_device_software_update_enforcement_latest_missing_delay_days_not_advertised(self):
+        sue = self._force_latest_software_update_enforcement()
+        sue.delay_days = None
+        sue.save()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="ERROR") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"ERROR:zentral.contrib.mdm.declarations.software_update:"
+             f"Software update enforcement {sue.pk}: missing local time or delay in days"],
+        )
+
+    def test_device_software_update_enforcement_latest_missing_local_time_not_advertised(self):
+        sue = self._force_latest_software_update_enforcement()
+        sue.local_time = None
+        sue.save()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="ERROR") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"ERROR:zentral.contrib.mdm.declarations.software_update:"
+             f"Software update enforcement {sue.pk}: missing local time or delay in days"],
+        )
+
+    def test_device_software_update_enforcement_latest_no_device_id_not_advertised(self):
+        self.enrolled_device.device_information = None
+        self._force_latest_software_update_enforcement()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="INFO") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"INFO:zentral.contrib.mdm.declarations.software_update:"
+             f"Enrolled device {self.enrolled_device.udid}: no software update device ID"],
+        )
+
+    def test_device_software_update_enforcement_latest_device_information_not_a_dict(self):
+        self.enrolled_device.device_information = ["SoftwareUpdateDeviceID"]
+        self._force_latest_software_update_enforcement()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="INFO") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"INFO:zentral.contrib.mdm.declarations.software_update:"
+             f"Enrolled device {self.enrolled_device.udid}: no software update device ID"],
+        )
+
+    def test_device_software_update_enforcement_latest_below_device_os_version_not_advertised(self):
+        device_id = self.enrolled_device.device_information["SoftwareUpdateDeviceID"]
+        su = force_software_update(device_id=device_id,
+                                   version="14.1.0",
+                                   build="23B74",
+                                   posting_date=date(2023, 10, 25))
+        self.enrolled_device.os_version = "15.6"
+        self.enrolled_device.build_version = "24G84"
+        self._force_latest_software_update_enforcement()
+        target = Target(self.enrolled_device)
+        with self.assertLogs("zentral.contrib.mdm.declarations.software_update", level="INFO") as cm:
+            self._assert_software_update_enforcement_not_advertised(target)
+        self.assertEqual(
+            cm.output,
+            [f"INFO:zentral.contrib.mdm.declarations.software_update:"
+             f"Enrolled device {self.enrolled_device.udid}: software update {su} below the device OS version"],
+        )
+
+    def test_device_software_update_enforcement_latest_equal_to_device_os_version_advertised(self):
+        device_id = self.enrolled_device.device_information["SoftwareUpdateDeviceID"]
+        force_software_update(device_id=device_id,
+                              version="14.1.0",
+                              build="23B74",
+                              posting_date=date(2023, 10, 25))
+        self.enrolled_device.os_version = "14.1"
+        self.enrolled_device.build_version = "23B74"
+        self._force_latest_software_update_enforcement()
+        target = Target(self.enrolled_device)
+        identifier = f"zentral.blueprint.{self.blueprint1.pk}.softwareupdate-enforcement-specific"
+        self.assertIn(identifier, target.activation["Payload"]["StandardConfigurations"])
+        self.assertIn(
+            identifier,
+            [c["Identifier"] for c in target.declaration_items["Declarations"]["Configurations"]],
+        )
+
+    def test_device_software_update_enforcement_one_time_missing_delay_days_advertised(self):
+        sue = force_software_update_enforcement(os_version="15.1", local_datetime=naive_utcnow())
+        self.assertIsNone(sue.delay_days)
+        self.assertIsNone(sue.local_time)
+        self.blueprint1.software_update_enforcements.add(sue)
+        self.enrolled_device.client_capabilities = MACOS_14_CLIENT_CAPABILITIES
+        target = Target(self.enrolled_device)
+        identifier = f"zentral.blueprint.{self.blueprint1.pk}.softwareupdate-enforcement-specific"
+        self.assertIn(identifier, target.activation["Payload"]["StandardConfigurations"])
+        self.assertIn(
+            identifier,
+            [c["Identifier"] for c in target.declaration_items["Declarations"]["Configurations"]],
+        )
+
     def test_device_declaration_items_config_and_dep_included(self):
         artifact, (artifact_version,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
         _, parent_artifact, _ = force_blueprint_artifact(

--- a/tests/mdm/test_mdm_views.py
+++ b/tests/mdm/test_mdm_views.py
@@ -2011,6 +2011,81 @@ class MDMViewsTestCase(TestCase):
             serial_number=serial_number,
         )
 
+    def _force_device_above_software_update_enforcement_ceiling(self, session):
+        """A steady state device whose OS is above the ceiling of its scoped enforcement: there is a software
+        update in the feed, but none of them applies to the device anymore."""
+        device_id = get_random_string(8)
+        now = naive_utcnow()
+        enrolled_device = session.enrolled_device
+        enrolled_device.client_capabilities = MACOS_14_CLIENT_CAPABILITIES
+        enrolled_device.device_information = {"SoftwareUpdateDeviceID": device_id}
+        enrolled_device.os_version = "15.6"
+        enrolled_device.build_version = "24G84"
+        # inventory up to date and certificate valid, so that the next command is the DDM sync
+        enrolled_device.device_information_updated_at = now
+        enrolled_device.security_info_updated_at = now
+        enrolled_device.cert_not_valid_after = now + timedelta(days=365)
+        enrolled_device.save()
+        force_software_update(
+            device_id=device_id, version="14.1.0", build="23B74", posting_date=date(2023, 10, 25)
+        )
+        sue = force_software_update_enforcement(
+            max_os_version="15", local_time=time(9, 30), delay_days=15
+        )
+        blueprint = self._add_blueprint(session)
+        blueprint.software_update_enforcements.add(sue)
+        return blueprint
+
+    def test_declarative_management_tokens_software_update_enforcement_above_ceiling(
+        self, post_event
+    ):
+        session, udid, serial_number = force_dep_enrollment_session(
+            self.mbu, authenticated=True, completed=True
+        )
+        self._force_device_above_software_update_enforcement_ceiling(session)
+        payload = {
+            "UDID": udid,
+            "MessageType": "DeclarativeManagement",
+            "Data": json.dumps({"un": 2}),
+            "Endpoint": "tokens",
+        }
+        response = self._put(reverse("mdm_public:checkin"), payload, session)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("DeclarationsToken", response.json()["SyncTokens"])
+
+    def test_declarative_management_declaration_items_software_update_enforcement_above_ceiling(
+        self, post_event
+    ):
+        session, udid, serial_number = force_dep_enrollment_session(
+            self.mbu, authenticated=True, completed=True
+        )
+        blueprint = self._force_device_above_software_update_enforcement_ceiling(session)
+        payload = {
+            "UDID": udid,
+            "MessageType": "DeclarativeManagement",
+            "Data": json.dumps({"un": 2}),
+            "Endpoint": "declaration-items",
+        }
+        response = self._put(reverse("mdm_public:checkin"), payload, session)
+        self.assertEqual(response.status_code, 200)
+        declarations = response.json()["Declarations"]
+        identifier = f"zentral.blueprint.{blueprint.pk}.softwareupdate-enforcement-specific"
+        self.assertNotIn(identifier, [c["Identifier"] for c in declarations["Configurations"]])
+        self.assertEqual(len(declarations["Activations"]), 1)
+
+    def test_device_channel_connect_software_update_enforcement_above_ceiling(
+        self, post_event
+    ):
+        session, udid, serial_number = force_dep_enrollment_session(
+            self.mbu, authenticated=True, completed=True
+        )
+        self._force_device_above_software_update_enforcement_ceiling(session)
+        payload = {"UDID": udid, "Status": "Idle"}
+        response = self._put(reverse("mdm_public:connect"), payload, session)
+        self.assertEqual(response.status_code, 200)
+        data = plistlib.loads(response.content)
+        self.assertEqual(data["Command"]["RequestType"], "DeclarativeManagement")
+
     def test_declarative_management_softwareupdate_enforcement_specific_one_time(
         self, post_event
     ):

--- a/tests/mdm/test_software_updates.py
+++ b/tests/mdm/test_software_updates.py
@@ -237,6 +237,47 @@ class MDMSoftwareUpdateTestCase(TestCase):
             event_count += 1
         self.assertEqual(event_count, 2)
 
+    # comparable OS versions
+
+    def test_comparable_os_version_drops_an_empty_extra(self):
+        su = force_software_update(
+            device_id="J413AP",
+            version="14.1.0",
+            posting_date=datetime.date(2023, 10, 25)
+        )
+        self.assertEqual(su.comparable_os_version, (14, 1, 0))
+
+    def test_comparable_os_version_keeps_the_extra(self):
+        su = force_software_update(
+            device_id="J413AP",
+            version="14.1.0",
+            version_extra="(a)",
+            posting_date=datetime.date(2023, 10, 25)
+        )
+        self.assertEqual(su.comparable_os_version, (14, 1, 0, "(a)"))
+
+    def test_full_comparable_os_version_always_has_four_elements(self):
+        for version_extra in ("", "(a)"):
+            with self.subTest(version_extra=version_extra):
+                su = force_software_update(
+                    device_id="J413AP",
+                    version="14.1.0",
+                    version_extra=version_extra,
+                    posting_date=datetime.date(2023, 10, 25)
+                )
+                self.assertEqual(su.full_comparable_os_version, (14, 1, 0, version_extra))
+
+    def test_full_comparable_os_version_compares_equal_to_the_enrolled_device(self):
+        enrolled_device = self._force_enrolled_device(device_id="J413AP", os_version="14.1")
+        su = force_software_update(
+            device_id="J413AP",
+            version="14.1.0",
+            posting_date=datetime.date(2023, 10, 25)
+        )
+        self.assertEqual(su.full_comparable_os_version, enrolled_device.comparable_os_version)
+        # comparable_os_version cannot be used for this: the update the device already runs compares lower
+        self.assertLess(su.comparable_os_version, enrolled_device.comparable_os_version)
+
     # best_available_software_updates
 
     def test_available_software_updates_no_updates_today_no_updates(self):

--- a/zentral/contrib/mdm/artifacts.py
+++ b/zentral/contrib/mdm/artifacts.py
@@ -25,7 +25,6 @@ from .declarations import (
     get_artifact_identifier,
     get_artifact_version_server_token,
     get_blueprint_declaration_identifier,
-    get_software_update_enforcement_specific_identifier,
     get_status_report_target_artifacts_info,
 )
 from .events import post_device_lock_pin_clear_event, post_target_artifact_update_events
@@ -857,6 +856,10 @@ class Target:
 
         return selected_sue
 
+    @cached_property
+    def software_update_enforcement_declaration(self):
+        return build_specific_software_update_enforcement(self)
+
     def iter_configuration_artifacts(self):
         """Iterate over the configuration artifacts to include in the managed activation"""
         for artifact, artifact_version, _ in self.all_installed_or_to_install_serialized(
@@ -882,7 +885,9 @@ class Target:
             ]
         }
         if self.software_update_enforcement:
-            payload["StandardConfigurations"].append(get_software_update_enforcement_specific_identifier(self))
+            sue_declaration = self.software_update_enforcement_declaration
+            if sue_declaration:
+                payload["StandardConfigurations"].append(sue_declaration["Identifier"])
         for artifact in self.iter_configuration_artifacts():
             payload["StandardConfigurations"].append(get_artifact_identifier(artifact))
         payload["StandardConfigurations"].sort()
@@ -922,11 +927,11 @@ class Target:
             ],
             "Management": []
         }
-        software_update_enforcement_specific = build_specific_software_update_enforcement(self, missing_ok=True)
-        if software_update_enforcement_specific:
+        sue_declaration = self.software_update_enforcement_declaration
+        if sue_declaration:
             declarations["Configurations"].append(
-                {"Identifier": software_update_enforcement_specific["Identifier"],
-                 "ServerToken": software_update_enforcement_specific["ServerToken"]}
+                {"Identifier": sue_declaration["Identifier"],
+                 "ServerToken": sue_declaration["ServerToken"]}
             )
         # snapshot of the artifact-backed declarations, keyed by identifier, so that a later fetch of one of
         # them resolves to the same artifact version and server token we advertised here — even when the live

--- a/zentral/contrib/mdm/declarations/management.py
+++ b/zentral/contrib/mdm/declarations/management.py
@@ -13,13 +13,18 @@ logger = logging.getLogger("zentral.contrib.mdm.declarations.management")
 # https://developer.apple.com/documentation/devicemanagement/status_reports
 def build_target_management_status_subscriptions(target):
     status_items = []
-    if target.client_capabilities:
+    client_capabilities = target.client_capabilities
+    # the client capabilities are stored as the device reported them, without any validation, so every
+    # step below can fail on a type instead of on a missing key
+    if isinstance(client_capabilities, dict):
         try:
-            supported_status_items = target.client_capabilities["supported-payloads"]["status-items"]
-        except KeyError:
-            logger.warning("Target %s: could not find supported status items", target)
-        else:
+            supported_status_items = client_capabilities["supported-payloads"]["status-items"]
             status_items = [si for si in supported_status_items if not si.startswith("test.")]
+        except (AttributeError, KeyError, TypeError):
+            logger.warning("Target %s: could not find supported status items", target)
+            status_items = []
+    elif client_capabilities is not None:
+        logger.warning("Target %s: client capabilities are not an object", target)
     if not status_items:
         # default status items supported by all clients
         status_items = [

--- a/zentral/contrib/mdm/declarations/protocol.py
+++ b/zentral/contrib/mdm/declarations/protocol.py
@@ -4,7 +4,7 @@ from .declaration import build_declaration
 from .exceptions import DeclarationError
 from .legacy_profile import build_legacy_profile
 from .management import build_target_management_status_subscriptions
-from .software_update import build_specific_software_update_enforcement
+from .software_update import get_specific_software_update_enforcement
 
 
 __all__ = ["build_declaration_response"]
@@ -19,7 +19,7 @@ def build_declaration_response(endpoint, event_payload, enrollment_session, targ
     elif declaration_identifier.endswith("activation"):
         return target.activation
     elif declaration_identifier.endswith("softwareupdate-enforcement-specific"):
-        return build_specific_software_update_enforcement(target)
+        return get_specific_software_update_enforcement(target)
     elif ".declaration." in declaration_identifier:
         return build_declaration(enrollment_session, target, declaration_identifier)
     elif ".cert-asset." in declaration_identifier:

--- a/zentral/contrib/mdm/declarations/software_update.py
+++ b/zentral/contrib/mdm/declarations/software_update.py
@@ -2,12 +2,14 @@ from datetime import datetime, timedelta
 import hashlib
 import logging
 from zentral.utils.time import naive_truncated_isoformat
+from zentral.contrib.mdm.models import SoftwareUpdate
 from zentral.contrib.mdm.software_updates import best_available_software_update
 from .exceptions import DeclarationError
 from .utils import get_blueprint_declaration_identifier
 
 
-__all__ = ["get_software_update_enforcement_specific_identifier", "build_specific_software_update_enforcement"]
+__all__ = ["get_software_update_enforcement_specific_identifier", "build_specific_software_update_enforcement",
+           "get_specific_software_update_enforcement"]
 
 
 logger = logging.getLogger("zentral.contrib.mdm.declarations.software_update")
@@ -18,28 +20,51 @@ def get_software_update_enforcement_specific_identifier(target):
 
 
 # https://github.com/apple/device-management/blob/release/declarative/declarations/configurations/softwareupdate.enforcement.specific.yaml  # NOQA
-def build_specific_software_update_enforcement(target, missing_ok=False):
+def build_specific_software_update_enforcement(target):
+    """Build the softwareupdate.enforcement.specific declaration, or return None if there is nothing to enforce.
+
+    Must not raise: the activation and the declaration items advertise this declaration if and only if this
+    returns one, and a target whose enforcement cannot be resolved has to keep the rest of its declarations.
+    """
     software_update_enforcement = target.software_update_enforcement
     if not software_update_enforcement:
-        if missing_ok:
-            return
-        raise DeclarationError("No software enforcement found for target")
+        return
+    enrolled_device = target.enrolled_device
     if software_update_enforcement.max_os_version:
+        if software_update_enforcement.local_time is None or software_update_enforcement.delay_days is None:
+            logger.error("Software update enforcement %s: missing local time or delay in days",
+                         software_update_enforcement.pk)
+            return
+        device_information = enrolled_device.device_information
+        if not isinstance(device_information, dict) or not device_information.get("SoftwareUpdateDeviceID"):
+            # the device has not reported its inventory yet, there is nothing to look up the feed with
+            logger.info("Enrolled device %s: no software update device ID", enrolled_device.udid)
+            return
         software_update = best_available_software_update(
-            target.enrolled_device,
+            enrolled_device,
             max_os_version=software_update_enforcement.max_os_version,
         )
         if not software_update:
-            raise DeclarationError("No software update available for target")
+            if SoftwareUpdate.objects.exists():
+                logger.error("Enrolled device %s: no software update available", enrolled_device.udid)
+            else:
+                # nothing has ever been synced from the Apple software lookup service, or every update
+                # available for the fleet has expired. No device can be enforced in this state.
+                logger.error("Enrolled device %s: empty software update feed", enrolled_device.udid)
+            return
+        if software_update.full_comparable_os_version < enrolled_device.comparable_os_version:
+            logger.info("Enrolled device %s: software update %s below the device OS version",
+                        enrolled_device.udid, software_update)
+            return
         local_datetime = (
             datetime.combine(software_update.availability.lower, software_update_enforcement.local_time)
             + timedelta(days=software_update_enforcement.delay_days)
         )
         target_os_version = software_update.target_os_version()
         target_build_version = software_update.build
-        if not target_build_version and target_os_version == target.enrolled_device.current_os_version:
+        if not target_build_version and target_os_version == enrolled_device.current_os_version:
             # TODO remove this it is confirmed that we always get the build from the feed
-            target_build_version = target.enrolled_device.current_build_version
+            target_build_version = enrolled_device.current_build_version
     else:
         local_datetime = software_update_enforcement.local_datetime
         target_os_version = software_update_enforcement.os_version
@@ -62,3 +87,12 @@ def build_specific_software_update_enforcement(target, missing_ok=False):
         "ServerToken": h.hexdigest(),
         "Payload": payload,
     }
+
+
+def get_specific_software_update_enforcement(target):
+    declaration = target.software_update_enforcement_declaration
+    if declaration:
+        return declaration
+    if not target.software_update_enforcement:
+        raise DeclarationError("No software enforcement found for target")
+    raise DeclarationError("No software update available for target")

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3614,6 +3614,15 @@ class SoftwareUpdate(models.Model):
     def comparable_os_version(self):
         return tuple(e for e in (self.major, self.minor, self.patch, self.extra) if e != "")
 
+    @property
+    def full_comparable_os_version(self):
+        """Always four elements, to compare with EnrolledDevice.comparable_os_version.
+
+        comparable_os_version drops an empty extra, and a three element tuple compares lower than the four
+        element tuple of an equal version, which would make an update the device already runs look older.
+        """
+        return (self.major, self.minor, self.patch, self.extra)
+
     def target_os_version(self):
         return ".".join(
             str(i)

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -607,10 +607,13 @@ class SoftwareUpdateEnforcementSerializer(serializers.ModelSerializer):
         if max_os_version:
             mode = "max_os_version"
             required_fields = (f for f in self.latest_fields if f not in ("delay_days", "local_time"))
+            # not required, the model defaults apply when they are omitted, but a null cannot be enforced
+            not_null_fields = ("delay_days", "local_time")
             other_fields = self.one_time_fields
         elif os_version:
             mode = "os_version"
             required_fields = (f for f in self.one_time_fields if f != "build_version")
+            not_null_fields = ()
             other_fields = self.latest_fields
         else:
             raise serializers.ValidationError("os_version or max_os_version are required")
@@ -619,6 +622,9 @@ class SoftwareUpdateEnforcementSerializer(serializers.ModelSerializer):
             value = data.get(field)
             if value is None or value == "":
                 errors[field] = f"This field is required if {mode} is used"
+        for field in not_null_fields:
+            if field in data and data[field] is None:
+                errors[field] = f"This field cannot be null if {mode} is used"
         for field in other_fields:
             if data.get(field):
                 errors[field] = f"This field cannot be set if {mode} is used"


### PR DESCRIPTION
## The problem

A software update enforcement in latest mode raised a `DeclarationError` if the server found no software update for the device. The paths that build the declaration manifest do not catch this exception. Therefore the server sent a 500 response.

These are the results for a device that runs an OS version above the maximum target OS version:

| Request | Before | After |
|---|---|---|
| `PUT /checkin`, endpoint `tokens` | 500 | 200 |
| `PUT /checkin`, endpoint `declaration-items` | 500 | 200 |
| `PUT /connect` | 500 | 200 |

The 500 response on `/connect` is the most severe result. The function `_trigger_declarative_management_sync` is the fourth step in the chain of `get_next_command_response`. The exception occurred before these steps:

- the installation of the artifacts
- FileVault
- the recovery password
- the DEP account configuration
- the extra inventory

Thus one enforcement that the server cannot resolve removed the device from management.

Two conditions cause the problem. Both conditions are common:

1. The OS version of the device is above the maximum target OS version. A user updated the device, or the device came with a higher version. For example, the maximum target OS version is `26`, and the device runs `26.3`.
2. The table `SoftwareUpdate` is empty. This condition removes all the devices in scope at the same time. The query for a candidate update has the filter `availability__contains=today`. The function `sync_software_updates` deletes the records that are no longer in the feed. Zentral does not supply a schedule for this function.

## The correction

The function `build_specific_software_update_enforcement` now returns `None`. It does not raise an exception. The activation includes the configuration only if this function returns a declaration.

The second part is necessary. Before the correction, the activation made sure only that an enforcement was in scope. It did not make sure that the server found an update. If you remove the configuration from the declaration items only, the activation keeps a `StandardConfigurations` entry that has no declaration item. The device then rejects the complete activation and all of its configurations.

The activation and the declaration items now read the same `Target.software_update_enforcement_declaration`. This also decreases the number of queries of the feed to one for each request.

The parameter `missing_ok` has no more callers, thus it is removed. The new function `get_specific_software_update_enforcement` keeps the two event reasons for the fetch path. Thus `build_declaration_response` remains a simple dispatcher, as it is for all the other declaration types.

## The conditions that give no declaration

| Condition | Log level |
|---|---|
| The local time or the delay in days is absent | error |
| The device did not report a `SoftwareUpdateDeviceID` | info |
| No candidate update, and the feed is empty | error |
| No candidate update, and the feed is not empty | error |
| The best available update is below the OS version of the device | info |

The message for an empty feed is different from the message for a device without a candidate update. If the feed is empty, the server can enforce an update on no device. This is a problem of the deployment, not a problem of the device.

The two conditions at the info level are normal. The device is not yet in the inventory, or the device is up to date. An error message for these two conditions hides the real errors, because the server writes one message for each device in the fleet.

The check for an empty feed does not use the platform. The feed of Apple has no key for `iPadOS`. Therefore the field `SoftwareUpdate.platform` never has this value, and a filter on the platform shows an empty feed for all the iPads. The server does this check only after it finds no candidate update.

## The comparison of the OS versions

A device that runs the same version as the target keeps the declaration. The server removes the declaration only if the target is below the version of the device. The test `test_..._latest_same` makes sure of this behavior.

The comparison uses the new property `SoftwareUpdate.full_comparable_os_version`. It does not use `comparable_os_version`, because that property removes an empty `extra`. For a device that runs `26.3`, and for an update to `26.3` that has no `extra`:

| Value | Result |
|---|---|
| `EnrolledDevice.comparable_os_version` | `(26, 3, 0, "")` |
| `SoftwareUpdate.comparable_os_version` | `(26, 3, 0)` |
| `SoftwareUpdate.full_comparable_os_version` | `(26, 3, 0, "")` |

A tuple of three elements compares lower than a tuple of four elements that has the same first three elements. Therefore an update that the device already runs looked older than the device.

The property `comparable_os_version` does not change. Two of its four callers need the tuple of three elements. One of these two callers is important. [dep.py:88](zentral/contrib/mdm/public_views/dep.py:88) sends a 403 response `com.apple.softwareupdate.required` if the update compares higher than the OS version that the device reported. If the tuple gets a fourth element, the server tells a device that is up to date to install an update, and the device cannot enroll. The function `best_available_software_updates` is not affected, because its `<=` operator gives the same result with both tuples.

To make the number of elements the same everywhere, you must also change `make_comparable_os_version` and the six comparisons with the value `(0, 0, 0)`. Three of these six comparisons are validators of the OS version. One comparison in munki changes an empty `max_os_version` from "no limit" to "removes all the items". This work is a different change.

## The API

The API now rejects a null value for `delay_days` and for `local_time` if `max_os_version` has a value. These two fields can be null, because a one time enforcement does not use them. But a latest enforcement that has no target date cannot build a declaration. Before the correction, the code raised a `TypeError` in `datetime.combine` on the same manifest paths. The form always required these two fields. Therefore only the API had the problem.

If you do not include the two fields, the behavior does not change. The server uses the defaults of the model. All the Zentral clients continue to work:

- The request structure of `goztl` has no `omitempty` option for these two pointers. Therefore `goztl` always sends the key, and it cannot remove one.
- The Terraform provider sends `14` and `09:30:00` if `max_os_version` has a value.

The acceptance tests of both clients pass without a change.

## Malformed client capabilities

The last commit corrects the same type of problem on the same paths. The server stores `client_capabilities` exactly as the device reported it in its status report. There is no validation. The function `build_target_management_status_subscriptions` caught only a `KeyError` for the lookup of the supported status items. But a value of an incorrect type raises a `TypeError`, and a status item that is not a string raises an `AttributeError`. Nothing catches these two exceptions while the server builds the manifest. Therefore `tokens`, `declaration-items` and `/connect` sent a 500 response, and the device received nothing.

These are the results before the correction:

| Value | Exception |
|---|---|
| `['supported-payloads']` | `TypeError: list indices must be integers` |
| `'nope'` | `TypeError: string indices must be integers` |
| `42` | `TypeError: 'int' object is not subscriptable` |

The function now uses the status items that all the clients support, as it did before for capabilities that have no `status-items` key. It also writes a warning. A value that is not an object has a different message, because the server can look up no key in it. The function `supports_software_update_enforcement_specific` has the check `isinstance(..., dict)`. This function was the only function without the check.

## The tests and the checks

- The complete test suite passes: 7958 tests.
- The patch coverage is 100% on all the changed lines. Method: get the intersection of the `missing_lines` of `coverage json` and the sections of `git diff -U0`.
- `mkdocs build --strict` passes.
- `ruff` finds no error in the changed files.
- Each commit passes `tests.mdm`. Therefore you can bisect the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
