### PR TITLE
Do not put the error from S3 in the enterprise app API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The MDM data asset API accepts only XML property lists now, like the upload form
 
 A malformed base 64 source on the MDM profile and provisioning profile API endpoints gives a 400 now, and not a 500.
 
-The MDM data asset API gives a generic message when it cannot download the file now, like the package API already did. The message of an error from S3 can contain the bucket, the key, the region or the state of the credentials. Zentral writes it to its logs instead. The messages about the file extension, the URI scheme and the hash are unchanged.
+The MDM data asset and enterprise app APIs give a generic message when they cannot download the file now, like the package API already did. The message of an error from S3 can contain the bucket, the key, the region or the state of the credentials. Zentral writes it to its logs instead. The messages about the file extension, the URI scheme and the hash are unchanged.
 
 Fixed an MDM software update enforcement in latest mode that took a device out of management when it had no update to enforce. The `tokens` and `declaration-items` check-ins and `/connect` gave a 500, and the device stopped receiving all of its declarations. A device above the *Maximum target OS version* was enough to cause it, and so was a deployment that never synchronized the Apple software lookup service. Zentral leaves the configuration out of the declarations it serves now, and writes a log message.
 

--- a/tests/mdm/test_api_enterprise_apps_views.py
+++ b/tests/mdm/test_api_enterprise_apps_views.py
@@ -240,23 +240,32 @@ class MDMEnterpriseAppsAPIViewsTestCase(TestCase, LoginCase, RequestCase, ListOr
     @patch("zentral.utils.external_resources.boto3.client")
     def test_create_enterprise_app_s3_error(self, boto3_client):
         boom = Mock()
-        boom.download_fileobj.side_effect = ValueError("Boom!!!")
+        boom.download_fileobj.side_effect = Exception(
+            "An error occurred (403) when calling the HeadObject operation: Forbidden"
+        )
         boto3_client.return_value = boom
         _, artifact, _ = force_blueprint_artifact(
             artifact_type=Artifact.Type.ENTERPRISE_APP
         )
         self.set_permissions("mdm.add_enterpriseapp")
         with patch.dict(os.environ, {"AWS_REGION": "eu-central-17"}):
-            response = self.post(reverse("mdm_api:enterprise_apps"),
-                                 data={"artifact": str(artifact.pk),
-                                       "package_uri": "s3://yolo/fomo.pkg",
-                                       "package_sha256": 64 * "0",
-                                       "macos": True,
-                                       "version": 2})
+            with self.assertLogs("zentral.contrib.mdm.serializers", level="ERROR") as captured:
+                response = self.post(reverse("mdm_api:enterprise_apps"),
+                                     data={"artifact": str(artifact.pk),
+                                           "package_uri": "s3://yolo/fomo.pkg",
+                                           "package_sha256": 64 * "0",
+                                           "macos": True,
+                                           "version": 2})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {'package_uri': ['Boom!!!']}
+            {'package_uri': ['Could not download or validate the enterprise app.']}
+        )
+        # the message from S3 stays on the server
+        self.assertNotIn("HeadObject", response.content.decode())
+        self.assertTrue(
+            any("Could not download or validate enterprise app from s3://yolo/fomo.pkg" in r
+                for r in captured.output)
         )
         boto3_client.assert_called_once_with("s3", region_name="eu-central-17")
         boom.download_fileobj.assert_called_once()

--- a/zentral/contrib/mdm/serializers.py
+++ b/zentral/contrib/mdm/serializers.py
@@ -1205,8 +1205,18 @@ class EnterpriseAppSerializer(ArtifactVersionSerializer):
         try:
             filename, tmp_file = download_external_resource(package_uri, package_sha256, (".pkg", ".ipa"))
             _, _, ea_data = read_package_info(tmp_file)
-        except Exception as e:
+        except ValueError as e:
+            # ValueError carries operator-facing validation messages
+            # (unknown URI scheme, unsupported extension, hash mismatch).
             raise serializers.ValidationError({"package_uri": str(e)})
+        except Exception:
+            # Surface a generic message; the actual exception may carry
+            # internal state (boto3 traceback, file paths, …). The full
+            # exception is logged server-side for diagnosis.
+            logger.exception("Could not download or validate enterprise app from %s", package_uri)
+            raise serializers.ValidationError(
+                {"package_uri": "Could not download or validate the enterprise app."}
+            )
         # same product ID?
         artifact = data["artifact_version"]["artifact"]
         if (


### PR DESCRIPTION
The enterprise app API is the last of the three callers of `download_external_resource` that sent everything boto3 raises to the client in `str(e)`. Those messages can contain the bucket, the key, the region or the state of the credentials. The package API and the data asset API already answer in the correct way, so this makes the three of them the same.

```python
except ValueError as e:
    # ValueError carries operator-facing validation messages
    # (unknown URI scheme, unsupported extension, hash mismatch).
    raise serializers.ValidationError({"package_uri": str(e)})
except Exception:
    # Surface a generic message; the actual exception may carry
    # internal state (boto3 traceback, file paths, …). The full
    # exception is logged server-side for diagnosis.
    logger.exception("Could not download or validate enterprise app from %s", package_uri)
    raise serializers.ValidationError(
        {"package_uri": "Could not download or validate the enterprise app."}
    )
```

`read_package_info` runs in the same `try`, and it raises a `ValueError` for its own message about the file extension. That message still reaches the client. The tests that check the messages about the URI scheme, the file extension and the hash do not change.

### The test

The test used a `ValueError` for the error from S3, but no error from boto3 is a `ValueError`, so it did not exercise the branch it looked like it exercised. It raises a plain exception now, and it makes sure that:

- the client gets the generic message,
- `HeadObject` is not in the body of the answer,
- the message from S3 is in the log.

### Tests

The full test suite, as CI does it: **7977 tests, OK**. All the added lines in `zentral/` have test coverage: 11 added lines, and 0 lines without coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
