### PR TITLE
Accept the content of an MDM data asset in the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ### Features
 
 
+#### MDM
+
+A data asset can be created and updated with its content in the request now, base 64 encoded in the new `source` attribute, and not only with a `file_uri` that points to an object in an S3 bucket. `file_uri` and `source` are mutually exclusive, and one of them is required. Zentral computes `file_sha256` from a `source`, and requires it only with a `file_uri`. A `file_sha256` given with a `source` is verified against the content. A data asset created from a `source` has no filename.
+
+The `file_uri` and `file_sha256` attributes of the data asset endpoints are not required fields anymore. A request without `file_uri` and without `source` gives one error for the two of them, and not one "This field is required." for each attribute.
+
+
 #### Santa
 
 A clean sync — `CLEAN` or `CLEAN_ALL` — can be queued for an enrolled machine from its machine page or from the API, and cancelled before its next preflight. The new `Santa::Action::"forceCleanSync"` PBAC action gives the permission, and accepts a meta business unit and a sync type.
@@ -49,6 +56,8 @@ Fixed an MDM data asset update that was rejected when it kept the same file: the
 The MDM data asset API accepts only XML property lists now, like the upload form. A binary property list was accepted, then stored and given to the devices as `text/xml`. An upload that used this is rejected now.
 
 A malformed base 64 source on the MDM profile and provisioning profile API endpoints gives a 400 now, and not a 500.
+
+The MDM data asset API gives a generic message when it cannot download the file now, like the package API already did. The message of an error from S3 can contain the bucket, the key, the region or the state of the credentials. Zentral writes it to its logs instead. The messages about the file extension, the URI scheme and the hash are unchanged.
 
 Fixed an MDM software update enforcement in latest mode that took a device out of management when it had no update to enforce. The `tokens` and `declaration-items` check-ins and `/connect` gave a 500, and the device stopped receiving all of its declarations. A device above the *Maximum target OS version* was enough to cause it, and so was a deployment that never synchronized the Apple software lookup service. Zentral leaves the configuration out of the declarations it serves now, and writes a log message.
 

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import io
 import os
@@ -151,9 +152,7 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'file_sha256': ['This field is required.'],
-             'file_uri': ['This field is required.'],
-             'type': ['This field is required.']}
+            {'type': ['This field is required.']}
         )
 
     def test_create_data_asset_plist_type_sha_error(self):
@@ -232,24 +231,32 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
     @patch("zentral.utils.external_resources.boto3.client")
     def test_create_data_asset_s3_error(self, boto3_client):
         boom = Mock()
-        boom.download_fileobj.side_effect = ValueError("Boom!!!")
+        boom.download_fileobj.side_effect = Exception(
+            "An error occurred (403) when calling the HeadObject operation: Forbidden"
+        )
         boto3_client.return_value = boom
         _, artifact, _ = force_blueprint_artifact(
             artifact_type=Artifact.Type.DATA_ASSET
         )
         self.set_permissions("mdm.add_dataasset")
         with patch.dict(os.environ, {"AWS_REGION": "eu-central-17"}):
-            response = self.post(reverse("mdm_api:data_assets"),
-                                 data={"artifact": str(artifact.pk),
-                                       "type": "ZIP",
-                                       "file_uri": "s3://yolo/fomo.zip",
-                                       "file_sha256": 64 * "0",
-                                       "macos": True,
-                                       "version": 2})
+            with self.assertLogs("zentral.contrib.mdm.serializers", level="ERROR") as captured:
+                response = self.post(reverse("mdm_api:data_assets"),
+                                     data={"artifact": str(artifact.pk),
+                                           "type": "ZIP",
+                                           "file_uri": "s3://yolo/fomo.zip",
+                                           "file_sha256": 64 * "0",
+                                           "macos": True,
+                                           "version": 2})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'file_uri': ['Boom!!!']}
+            {'file_uri': ['Could not download the data asset.']}
+        )
+        # the message from S3 stays on the server
+        self.assertNotIn("HeadObject", response.content.decode())
+        self.assertTrue(
+            any("Could not download data asset from s3://yolo/fomo.zip" in r for r in captured.output)
         )
         boto3_client.assert_called_once_with("s3", region_name="eu-central-17")
         boom.download_fileobj.assert_called_once()
@@ -516,6 +523,176 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
         blueprint.refresh_from_db()
         self.assertEqual(len(blueprint.serialized_artifacts[str(artifact.pk)]["versions"]), 2)
 
+    # create data asset from an inline source
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_data_asset_source_plist(self, post_event):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        content = build_plistfile(random=True).getvalue()
+        self.set_permissions("mdm.add_dataasset")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("mdm_api:data_assets"),
+                                 data={"artifact": str(artifact.pk),
+                                       "type": "PLIST",
+                                       "source": base64.b64encode(content).decode("ascii"),
+                                       "macos": True,
+                                       "version": 2})
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["filename"], "")
+        self.assertEqual(data["file_sha256"], hashlib.sha256(content).hexdigest())
+        self.assertEqual(data["file_size"], len(content))
+        data_asset = ArtifactVersion.objects.get(pk=data["id"]).data_asset
+        # the extension of the stored file is what sets the content type of the object
+        self.assertTrue(data_asset.file.name.endswith(".plist"))
+        data_asset.file.open("rb")
+        self.assertEqual(data_asset.file.read(), content)
+        data_asset.file.close()
+
+    def test_create_data_asset_source_zip(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        content = build_zipfile(random=True).getvalue()
+        self.set_permissions("mdm.add_dataasset")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("mdm_api:data_assets"),
+                                 data={"artifact": str(artifact.pk),
+                                       "type": "ZIP",
+                                       "source": base64.b64encode(content).decode("ascii"),
+                                       "macos": True,
+                                       "version": 2})
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["filename"], "")
+        data_asset = ArtifactVersion.objects.get(pk=data["id"]).data_asset
+        self.assertTrue(data_asset.file.name.endswith(".zip"))
+
+    def test_create_data_asset_source_matching_file_sha256(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        content = build_plistfile(random=True).getvalue()
+        self.set_permissions("mdm.add_dataasset")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("mdm_api:data_assets"),
+                                 data={"artifact": str(artifact.pk),
+                                       "type": "PLIST",
+                                       "source": base64.b64encode(content).decode("ascii"),
+                                       "file_sha256": hashlib.sha256(content).hexdigest(),
+                                       "macos": True,
+                                       "version": 2})
+        self.assertEqual(response.status_code, 201)
+
+    def test_create_data_asset_source_hash_mismatch(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        content = build_plistfile(random=True).getvalue()
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "source": base64.b64encode(content).decode("ascii"),
+                                   "file_sha256": 64 * "0",
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"file_sha256": ["Hash mismatch"]})
+
+    def test_create_data_asset_source_invalid_plist(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "source": base64.b64encode(b"\x00").decode("ascii"),
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"source": ["Invalid PLIST file"]})
+
+    def test_create_data_asset_source_invalid_zip(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "ZIP",
+                                   "source": base64.b64encode(b"\x00").decode("ascii"),
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"source": ["Invalid ZIP file"]})
+
+    def test_create_data_asset_source_not_different_from_latest_one(self):
+        artifact, (ea_av,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        data_asset = ea_av.data_asset
+        data_asset.file.open("rb")
+        content = data_asset.file.read()
+        data_asset.file.close()
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "ZIP",
+                                   "source": base64.b64encode(content).decode("ascii"),
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"source": ["This file is not different from the latest one"]})
+
+    def test_create_data_asset_source_and_file_uri_error(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        content = build_plistfile(random=True).getvalue()
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "file_uri": "s3://yolo/fomo.plist",
+                                   "file_sha256": hashlib.sha256(content).hexdigest(),
+                                   "source": base64.b64encode(content).decode("ascii"),
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"non_field_errors": ["file_uri and source are mutually exclusive"]}
+        )
+
+    def test_create_data_asset_no_source_no_file_uri_error(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"non_field_errors": ["file_uri or source is required"]}
+        )
+
+    def test_create_data_asset_file_uri_without_file_sha256_error(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "file_uri": "s3://yolo/fomo.plist",
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"file_sha256": ["This field is required with file_uri"]}
+        )
+
+    def test_create_data_asset_source_invalid_base64_error(self):
+        artifact, _ = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        self.set_permissions("mdm.add_dataasset")
+        response = self.post(reverse("mdm_api:data_assets"),
+                             data={"artifact": str(artifact.pk),
+                                   "type": "PLIST",
+                                   "source": "YQ",  # length not a multiple of four
+                                   "macos": True,
+                                   "version": 2})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"source": ["Invalid base64-encoded value"]})
+
     # get data asset
 
     def test_get_data_asset_unauthorized(self):
@@ -733,6 +910,24 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
         ea_av.refresh_from_db()
         self.assertEqual(ea_av.macos_min_version, "14.0")
         self.assertEqual(ea_av.data_asset.file_sha256, data_asset.file_sha256)
+
+    def test_update_data_asset_source(self):
+        artifact, (ea_av,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        content = build_zipfile(random=True).getvalue()
+        self.set_permissions("mdm.change_dataasset")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse("mdm_api:data_asset", args=(ea_av.pk,)),
+                                data={"artifact": str(artifact.pk),
+                                      "type": "ZIP",
+                                      "source": base64.b64encode(content).decode("ascii"),
+                                      "macos": True,
+                                      "version": ea_av.version})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["filename"], "")
+        self.assertEqual(data["file_sha256"], hashlib.sha256(content).hexdigest())
+        ea_av.refresh_from_db()
+        self.assertTrue(ea_av.data_asset.file.name.endswith(".zip"))
 
     # delete data asset
 

--- a/tests/mdm/test_api_data_assets_views.py
+++ b/tests/mdm/test_api_data_assets_views.py
@@ -115,6 +115,45 @@ class MDMDataAssetsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOrderi
         self.set_permissions("mdm.view_dataasset")
         self.assert_list_pages_every_row_once(reverse("mdm_api:data_assets"), ascending_ids)
 
+    # data asset endpoint metadata
+    #
+    # The terraform provider reads the OPTIONS of the list endpoint to tell a Zentral that has
+    # never heard of an attribute apart from one rejecting its value, so the shape of this answer
+    # is a contract and not a DRF implementation detail. Note that Zentral asks for the view
+    # permission on OPTIONS, where DRF asks for nothing.
+
+    def test_options_data_assets_unauthorized(self):
+        response = self.client.options(reverse("mdm_api:data_assets"))
+        self.assertEqual(response.status_code, 401)
+
+    def test_options_data_assets_permission_denied(self):
+        response = self.client.options(reverse("mdm_api:data_assets"),
+                                       HTTP_AUTHORIZATION=f"Token {self._get_api_key()}")
+        self.assertEqual(response.status_code, 403)
+
+    def test_options_data_assets_without_add_permission_has_no_actions(self):
+        self.set_permissions("mdm.view_dataasset")
+        response = self.client.options(reverse("mdm_api:data_assets"),
+                                       HTTP_AUTHORIZATION=f"Token {self._get_api_key()}")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("actions", response.json())
+
+    def test_options_data_assets(self):
+        self.set_permissions("mdm.view_dataasset", "mdm.add_dataasset")
+        response = self.client.options(reverse("mdm_api:data_assets"),
+                                       HTTP_AUTHORIZATION=f"Token {self._get_api_key()}")
+        self.assertEqual(response.status_code, 200)
+        post_fields = response.json()["actions"]["POST"]
+        self.assertIn("source", post_fields)
+        self.assertFalse(post_fields["source"]["read_only"])
+        self.assertFalse(post_fields["source"]["required"])
+        self.assertFalse(post_fields["file_uri"]["required"])
+        self.assertFalse(post_fields["file_uri"]["read_only"])
+        self.assertFalse(post_fields["file_sha256"]["required"])
+        self.assertTrue(post_fields["type"]["required"])
+        self.assertTrue(post_fields["filename"]["read_only"])
+        self.assertTrue(post_fields["file_size"]["read_only"])
+
     # create data asset
 
     def test_create_data_asset_unauthorized(self):

--- a/tests/mdm/test_management_data_asset.py
+++ b/tests/mdm/test_management_data_asset.py
@@ -74,6 +74,11 @@ class MDMDataAssetManagementViewsTestCase(TestCase, LoginCase):
             f"{slug}_{data_asset.pk}_v{artifact_version.version}.zip"
         )
 
+    def test_model_get_type_file_extension_unknown_type(self):
+        with self.assertLogs("zentral.contrib.mdm.models", level="ERROR") as captured:
+            self.assertIsNone(DataAsset.get_type_file_extension("YOLO"))
+        self.assertTrue(any("Unknown file extension for type YOLO" in r for r in captured.output))
+
     def test_post_delete_data_asset_deletes_file(self):
         _, (artifact_version,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
         data_asset = artifact_version.data_asset

--- a/tests/mdm/test_management_data_asset.py
+++ b/tests/mdm/test_management_data_asset.py
@@ -95,6 +95,31 @@ class MDMDataAssetManagementViewsTestCase(TestCase, LoginCase):
                 data_asset.delete()
         self.assertTrue(any("Could not delete data asset file" in r for r in captured.output))
 
+    def test_download_data_asset_without_filename(self):
+        _, (artifact_version,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        data_asset = artifact_version.data_asset
+        data_asset.type = DataAsset.Type.PLIST
+        data_asset.filename = ""
+        data_asset.save()
+        self.login("mdm.view_artifactversion")
+        response = self.client.get(reverse("mdm:download_data_asset", args=(artifact_version.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Content-Disposition"],
+            f'attachment; filename="data_asset_{artifact_version.pk}.plist"'
+        )
+
+    def test_data_asset_detail_without_filename(self):
+        artifact, (artifact_version,) = force_artifact(artifact_type=Artifact.Type.DATA_ASSET)
+        data_asset = artifact_version.data_asset
+        data_asset.filename = ""
+        data_asset.save()
+        self.login("mdm.view_artifact", "mdm.view_artifactversion")
+        response = self.client.get(reverse("mdm:artifact_version", args=(artifact.pk, artifact_version.pk)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<th>Filename</th>")
+        self.assertContains(response, "<td>-</td>")
+
     # upload data asset GET
 
     def test_upload_data_asset_get_redirect(self):

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3085,6 +3085,14 @@ class DataAsset(models.Model):
             return "application/zip"
         logger.error("Unknown content type for type %s", data_type)
 
+    @classmethod
+    def get_type_file_extension(cls, data_type):
+        if data_type == cls.Type.PLIST:
+            return ".plist"
+        elif data_type == cls.Type.ZIP:
+            return ".zip"
+        logger.error("Unknown file extension for type %s", data_type)
+
     def get_export_filename(self):
         slug = slugify(self.artifact_version.artifact.name)
         _, ext = os.path.splitext(self.filename)

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -1,8 +1,10 @@
 import base64
+import hashlib
 import logging
 import os
 import plistlib
 import re
+import tempfile
 import uuid
 import zipfile
 
@@ -716,6 +718,17 @@ class BlueprintArtifactSerializer(serializers.ModelSerializer):
         return instance
 
 
+class B64EncodedBinaryField(serializers.Field):
+    def to_representation(self, value):
+        return base64.b64encode(value).decode("ascii")
+
+    def to_internal_value(self, data):
+        try:
+            return base64.b64decode(data)
+        except Exception:
+            raise serializers.ValidationError("Invalid base64-encoded value")
+
+
 class ArtifactVersionSerializer(serializers.Serializer):
     id = serializers.UUIDField(read_only=True, source="artifact_version.pk")
     artifact = serializers.PrimaryKeyRelatedField(queryset=Artifact.objects.all(),
@@ -886,8 +899,9 @@ class CertAssetSerializer(ArtifactVersionSerializer):
 
 class DataAssetSerializer(ArtifactVersionSerializer):
     type = serializers.ChoiceField(required=True, choices=DataAsset.Type.choices)
-    file_uri = serializers.CharField(required=True, write_only=True)
-    file_sha256 = serializers.RegexField(r"^[0-9a-f]{64}$", required=True)
+    file_uri = serializers.CharField(required=False, write_only=True)
+    source = B64EncodedBinaryField(required=False, write_only=True)
+    file_sha256 = serializers.RegexField(r"^[0-9a-f]{64}$", required=False)
     file_size = serializers.IntegerField(read_only=True)
     filename = serializers.CharField(read_only=True)
 
@@ -895,20 +909,47 @@ class DataAssetSerializer(ArtifactVersionSerializer):
         data = super().validate(data)
         # type
         data_asset_type = DataAsset.Type(data["type"])
-        if data_asset_type == DataAsset.Type.PLIST:
-            supported_file_extensions = (".plist",)
-        elif data_asset_type == DataAsset.Type.ZIP:
-            supported_file_extensions = (".zip",)
-        else:
+        file_extension = DataAsset.get_type_file_extension(data_asset_type)
+        if file_extension is None:
             raise RuntimeError("Unknown data asset type")
-        # download external resource
-        try:
-            filename, tmp_file = download_external_resource(
-                data["file_uri"], data["file_sha256"],
-                supported_file_extensions
-            )
-        except Exception as e:
-            raise serializers.ValidationError({"file_uri": str(e)})
+        # the file, either inline or from an external resource
+        file_uri = data.get("file_uri")
+        source = data.get("source")
+        if file_uri and source is not None:
+            raise serializers.ValidationError("file_uri and source are mutually exclusive")
+        if not file_uri and source is None:
+            raise serializers.ValidationError("file_uri or source is required")
+        if source is not None:
+            # no file to name it after
+            filename = ""
+            file_sha256 = hashlib.sha256(source).hexdigest()
+            if data.get("file_sha256") and data["file_sha256"] != file_sha256:
+                raise serializers.ValidationError({"file_sha256": "Hash mismatch"})
+            error_field = "source"
+            tmp_file = tempfile.NamedTemporaryFile(suffix=file_extension, delete=False)
+            tmp_file.write(source)
+            tmp_file.flush()
+            tmp_file.seek(0)
+        else:
+            if not data.get("file_sha256"):
+                raise serializers.ValidationError({"file_sha256": "This field is required with file_uri"})
+            file_sha256 = data["file_sha256"]
+            error_field = "file_uri"
+            try:
+                filename, tmp_file = download_external_resource(file_uri, file_sha256, (file_extension,))
+            except ValueError as e:
+                # ValueError carries operator-facing validation messages
+                # (unknown URI scheme, unsupported extension, hash mismatch).
+                raise serializers.ValidationError({"file_uri": str(e)})
+            except Exception:
+                # Surface a generic message; the actual exception may carry
+                # internal state (boto3 traceback, file paths, …). The full
+                # exception is logged server-side for diagnosis.
+                logger.exception("Could not download data asset from %s", file_uri)
+                raise serializers.ValidationError(
+                    {"file_uri": "Could not download the data asset."}
+                )
+        data["file_sha256"] = file_sha256
         # verify file type
         if data_asset_type == DataAsset.Type.PLIST:
             try:
@@ -916,12 +957,12 @@ class DataAssetSerializer(ArtifactVersionSerializer):
             except Exception:
                 tmp_file.close()
                 os.unlink(tmp_file.name)
-                raise serializers.ValidationError({"file_uri": "Invalid PLIST file"})
+                raise serializers.ValidationError({error_field: "Invalid PLIST file"})
         elif data_asset_type == DataAsset.Type.ZIP:
             if not zipfile.is_zipfile(tmp_file):
                 tmp_file.close()
                 os.unlink(tmp_file.name)
-                raise serializers.ValidationError({"file_uri": "Invalid ZIP file"})
+                raise serializers.ValidationError({error_field: "Invalid ZIP file"})
         # verify last version
         latest_data_asset_qs = DataAsset.objects.filter(
             artifact_version__artifact=data["artifact_version"]["artifact"]
@@ -930,7 +971,7 @@ class DataAssetSerializer(ArtifactVersionSerializer):
             latest_data_asset_qs = latest_data_asset_qs.exclude(artifact_version=self.instance.artifact_version)
         latest_data_asset = latest_data_asset_qs.order_by("-artifact_version__version").first()
         if latest_data_asset and latest_data_asset.file_sha256 == data["file_sha256"]:
-            raise serializers.ValidationError({"file_uri": "This file is not different from the latest one"})
+            raise serializers.ValidationError({error_field: "This file is not different from the latest one"})
         # add data asset info
         tmp_file.seek(0)
         file = File(tmp_file)
@@ -1046,17 +1087,6 @@ class DeclarationSerializer(ArtifactVersionSerializer):
             for blueprint in instance.artifact_version.artifact.blueprints():
                 update_blueprint_serialized_artifacts(blueprint)
         return instance
-
-
-class B64EncodedBinaryField(serializers.Field):
-    def to_representation(self, value):
-        return base64.b64encode(value).decode("ascii")
-
-    def to_internal_value(self, data):
-        try:
-            return base64.b64decode(data)
-        except Exception:
-            raise serializers.ValidationError("Invalid base64-encoded value")
 
 
 class ProfileSerializer(ArtifactVersionSerializer):

--- a/zentral/contrib/mdm/templates/mdm/_data_asset_detail.html
+++ b/zentral/contrib/mdm/templates/mdm/_data_asset_detail.html
@@ -7,7 +7,7 @@
 </tr>
 <tr>
   <th>Filename</th>
-  <td>{{ data_asset.filename }}</td>
+  <td>{{ data_asset.filename|default:"-" }}</td>
 </tr>
 <tr>
   <th>File size</th>

--- a/zentral/contrib/mdm/views/management.py
+++ b/zentral/contrib/mdm/views/management.py
@@ -952,7 +952,9 @@ class DownloadDataAssetView(PermissionRequiredMixin, View):
         else:
             return FileResponse(
                 self._file_storage.open(data_asset.file.name),
-                filename=data_asset.filename or f"data_asset_{data_asset.artifact_version.pk}.zip",
+                filename=(data_asset.filename
+                          or f"data_asset_{data_asset.artifact_version.pk}"
+                             f"{data_asset.get_type_file_extension(data_asset.get_type())}"),
                 as_attachment=True
             )
 


### PR DESCRIPTION
Before this change, a data asset was only possible as an object in an S3 bucket. The request had to contain a `file_uri` and the `file_sha256` of the content. Now the request can contain the content, base 64 encoded in the new `source` attribute. The profile endpoints already accept a `.mobileconfig` in this way.

```hcl
resource "zentral_mdm_data_asset" "config-dict-2" {
  artifact_id = zentral_mdm_artifact.config-dict.id
  type        = "PLIST"
  source      = filebase64("${path.module}/plists/config-dict.v2.plist")
  ios         = true
  version     = 2
}
```

This change does not modify the model or the storage. Zentral puts the file in the dist storage, and sends it to the device with a redirect, as before. Only the input to the API changes.

### The two methods

Send `file_uri` or `source`, but not the two of them. One of them is necessary.

Zentral calculates `file_sha256` from a `source`. You must send `file_sha256` only with a `file_uri`. If you send `file_sha256` with a `source`, Zentral compares it with the content.

The two methods give the same filename, hash and temporary file before the other checks start. Therefore these parts do not change: the PLIST and ZIP checks, the comparison with the last version, the creation of the artifact version, and the removal of the temporary file.

### The extension of the temporary file is important

The temporary file keeps the extension of the type. `FileField` makes the storage path from the name of the `File` object, and not from the `filename` column. The extension in the storage path sets the content type of the stored object. The data asset declaration sends this content type to the device. `download_s3_external_resource` uses a suffix for its temporary file for the same reason. A test makes sure that the storage path ends with `.plist`.

### A data asset from a source has no filename

There is no file to give the name. No important function reads the `filename` column. The declaration contains the content type, the size and the hash, and the download view uses the storage path for the name of the response.

The second commit corrects the two locations that showed an empty value. The download in the management interface used a name that ends with `.zip` for all the types. The detail page showed an empty cell.

### Change to the API errors

`file_uri` and `file_sha256` are not necessary fields now. Zentral does these checks in `validate()`. A request without `file_uri` and without `source` gives one error for the two of them. Before, it gave one `This field is required.` for each attribute. This PR changes the test that had the old behavior.

### The error from S3 does not go to the client

CodeQL gave an alert on the download of the external resource. All the errors from boto3 went to the client in `str(e)`. These messages can contain the bucket, the key, the region or the state of the credentials.

The package API already has the correct behavior. It sends the message of a `ValueError`, because this message is for the operator. For all the other errors, it writes the details to the log, and sends a generic message. The data asset API does the same now. The messages about the file extension, the URI scheme and the hash do not change.

The test used a `ValueError` for the error from S3, but no error from boto3 is a `ValueError`. The test raises a general exception now, and makes sure that the message stays in the log.

### The third commit adds only tests

The Terraform provider will read the `OPTIONS` of the list endpoint. With this data, the provider can find the difference between a Zentral that does not know the `source` attribute, and a Zentral that refuses the value. Therefore the content of this answer is a contract, and not an internal detail of DRF. A change of `source` to a `HiddenField`, or a change to the structure of the serializer, removes this data. No other test finds this problem.

The tests also check the permissions. `DefaultDjangoModelPermissions` needs the view permission for `OPTIONS`, but DRF needs no permission. Without the add permission, DRF does not put `actions` in the answer. A client must read this as "no answer", and not as "no such attribute".

### Note about the diff

`B64EncodedBinaryField` moves up in `serializers.py`, because `DataAssetSerializer` uses it now. The behavior does not change, but the diff looks larger.

### Tests

The full test suite, as CI does it: **7977 tests, OK**.

All the added lines in `zentral/` have test coverage. To find this, compare the missing lines from `coverage json` with the hunks from `git diff -U0`: 70 added lines, and 0 lines without coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
