### PR TITLE
Reject PATCH on the last two API views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ The `version` attribute of an Osquery query in an event payload is the version o
 
 `PATCH` gives a `405 Method Not Allowed` on the Monolith catalog, condition, enrollment and manifest enrollment package endpoints. Use `PUT`, and send all the attributes of the object.
 
+
+#### 🧨 PATCH on the Santa rule and Inventory JMESPath check endpoints
+
+`PATCH` gives a `405 Method Not Allowed` on the Santa rule and the Inventory JMESPath check endpoints. Use `PUT`, and send all the attributes of the object. These were the last two endpoints that accepted the method. A `PATCH` on a Santa rule gave a 500, because the serializer reads a `target` attribute that the request did not contain.
+
+
 #### 🧨 Santa enrolled machines metrics
 
 `zentral_santa_enrolled_machines_total` and `zentral_santa_enrolled_machines_sync_total` are replaced by `zentral_santa_enrolled_machines_bucket` and `zentral_santa_enrolled_machines_sync_bucket`, which have an `le` label. The `le="+Inf"` bucket gives the value of the two removed gauges: in a dashboard or an alert, change the metric name and select that bucket. A query that sums the buckets counts each machine seven times.

--- a/tests/server_base/test_api_http_methods.py
+++ b/tests/server_base/test_api_http_methods.py
@@ -1,0 +1,45 @@
+from django.test import SimpleTestCase
+from django.urls import URLPattern, URLResolver, get_resolver
+from rest_framework.views import APIView
+
+
+def iter_api_views(resolver=None, prefix=""):
+    if resolver is None:
+        resolver = get_resolver()
+    for pattern in resolver.url_patterns:
+        path = prefix + str(pattern.pattern)
+        if isinstance(pattern, URLResolver):
+            yield from iter_api_views(pattern, path)
+        elif isinstance(pattern, URLPattern):
+            view_class = getattr(pattern.callback, "cls", None)
+            if view_class is not None and issubclass(view_class, APIView):
+                yield path, view_class
+
+
+class APIHTTPMethodsTestCase(SimpleTestCase):
+    maxDiff = None
+
+    def test_the_traversal_reaches_the_api(self):
+        """A guard that stops traversing passes for the wrong reason.
+
+        The counts are lower bounds on an API that only grows; they exist so that a change to how
+        the URL conf or DRF exposes the view class fails here instead of quietly checking nothing.
+        """
+        views = list(iter_api_views())
+        self.assertGreater(len(views), 150)
+        self.assertGreater(len([cls for _, cls in views if hasattr(cls, "patch")]), 40)
+
+    def test_no_api_view_answers_patch(self):
+        """Zentral only does full updates.
+
+        Several serializers read a declared field straight out of validated_data in validate(),
+        which a partial update leaves out — a KeyError, and a 500. A view that inherits a patch()
+        handler from DRF has to leave the method out of its http_method_names.
+        """
+        offenders = []
+        for path, view_class in iter_api_views():
+            if not hasattr(view_class, "patch"):
+                continue
+            if "patch" in (method.lower() for method in view_class.http_method_names):
+                offenders.append(f"{path} {view_class.__module__}.{view_class.__name__}")
+        self.assertEqual(sorted(offenders), [])

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 from accounts.api_authentication import APITokenAuthentication
 from zentral.core.events.base import EventRequest
 from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
+                               FULL_UPDATE_AND_DELETE_METHOD_NAMES,
                                ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import JMESPathCheckCreated, JMESPathCheckDeleted, JMESPathCheckUpdated
 from .forms import AndroidAppSearchForm, DebPackageSearchForm, IOSAppSearchForm, MacOSAppSearchForm, ProgramsSearchForm
@@ -438,6 +439,7 @@ class JMESPathCheckDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = JMESPathCheck.objects.select_related("compliance_check").all()
     permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = JMESPathCheckSerializer
+    http_method_names = FULL_UPDATE_AND_DELETE_METHOD_NAMES
 
     def perform_update(self, serializer):
         serializer.save()

--- a/zentral/contrib/santa/api_views.py
+++ b/zentral/contrib/santa/api_views.py
@@ -18,6 +18,7 @@ from zentral.contrib.inventory.models import File, MetaMachine, Tag
 from zentral.contrib.santa.utils import build_configuration_plist, build_configuration_profile
 from zentral.core.events.base import AuditEvent
 from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
+                               FULL_UPDATE_AND_DELETE_METHOD_NAMES,
                                ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
                                PBACPermission, RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import post_santa_ruleset_update_events, post_santa_rule_update_event
@@ -281,6 +282,7 @@ class RuleDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Rule.objects.select_related("configuration", "ruleset", "target")
     permission_classes = (DefaultDjangoModelPermissions,)
     serializer_class = RuleSerializer
+    http_method_names = FULL_UPDATE_AND_DELETE_METHOD_NAMES
 
     def perform_destroy(self, instance):
         if instance.is_voting_rule:

--- a/zentral/utils/drf.py
+++ b/zentral/utils/drf.py
@@ -70,6 +70,14 @@ class DefaultDjangoModelPermissions(DjangoModelPermissions):
     }
 
 
+# http methods
+
+# Zentral only does full updates — PATCH is a 405 everywhere, so the serializers' update()
+# methods can rely on every declared field being present in validated_data
+FULL_UPDATE_METHOD_NAMES = ["get", "head", "options", "put"]
+FULL_UPDATE_AND_DELETE_METHOD_NAMES = FULL_UPDATE_METHOD_NAMES + ["delete"]
+
+
 # views with audit events
 
 
@@ -101,9 +109,7 @@ class ListCreateAPIViewWithAudit(generics.ListCreateAPIView):
 
 class RetrieveUpdateAPIViewWithAudit(generics.RetrieveUpdateAPIView):
     permission_classes = [DefaultDjangoModelPermissions]
-    # Zentral only does full updates — PATCH is a 405 everywhere, so the serializers' update()
-    # methods can rely on every declared field being present in validated_data
-    http_method_names = ["get", "head", "options", "put"]
+    http_method_names = FULL_UPDATE_METHOD_NAMES
 
     def get_audit_machine_serial_number(self):
         return None
@@ -131,7 +137,7 @@ class RetrieveUpdateAPIViewWithAudit(generics.RetrieveUpdateAPIView):
 
 class RetrieveUpdateDestroyAPIViewWithAudit(RetrieveUpdateAPIViewWithAudit,
                                             generics.RetrieveUpdateDestroyAPIView):
-    http_method_names = RetrieveUpdateAPIViewWithAudit.http_method_names + ["delete"]
+    http_method_names = FULL_UPDATE_AND_DELETE_METHOD_NAMES
 
     def get_perform_destroy_kwargs(self):
         """The keyword arguments for the delete() of the object.


### PR DESCRIPTION
## What this does

`PATCH` gives a `405 Method Not Allowed` on the santa rule and the inventory JMESPath check endpoints. These are the last two API views that accepted the method.

## Why the PR is much smaller than before

When this PR opened, 15 plain DRF detail views across osquery, monolith, munki, santa and inventory still answered a `PATCH`. The audit event work of 2026.6 moved 13 of them to the audited bases, which set `http_method_names`, so those views are already done on main. Only two are left, and this PR now rebases onto main with that reduced scope.

## Why PATCH has to be a 405

Zentral only does full updates. Several serializers read a declared field directly from `validated_data` in `validate()`. A partial update leaves the key out, so the request ended in a `KeyError` and a 500, and not in a 400. The santa rule serializer reads `data["target"]` in this way.

## The guard test

`tests/server_base/test_api_http_methods.py` walks the URL conf, and does not add a 405 test to each endpoint. It finds each `APIView` that has a `patch()` handler — 60 of the 204 API views — and names the ones that still accept the method. This also covers the next view that someone adds.

A second test makes sure that the traversal reaches the API. A guard that stops traversing passes for the wrong reason, so a change to the way the URL conf gives the view class fails there, and does not pass with nothing checked.

## Note on #1650

#1650 moves the inventory JMESPath check view to the audited base, which sets `http_method_names` on its own. The two PRs touch the same lines. If #1650 goes in first, remove the `http_method_names` line from the inventory view here.

## Tests

- 1398 tests in `tests.server_base.test_api_http_methods`, `tests.santa` and `tests.inventory`: OK
- No test in the suite did a `PATCH` that worked, so nothing needed a change to keep passing