### PR TITLE
Publish audit events from the Osquery management views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ The enrolled machine and sync state metrics are bucketed by the age of the last 
 ### Backward incompatibilities
 
 
+#### 🧨 Osquery query payload in events
+
+The `version` attribute of an Osquery query in an event payload is the version of the query again. It was the minimum Osquery version of the query, which replaced the query version when the query had one. The minimum Osquery version has its own `minimum_osquery_version` attribute now. The query payload also has the `pk`, `name` and `tag` attributes, and the compliance check of the query. This payload is a part of the `osquery_pack_query_update` events.
+
+
 #### 🧨 Santa enrolled machines metrics
 
 `zentral_santa_enrolled_machines_total` and `zentral_santa_enrolled_machines_sync_total` are replaced by `zentral_santa_enrolled_machines_bucket` and `zentral_santa_enrolled_machines_sync_bucket`, which have an `le` label. The `le="+Inf"` bucket gives the value of the two removed gauges: in a dashboard or an alert, change the metric name and select that bucket. A query that sums the buckets counts each machine seven times.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ A data asset can be created and updated with its content in the request now, bas
 The `file_uri` and `file_sha256` attributes of the data asset endpoints are not required fields anymore. A request without `file_uri` and without `source` gives one error for the two of them, and not one "This field is required." for each attribute.
 
 
+#### Osquery
+
+Zentral publishes a `zentral_audit` event when a user creates, updates or deletes an Osquery object from the web console: automatic table constructions, configurations, configuration packs, enrollments, file categories, packs, pack queries, queries and distributed query runs. Each event carries the full value of the object before and after the change, and the user, the source IP and the request that made it.
+
+A run that stops other runs of the same query — the "Halt current runs" option — now publishes one event for each stopped run. Before, the other runs ended with no record of it.
+
+
 #### Santa
 
 A clean sync — `CLEAN` or `CLEAN_ALL` — can be queued for an enrolled machine from its machine page or from the API, and cancelled before its next preflight. The new `Santa::Action::"forceCleanSync"` PBAC action gives the permission, and accepts a meta business unit and a sync type.
@@ -35,6 +42,8 @@ The `version` attribute of an Osquery query in an event payload is the version o
 
 ### Bug fixes
 
+
+Fixed the version of an Osquery query in the events published when a user changed the query from the web console. The version was a database expression, and not a number.
 
 Fixed the `zentral_audit` event published when a user increases the version of an enrollment. The enrollment payload had no version, so the event showed the same value before and after the change. The payload has the `version` and `updated_at` attributes now, for the Monolith, Munki, Osquery, Santa and Turbo enrollments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The enrolled machine and sync state metrics are bucketed by the age of the last 
 ### Bug fixes
 
 
+Fixed the `zentral_audit` event published when a user increases the version of an enrollment. The enrollment payload had no version, so the event showed the same value before and after the change. The payload has the `version` and `updated_at` attributes now, for the Monolith, Munki, Osquery, Santa and Turbo enrollments.
+
 Fixed the version of a Munki script check that increased on every API update: the excluded tags were compared with the included tags. A new version makes every machine in scope run the check again.
 
 Fixed the Santa machines reported out of sync when a rule of the current sync session replaced a rule they already had. The ledger keeps the rule the client confirmed until it confirms the replacement, and a lost session returns to it.

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -6,6 +6,21 @@
 
 To activate the osquery module, you need to add a `zentral.contrib.osquery` section to the `apps` section in `base.json`.
 
+## Audit events
+
+Zentral publishes a `zentral_audit` event when a user creates, updates or deletes an Osquery object from the web console: automatic table constructions, configurations, configuration packs, enrollments, file categories, packs, pack queries, queries, and distributed query runs. Each event carries the value of the object before and after the change, with the user, the source IP and the request that made it.
+
+Most of these objects are managed with the Zentral Terraform provider: the automatic table constructions, the configurations, the configuration packs, the enrollments, the file categories, the packs and the queries. For these objects, the event records a change that did not come from the Terraform configuration.
+
+Distributed query runs are not managed with Terraform. A run executes SQL on the machines, and the event records that action.
+
+Two effects of a change have no event of their own:
+
+* A change to a configuration increases the version of each of its enrollments. The event of the configuration records the change.
+* A change to a pack query sets the update time of its pack. The event of the pack query records the change.
+
+The "Halt current runs" option of a new run stops the other runs of the same query. Each stopped run has its own event.
+
 ## HTTP API
 
 ### Requests

--- a/tests/osquery/test_setup_atcs.py
+++ b/tests/osquery/test_setup_atcs.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
 from accounts.models import User
+from tests.osquery.utils import assert_audit_event
+from zentral.core.events.base import AuditEvent
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.osquery.models import AutomaticTableConstruction
 
@@ -62,18 +65,46 @@ class OsquerySetupATCViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/automatictableconstruction_form.html")
         self.assertContains(response, "Create Automatic table construction")
 
-    def test_create_atc_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_atc_post(self, post_event):
         self.login("osquery.add_automatictableconstruction", "osquery.view_automatictableconstruction")
         atc_name = get_random_string(12)
         atc_description = get_random_string(12)
         atc_dict = self._get_atc_dict(name=atc_name, description=atc_description)
-        response = self.client.post(reverse("osquery:create_atc"), atc_dict, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:create_atc"), atc_dict, follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/automatictableconstruction_detail.html")
         self.assertContains(response, atc_name)
         atc = response.context["object"]
         self.assertEqual(atc.name, atc_name)
         self.assertEqual(atc.description, atc_description)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.automatictableconstruction",
+                 "pk": str(atc.pk),
+                 "new_value": {
+                     "pk": atc.pk,
+                     "name": atc_name,
+                     "description": atc_description,
+                     "table_name": atc_dict["table_name"],
+                     "query": atc_dict["query"],
+                     "path": atc_dict["path"],
+                     "columns": atc.columns,
+                     "platforms": atc.platforms,
+                     "created_at": atc.created_at.isoformat(),
+                     "updated_at": atc.updated_at.isoformat(),
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"osquery_automatic_table_construction": [str(atc.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
     # update atc
 
@@ -94,17 +125,24 @@ class OsquerySetupATCViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "osquery/automatictableconstruction_form.html")
 
-    def test_update_atc_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_atc_post(self, post_event):
         atc, atc_dict = self._force_atc()
+        prev_value = atc.serialize_for_event()
         self.login("osquery.change_automatictableconstruction", "osquery.view_automatictableconstruction")
         atc_dict["name"] = get_random_string(12)
-        response = self.client.post(reverse("osquery:update_atc", args=(atc.pk,)),
-                                    atc_dict, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:update_atc", args=(atc.pk,)),
+                                        atc_dict, follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/automatictableconstruction_detail.html")
         self.assertContains(response, atc_dict["name"])
         atc = response.context["object"]
         self.assertEqual(atc.name, atc_dict["name"])
+        payload, metadata = assert_audit_event(self, post_event, "updated", atc, prev_value=prev_value)
+        self.assertNotEqual(payload["object"]["prev_value"]["name"], payload["object"]["new_value"]["name"])
+        self.assertEqual(metadata["objects"], {"osquery_automatic_table_construction": [str(atc.pk)]})
 
     # delete atc
 
@@ -126,14 +164,20 @@ class OsquerySetupATCViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/automatictableconstruction_confirm_delete.html")
         self.assertContains(response, atc.name)
 
-    def test_delete_atc_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_atc_post(self, post_event):
         atc, _ = self._force_atc()
+        prev_value = atc.serialize_for_event()
         self.login("osquery.delete_automatictableconstruction", "osquery.view_automatictableconstruction")
-        response = self.client.post(reverse("osquery:delete_atc", args=(atc.pk,)), follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_atc", args=(atc.pk,)), follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/automatictableconstruction_list.html")
         self.assertEqual(AutomaticTableConstruction.objects.filter(pk=atc.pk).count(), 0)
         self.assertNotContains(response, atc.name)
+        _, metadata = assert_audit_event(self, post_event, "deleted", atc, prev_value=prev_value)
+        self.assertEqual(metadata["objects"], {"osquery_automatic_table_construction": [str(atc.pk)]})
 
     # atc list
 

--- a/tests/osquery/test_setup_configurations.py
+++ b/tests/osquery/test_setup_configurations.py
@@ -1,12 +1,16 @@
+from unittest.mock import patch
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
 from accounts.models import User
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
+from zentral.core.events.base import AuditEvent
 from zentral.contrib.inventory.models import Tag
-from zentral.contrib.osquery.models import Configuration, ConfigurationPack, Pack, PackQuery, Query
+from zentral.contrib.osquery.models import (AutomaticTableConstruction, Configuration,
+                                            ConfigurationPack, FileCategory, Pack, PackQuery, Query)
 
 
 class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
@@ -60,17 +64,20 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/configuration_form.html")
         self.assertContains(response, "Create Osquery configuration")
 
-    def test_create_configuration_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_configuration_post(self, post_event):
         self.login("osquery.add_configuration", "osquery.view_configuration")
         configuration_name = get_random_string(64)
         configuration_description = get_random_string(12)
-        response = self.client.post(reverse("osquery:create_configuration"),
-                                    {"name": configuration_name,
-                                     "description": configuration_description,
-                                     "inventory_interval": 86321,
-                                     "inventory_ec2": True},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:create_configuration"),
+                                        {"name": configuration_name,
+                                         "description": configuration_description,
+                                         "inventory_interval": 86321,
+                                         "inventory_ec2": True},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertContains(response, configuration_name)
         self.assertContains(response, configuration_description)
@@ -78,6 +85,34 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertEqual(configuration.name, configuration_name)
         self.assertEqual(configuration.description, configuration_description)
         self.assertEqual(configuration.inventory_interval, 86321)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.configuration",
+                 "pk": str(configuration.pk),
+                 "new_value": {
+                     "pk": configuration.pk,
+                     "name": configuration_name,
+                     "description": configuration_description,
+                     # unchecked checkboxes are not posted, so the model default of True does not apply
+                     "inventory": False,
+                     "inventory_apps": False,
+                     "inventory_ec2": True,
+                     "inventory_interval": 86321,
+                     "options": {},
+                     "file_categories": [],
+                     "automatic_table_constructions": [],
+                     "created_at": configuration.created_at.isoformat(),
+                     "updated_at": configuration.updated_at.isoformat(),
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"osquery_configuration": [str(configuration.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
         self.assertTrue(configuration.inventory_ec2)
         self.assertEqual(configuration.options, {})
 
@@ -101,20 +136,43 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/configuration_form.html")
         self.assertContains(response, "Update Osquery configuration")
 
-    def test_update_configuration_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_configuration_post(self, post_event):
         configuration = self._force_configuration()
+        prev_value = configuration.serialize_for_event()
         self.login("osquery.change_configuration", "osquery.view_configuration")
         new_name = get_random_string(64)
-        response = self.client.post(reverse("osquery:update_configuration", args=(configuration.pk,)),
-                                    {"name": new_name, "inventory_interval": 863},
-                                    follow=True)
+        file_category = FileCategory.objects.create(name=get_random_string(12), slug=get_random_string(12))
+        atc = AutomaticTableConstruction.objects.create(
+            name=get_random_string(12),
+            table_name=get_random_string(length=12, allowed_chars="abcd_"),
+            query="select 1 from yo;",
+            path="/home/yolo",
+            columns=["un"],
+        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:update_configuration", args=(configuration.pk,)),
+                                        {"name": new_name,
+                                         "inventory_interval": 863,
+                                         "file_categories": [file_category.pk],
+                                         "automatic_table_constructions": [atc.pk]},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertContains(response, new_name)
         configuration = response.context["object"]
         self.assertEqual(configuration.name, new_name)
         self.assertEqual(configuration.inventory_interval, 863)
         self.assertEqual(configuration.options, {})
+        payload, metadata = assert_audit_event(self, post_event, "updated", configuration, prev_value=prev_value)
+        self.assertEqual(payload["object"]["new_value"]["inventory_interval"], 863)
+        self.assertEqual(payload["object"]["prev_value"]["file_categories"], [])
+        self.assertEqual(payload["object"]["new_value"]["file_categories"],
+                         [{"pk": file_category.pk, "name": file_category.name}])
+        self.assertEqual(payload["object"]["new_value"]["automatic_table_constructions"],
+                         [{"pk": atc.pk, "name": atc.name}])
+        self.assertEqual(metadata["objects"], {"osquery_configuration": [str(configuration.pk)]})
 
     # configuration list
 
@@ -175,15 +233,18 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/configurationpack_form.html")
         self.assertEqual(response.context["configuration"], configuration)
 
-    def test_add_configuration_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_add_configuration_pack_post(self, post_event):
         configuration = self._force_configuration()
         pack = self._force_pack()
         self.login("osquery.change_configuration", "osquery.view_configuration")
-        response = self.client.post(
-            reverse("osquery:add_configuration_pack", args=(configuration.pk,)),
-            {"pack": pack.pk},
-            follow=True
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("osquery:add_configuration_pack", args=(configuration.pk,)),
+                {"pack": pack.pk},
+                follow=True
+            )
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertEqual(response.context["configuration"], configuration)
         configuration_packs = response.context["configuration_packs"]
@@ -192,6 +253,29 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertEqual(configuration_pack.configuration, configuration)
         self.assertEqual(configuration_pack.pack, pack)
         self.assertEqual(configuration_pack.tags.count(), 0)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.configurationpack",
+                 "pk": str(configuration_pack.pk),
+                 "new_value": {
+                     "pk": configuration_pack.pk,
+                     "configuration": {"pk": configuration.pk, "name": configuration.name},
+                     "pack": {"pk": pack.pk, "slug": pack.slug},
+                     "tags": [],
+                     "excluded_tags": [],
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"],
+                         {"osquery_configuration_pack": [str(configuration_pack.pk)],
+                          "osquery_configuration": [str(configuration.pk)],
+                          "osquery_pack": [str(pack.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
     # update configuration pack
 
@@ -239,20 +323,24 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
             f"'{tag.name}' cannot be both included and excluded"
         )
 
-    def test_update_configuration_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_configuration_pack_post(self, post_event):
         configuration_pack = self._force_configuration_pack()
+        prev_value = configuration_pack.serialize_for_event()
         self.login("osquery.change_configuration", "osquery.view_configuration")
         tag = Tag.objects.create(name=get_random_string(12))
         excluded_tag = Tag.objects.create(name=get_random_string(12))
-        response = self.client.post(
-            reverse("osquery:update_configuration_pack",
-                    args=(configuration_pack.configuration.pk, configuration_pack.pk)),
-            {"pack": configuration_pack.pack.pk,
-             "tags": [tag.pk],
-             "excluded_tags": [excluded_tag.pk]},
-            follow=True
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("osquery:update_configuration_pack",
+                        args=(configuration_pack.configuration.pk, configuration_pack.pk)),
+                {"pack": configuration_pack.pack.pk,
+                 "tags": [tag.pk],
+                 "excluded_tags": [excluded_tag.pk]},
+                follow=True
+            )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertEqual(response.context["object"], configuration_pack.configuration)
         configuration_packs = response.context["configuration_packs"]
@@ -263,6 +351,16 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertEqual(list(resp_configuration_pack.tags.all()), [tag])
         self.assertEqual(list(resp_configuration_pack.excluded_tags.all()), [excluded_tag])
         self.assertContains(response, tag.name)
+        payload, metadata = assert_audit_event(self, post_event, "updated", resp_configuration_pack,
+                                               prev_value=prev_value)
+        self.assertEqual(payload["object"]["prev_value"]["tags"], [])
+        self.assertEqual(payload["object"]["new_value"]["tags"], [{"pk": tag.pk, "name": tag.name}])
+        self.assertEqual(payload["object"]["new_value"]["excluded_tags"],
+                         [{"pk": excluded_tag.pk, "name": excluded_tag.name}])
+        self.assertEqual(metadata["objects"],
+                         {"osquery_configuration_pack": [str(configuration_pack.pk)],
+                          "osquery_configuration": [str(configuration_pack.configuration.pk)],
+                          "osquery_pack": [str(configuration_pack.pack.pk)]})
 
     # remove configuration pack
 
@@ -286,14 +384,23 @@ class OsquerySetupConfigurationsViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/configurationpack_confirm_delete.html")
         self.assertEqual(response.context["object"], configuration_pack)
 
-    def test_remove_configuration_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_remove_configuration_pack_post(self, post_event):
         configuration_pack = self._force_configuration_pack()
+        prev_value = configuration_pack.serialize_for_event()
         self.login("osquery.change_configuration", "osquery.view_configuration")
-        response = self.client.post(reverse("osquery:remove_configuration_pack",
-                                            args=(configuration_pack.configuration.pk, configuration_pack.pk)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:remove_configuration_pack",
+                                                args=(configuration_pack.configuration.pk, configuration_pack.pk)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertEqual(response.context["object"], configuration_pack.configuration)
         configuration_packs = response.context["configuration_packs"]
         self.assertEqual(configuration_packs.count(), 0)
+        _, metadata = assert_audit_event(self, post_event, "deleted", configuration_pack, prev_value=prev_value)
+        self.assertEqual(metadata["objects"],
+                         {"osquery_configuration_pack": [str(configuration_pack.pk)],
+                          "osquery_configuration": [str(configuration_pack.configuration.pk)],
+                          "osquery_pack": [str(configuration_pack.pack.pk)]})

--- a/tests/osquery/test_setup_distributed_queries.py
+++ b/tests/osquery/test_setup_distributed_queries.py
@@ -7,7 +7,9 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
+from zentral.core.events.base import AuditEvent
 from zentral.contrib.osquery.models import (
     DistributedQuery,
     DistributedQueryMachine,
@@ -72,22 +74,57 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, query.name)
         self.assertNotContains(response, "Halt current")
 
-    def test_create_distributed_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_distributed_query_post(self, post_event):
         query = self._force_query()
+        query.minimum_osquery_version = "5.10.2"
+        query.save()
         self.login("osquery.add_distributedquery", "osquery.view_distributedquery")
-        response = self.client.post(
-            "{}?q={}".format(reverse("osquery:create_distributed_query"), query.pk),
-            {"valid_from": naive_utcnow().strftime("%Y-%m-%d %H:%M:%S"),
-             "shard": "100"},
-            follow=True
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                "{}?q={}".format(reverse("osquery:create_distributed_query"), query.pk),
+                {"valid_from": naive_utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                 "shard": "100"},
+                follow=True
+            )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/distributedquery_detail.html")
         self.assertEqual(response.context["query"], query)
         distributed_query = response.context["object"]
         self.assertEqual(distributed_query.query, query)
         self.assertEqual(distributed_query.sql, query.sql)
         self.assertEqual(distributed_query.query_version, query.version)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.distributedquery",
+                 "pk": str(distributed_query.pk),
+                 "new_value": {
+                     "pk": distributed_query.pk,
+                     "query": {"pk": query.pk, "name": query.name},
+                     "query_version": query.version,
+                     "sql": query.sql,
+                     "platforms": [],
+                     "valid_from": distributed_query.valid_from.isoformat(),
+                     "valid_until": None,
+                     "serial_numbers": [],
+                     "tags": [],
+                     "shard": 100,
+                     "minimum_osquery_version": "5.10.2",
+                     "created_at": distributed_query.created_at.isoformat(),
+                     "updated_at": distributed_query.updated_at.isoformat(),
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"],
+                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                          "osquery_query": [str(query.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
     def test_create_distributed_query_valid_until_less_than_valid_from(self):
         query = self._force_query()
@@ -128,35 +165,46 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, distributed_query.query.name)
         self.assertContains(response, "Halt current")
 
-    def test_create_distributed_no_halt_current_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_distributed_no_halt_current_post(self, post_event):
         distributed_query = self._force_distributed_query()
         self.login("osquery.add_distributedquery", "osquery.view_distributedquery")
-        response = self.client.post(
-            "{}?q={}".format(reverse("osquery:create_distributed_query"), distributed_query.query.pk),
-            {"valid_from": naive_utcnow().strftime("%Y-%m-%d %H:%M:%S"),
-             "shard": "100"},
-            follow=True
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                "{}?q={}".format(reverse("osquery:create_distributed_query"), distributed_query.query.pk),
+                {"valid_from": naive_utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                 "shard": "100"},
+                follow=True
+            )
         self.assertEqual(response.status_code, 200)
+        # only the new run is audited, the untouched one is not
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/distributedquery_detail.html")
         self.assertEqual(response.context["query"], distributed_query.query)
         distributed_query2 = response.context["object"]
         self.assertEqual(distributed_query.query, distributed_query2.query)
         distributed_query.refresh_from_db()
         self.assertEqual(distributed_query.valid_until, None)
+        self.assertEqual(post_event.call_count, 1)
+        assert_audit_event(self, post_event, "created", distributed_query2)
 
-    def test_create_distributed_halt_current_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_distributed_halt_current_post(self, post_event):
         distributed_query = self._force_distributed_query()
+        prev_value = distributed_query.serialize_for_event()
         self.login("osquery.add_distributedquery", "osquery.view_distributedquery")
         pre_post_dt = naive_utcnow()
-        response = self.client.post(
-            "{}?q={}".format(reverse("osquery:create_distributed_query"), distributed_query.query.pk),
-            {"valid_from": naive_utcnow().strftime("%Y-%m-%d %H:%M:%S"),
-             "shard": "100",
-             "halt_current_runs": "on"},
-            follow=True
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                "{}?q={}".format(reverse("osquery:create_distributed_query"), distributed_query.query.pk),
+                {"valid_from": naive_utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                 "shard": "100",
+                 "halt_current_runs": "on"},
+                follow=True
+            )
         self.assertEqual(response.status_code, 200)
+        # the halted run is audited too, not just the new one
+        self.assertEqual(len(callbacks), 2)
         self.assertTemplateUsed(response, "osquery/distributedquery_detail.html")
         self.assertEqual(response.context["query"], distributed_query.query)
         distributed_query2 = response.context["object"]
@@ -165,6 +213,16 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertFalse(distributed_query.is_active())
         self.assertTrue(distributed_query.valid_until > pre_post_dt)
         self.assertTrue(distributed_query.valid_until < naive_utcnow())
+        self.assertEqual(post_event.call_count, 2)
+        halt_payload, halt_metadata = assert_audit_event(self, post_event, "updated", distributed_query,
+                                                         prev_value=prev_value)
+        self.assertIsNone(halt_payload["object"]["prev_value"]["valid_until"])
+        self.assertEqual(halt_payload["object"]["new_value"]["valid_until"],
+                         distributed_query.valid_until.isoformat())
+        self.assertEqual(halt_metadata["objects"],
+                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                          "osquery_query": [str(distributed_query.query.pk)]})
+        assert_audit_event(self, post_event, "created", distributed_query2, call_index=1)
 
     # update distributed query
 
@@ -187,21 +245,32 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.context["object"], distributed_query)
         self.assertNotContains(response, "Halt current")
 
-    def test_update_distributed_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_distributed_query_post(self, post_event):
         distributed_query = self._force_distributed_query()
+        prev_value = distributed_query.serialize_for_event()
         self.login("osquery.change_distributedquery", "osquery.view_distributedquery")
-        response = self.client.post(
-            reverse("osquery:update_distributed_query", args=(distributed_query.pk,)),
-            {"valid_from": "2020-07-30 11:50:00",
-             "valid_until": "2021-02-18 20:55:00",
-             "shard": "99"},
-            follow=True
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(
+                reverse("osquery:update_distributed_query", args=(distributed_query.pk,)),
+                {"valid_from": "2020-07-30 11:50:00",
+                 "valid_until": "2021-02-18 20:55:00",
+                 "shard": "99"},
+                follow=True
+            )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/distributedquery_detail.html")
         self.assertEqual(response.context["object"], distributed_query)
         distributed_query.refresh_from_db()
         self.assertEqual(distributed_query.shard, 99)
+        payload, metadata = assert_audit_event(self, post_event, "updated", distributed_query,
+                                               prev_value=prev_value)
+        self.assertIsNone(payload["object"]["prev_value"]["valid_until"])
+        self.assertEqual(payload["object"]["new_value"]["valid_until"], "2021-02-18T20:55:00")
+        self.assertEqual(metadata["objects"],
+                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                          "osquery_query": [str(distributed_query.query.pk)]})
 
     def test_update_distributed_query_valid_until_less_than_valid_from(self):
         distributed_query = self._force_distributed_query()
@@ -281,14 +350,22 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/distributedquery_confirm_delete.html")
         self.assertEqual(response.context["object"], distributed_query)
 
-    def test_delete_distributed_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_distributed_query_post(self, post_event):
         distributed_query = self._force_distributed_query()
+        prev_value = distributed_query.serialize_for_event()
         self.login("osquery.delete_distributedquery", "osquery.view_distributedquery")
-        response = self.client.post(reverse("osquery:delete_distributed_query", args=(distributed_query.pk,)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_distributed_query", args=(distributed_query.pk,)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/distributedquery_list.html")
         self.assertNotIn(distributed_query, response.context["distributed_queries"])
+        _, metadata = assert_audit_event(self, post_event, "deleted", distributed_query, prev_value=prev_value)
+        self.assertEqual(metadata["objects"],
+                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                          "osquery_query": [str(distributed_query.query.pk)]})
 
     # distributed query machines
 

--- a/tests/osquery/test_setup_enrollments.py
+++ b/tests/osquery/test_setup_enrollments.py
@@ -6,6 +6,7 @@ from django.utils.crypto import get_random_string
 from django.test import TestCase
 
 from accounts.models import User
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit
 from zentral.contrib.osquery.models import Configuration, Enrollment
@@ -65,16 +66,19 @@ class OsquerySetupEnrollmentsViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, configuration.name)
         get_osquery_versions.assert_called_once_with()
 
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     @patch("zentral.contrib.osquery.forms.get_osquery_versions")
-    def test_create_enrollment_view_post(self, get_osquery_versions):
+    def test_create_enrollment_view_post(self, get_osquery_versions, post_event):
         get_osquery_versions.returns = []
         self.login("osquery.add_enrollment", "osquery.view_configuration", "osquery.view_enrollment")
         configuration = self._force_configuration()
-        response = self.client.post(reverse("osquery:create_enrollment", args=(configuration.pk,)),
-                                    {"secret-meta_business_unit": self.mbu.pk,
-                                     "configuration": configuration.pk,
-                                     "osquery_release": ""}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:create_enrollment", args=(configuration.pk,)),
+                                        {"secret-meta_business_unit": self.mbu.pk,
+                                         "configuration": configuration.pk,
+                                         "osquery_release": ""}, follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertEqual(response.context["object"], configuration)
         enrollment = response.context["enrollments"][0]
@@ -83,6 +87,12 @@ class OsquerySetupEnrollmentsViewsTestCase(TestCase, LoginCase):
         for view_name in ("enrollment_package", "enrollment_script", "enrollment_powershell_script"):
             self.assertContains(response, reverse(f"osquery_api:{view_name}", args=(enrollment.pk,)))
         get_osquery_versions.assert_called_once_with()
+        payload, metadata = assert_audit_event(self, post_event, "created", enrollment)
+        self.assertEqual(payload["object"]["new_value"]["configuration"],
+                         {"pk": configuration.pk, "name": configuration.name})
+        self.assertEqual(metadata["objects"],
+                         {"osquery_enrollment": [str(enrollment.pk)],
+                          "osquery_configuration": [str(configuration.pk)]})
 
     @patch("zentral.contrib.osquery.releases.requests.get")
     def test_create_enrollment_view_get_osquery_versions_error_post(self, requests_get):
@@ -124,17 +134,27 @@ class OsquerySetupEnrollmentsViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "osquery/enrollment_confirm_version_bump.html")
 
-    def test_bump_enrollment_version_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_bump_enrollment_version_post(self, post_event):
         enrollment = self._force_enrollment()
         version = enrollment.version
+        prev_value = enrollment.serialize_for_event()
         self.login("osquery.change_enrollment", "osquery.view_configuration")
-        response = self.client.post(reverse("osquery:bump_enrollment_version",
-                                            args=(enrollment.configuration.pk, enrollment.pk)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:bump_enrollment_version",
+                                                args=(enrollment.configuration.pk, enrollment.pk)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.version, version + 1)
+        payload, metadata = assert_audit_event(self, post_event, "updated", enrollment, prev_value=prev_value)
+        self.assertEqual(payload["object"]["prev_value"]["version"], version)
+        self.assertEqual(payload["object"]["new_value"]["version"], version + 1)
+        self.assertEqual(metadata["objects"],
+                         {"osquery_enrollment": [str(enrollment.pk)],
+                          "osquery_configuration": [str(enrollment.configuration.pk)]})
 
     # delete enrollment
 
@@ -158,18 +178,26 @@ class OsquerySetupEnrollmentsViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/enrollment_confirm_delete.html")
         self.assertContains(response, enrollment.configuration.name)
 
-    def test_delete_enrollment_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_enrollment_post(self, post_event):
         enrollment = self._force_enrollment()
+        prev_value = enrollment.serialize_for_event()
         self.login("osquery.delete_enrollment", "osquery.view_configuration")
-        response = self.client.post(reverse("osquery:delete_enrollment", args=(enrollment.configuration.pk,
-                                                                               enrollment.pk)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_enrollment", args=(enrollment.configuration.pk,
+                                                                                   enrollment.pk)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/configuration_detail.html")
         self.assertContains(response, enrollment.configuration.name)
         ctx_configuration = response.context["configuration"]
         self.assertEqual(ctx_configuration, enrollment.configuration)
         self.assertEqual(ctx_configuration.enrollment_set.filter(pk=enrollment.pk).count(), 0)
+        _, metadata = assert_audit_event(self, post_event, "deleted", enrollment, prev_value=prev_value)
+        self.assertEqual(metadata["objects"],
+                         {"osquery_enrollment": [str(enrollment.pk)],
+                          "osquery_configuration": [str(enrollment.configuration.pk)]})
 
     def test_delete_enrollment_distributor_404(self):
         enrollment = self._force_enrollment()

--- a/tests/osquery/test_setup_file_categories.py
+++ b/tests/osquery/test_setup_file_categories.py
@@ -1,11 +1,14 @@
+from unittest.mock import patch
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 
 from accounts.models import User
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.osquery.models import FileCategory
+from zentral.core.events.base import AuditEvent
 
 
 class OsquerySetupFileCategoriesViewsTestCase(TestCase, LoginCase):
@@ -51,20 +54,48 @@ class OsquerySetupFileCategoriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/filecategory_form.html")
         self.assertContains(response, "Create File category")
 
-    def test_create_file_category_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_file_category_post(self, post_event):
         self.login("osquery.add_filecategory", "osquery.view_filecategory")
         file_category_name = get_random_string(64)
-        response = self.client.post(reverse("osquery:create_file_category"),
-                                    {"name": file_category_name,
-                                     "file_paths": "yolo, fomo"},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:create_file_category"),
+                                        {"name": file_category_name,
+                                         "file_paths": "yolo, fomo"},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/filecategory_detail.html")
         self.assertContains(response, file_category_name)
         file_category = response.context["object"]
         self.assertEqual(file_category.name, file_category_name)
         self.assertEqual(file_category.file_paths, ["yolo", "fomo"])
         self.assertEqual(file_category.access_monitoring, False)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.filecategory",
+                 "pk": str(file_category.pk),
+                 "new_value": {
+                     "pk": file_category.pk,
+                     "name": file_category_name,
+                     "slug": file_category.slug,
+                     "description": "",
+                     "file_paths": ["fomo", "yolo"],
+                     "exclude_paths": [],
+                     "file_paths_queries": [],
+                     "access_monitoring": False,
+                     "created_at": file_category.created_at.isoformat(),
+                     "updated_at": file_category.updated_at.isoformat(),
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"osquery_file_category": [str(file_category.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
     # update file category
 
@@ -87,22 +118,30 @@ class OsquerySetupFileCategoriesViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, "Update File category")
         self.assertContains(response, file_category.name)
 
-    def test_update_file_category_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_file_category_post(self, post_event):
         file_category = self._force_file_category()
+        prev_value = file_category.serialize_for_event()
         self.login("osquery.change_filecategory", "osquery.view_filecategory")
         new_name = get_random_string(12)
-        response = self.client.post(reverse("osquery:update_file_category", args=(file_category.pk,)),
-                                    {"name": new_name,
-                                     "file_paths": "yolo, 2020forever",
-                                     "access_monitoring": "on"},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:update_file_category", args=(file_category.pk,)),
+                                        {"name": new_name,
+                                         "file_paths": "yolo, 2020forever",
+                                         "access_monitoring": "on"},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/filecategory_detail.html")
         self.assertContains(response, new_name)
         file_category = response.context["object"]
         self.assertEqual(file_category.name, new_name)
         self.assertEqual(file_category.file_paths, ["yolo", "2020forever"])
         self.assertEqual(file_category.access_monitoring, True)
+        payload, metadata = assert_audit_event(self, post_event, "updated", file_category, prev_value=prev_value)
+        self.assertFalse(payload["object"]["prev_value"]["access_monitoring"])
+        self.assertTrue(payload["object"]["new_value"]["access_monitoring"])
+        self.assertEqual(metadata["objects"], {"osquery_file_category": [str(file_category.pk)]})
 
     # delete file category
 
@@ -124,14 +163,21 @@ class OsquerySetupFileCategoriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/filecategory_confirm_delete.html")
         self.assertContains(response, file_category.name)
 
-    def test_delete_file_category_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_file_category_post(self, post_event):
         file_category = self._force_file_category()
+        prev_value = file_category.serialize_for_event()
         self.login("osquery.delete_filecategory", "osquery.view_filecategory")
-        response = self.client.post(reverse("osquery:delete_file_category", args=(file_category.pk,)), follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_file_category", args=(file_category.pk,)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/filecategory_list.html")
         self.assertEqual(FileCategory.objects.filter(pk=file_category.pk).count(), 0)
         self.assertNotContains(response, file_category.name)
+        _, metadata = assert_audit_event(self, post_event, "deleted", file_category, prev_value=prev_value)
+        self.assertEqual(metadata["objects"], {"osquery_file_category": [str(file_category.pk)]})
 
     # file category list
 

--- a/tests/osquery/test_setup_packs.py
+++ b/tests/osquery/test_setup_packs.py
@@ -1,14 +1,17 @@
 from io import BytesIO
+from unittest.mock import patch
 from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.test import TestCase
 from django.utils.crypto import get_random_string
 
 from accounts.models import User
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
 from django.utils.text import slugify
 from zentral.contrib.osquery.compliance_checks import sync_query_compliance_check
 from zentral.contrib.osquery.models import Pack, PackQuery, Query
+from zentral.core.events.base import AuditEvent
 
 
 class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
@@ -70,15 +73,42 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/pack_form.html")
         self.assertContains(response, "Create Pack")
 
-    def test_create_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_pack_post(self, post_event):
         self.login("osquery.add_pack", "osquery.view_pack")
         pack_name = get_random_string(64)
-        response = self.client.post(reverse("osquery:create_pack"), {"name": pack_name}, follow=True)
+        pack_description = get_random_string(12)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:create_pack"),
+                                        {"name": pack_name, "description": pack_description},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/pack_detail.html")
         self.assertContains(response, pack_name)
         pack = response.context["object"]
         self.assertEqual(pack.name, pack_name)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.pack",
+                 "pk": str(pack.pk),
+                 "new_value": {
+                     "pk": pack.pk,
+                     "slug": pack.slug,
+                     "name": pack_name,
+                     "description": pack_description,
+                     "created_at": pack.created_at.isoformat(),
+                     "updated_at": pack.updated_at.isoformat(),
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"osquery_pack": [str(pack.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
     # update pack
 
@@ -99,20 +129,28 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "osquery/pack_form.html")
 
-    def test_update_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_pack_post(self, post_event):
         pack = self._force_pack()
+        prev_value = pack.serialize_for_event()
         self.login("osquery.change_pack", "osquery.view_pack")
         new_name = get_random_string(12)
-        response = self.client.post(reverse("osquery:update_pack", args=(pack.pk,)),
-                                    {"name": new_name,
-                                     "shard": 97},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:update_pack", args=(pack.pk,)),
+                                        {"name": new_name,
+                                         "shard": 97},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/pack_detail.html")
         self.assertContains(response, new_name)
         pack = response.context["object"]
         self.assertEqual(pack.name, new_name)
         self.assertEqual(pack.shard, 97)
+        payload, metadata = assert_audit_event(self, post_event, "updated", pack, prev_value=prev_value)
+        self.assertNotIn("shard", payload["object"]["prev_value"])
+        self.assertEqual(payload["object"]["new_value"]["shard"], 97)
+        self.assertEqual(metadata["objects"], {"osquery_pack": [str(pack.pk)]})
 
     # upload pack
 
@@ -216,14 +254,20 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/pack_confirm_delete.html")
         self.assertContains(response, pack.name)
 
-    def test_delete_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_pack_post(self, post_event):
         pack = self._force_pack()
+        prev_value = pack.serialize_for_event()
         self.login("osquery.delete_pack", "osquery.view_pack")
-        response = self.client.post(reverse("osquery:delete_pack", args=(pack.pk,)), follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_pack", args=(pack.pk,)), follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/pack_list.html")
         self.assertEqual(Pack.objects.filter(pk=pack.pk).count(), 0)
         self.assertNotContains(response, pack.name)
+        _, metadata = assert_audit_event(self, post_event, "deleted", pack, prev_value=prev_value)
+        self.assertEqual(metadata["objects"], {"osquery_pack": [str(pack.pk)]})
 
     # pack list
 
@@ -311,18 +355,26 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertFormError(response.context["form"], "snapshot_mode",
                              "'Log removed actions' and 'Snapshot mode' are mutually exclusive")
 
-    def test_add_pack_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_add_pack_query_post(self, post_event):
         pack = self._force_pack()
         query = self._force_query()
         self.login("osquery.add_packquery", "osquery.view_pack", "osquery.view_packquery")
-        response = self.client.post(reverse("osquery:add_pack_query", args=(pack.pk,)),
-                                    {"query": query.pk, "interval": 3456}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:add_pack_query", args=(pack.pk,)),
+                                        {"query": query.pk, "interval": 3456}, follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/pack_detail.html")
         self.assertEqual(response.context["object"], pack)
         self.assertContains(response, query.name)
         self.assertContains(response, "3456s")
         self.assertNotContains(response, "Compliance check")
+        pack_query = query.packquery
+        payload, metadata = assert_audit_event(self, post_event, "created", pack_query)
+        self.assertEqual(payload["object"]["new_value"]["interval"], 3456)
+        self.assertEqual(payload["object"]["new_value"]["pack"], {"pk": pack.pk, "slug": pack.slug})
+        self.assertEqual(metadata["objects"], {"osquery_pack_query": [str(pack_query.pk)]})
 
     def test_add_pack_query_with_slug_conflict(self):
         query_name = get_random_string(16)
@@ -404,17 +456,26 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertFormError(response.context["form"], "snapshot_mode",
                              "'Log removed actions' and 'Snapshot mode' are mutually exclusive")
 
-    def test_update_pack_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_pack_query_post(self, post_event):
         query = self._force_query(force_pack=True)
         pack_query = query.packquery
+        prev_value = pack_query.serialize_for_event()
         self.login("osquery.change_packquery", "osquery.view_pack", "osquery.view_packquery")
-        response = self.client.post(reverse("osquery:update_pack_query", args=(pack_query.pack.pk, pack_query.pk)),
-                                    {"query": query.pk, "interval": 12345}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:update_pack_query",
+                                                args=(pack_query.pack.pk, pack_query.pk)),
+                                        {"query": query.pk, "interval": 12345}, follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/pack_detail.html")
         self.assertEqual(response.context["object"], pack_query.pack)
         self.assertContains(response, query.name)
         self.assertContains(response, "12345s")
+        pack_query.refresh_from_db()
+        payload, metadata = assert_audit_event(self, post_event, "updated", pack_query, prev_value=prev_value)
+        self.assertEqual(payload["object"]["new_value"]["interval"], 12345)
+        self.assertEqual(metadata["objects"], {"osquery_pack_query": [str(pack_query.pk)]})
 
     def test_update_pack_query_with_compliance_check(self):
         query = self._force_query(force_pack=True, force_compliance_check=True)
@@ -453,14 +514,21 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.context["object"], pack_query)
         self.assertContains(response, query.name)
 
-    def test_delete_pack_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_pack_query_post(self, post_event):
         query = self._force_query(force_pack=True)
         pack_query = query.packquery
+        prev_value = pack_query.serialize_for_event()
         self.login("osquery.delete_packquery", "osquery.view_pack")
-        response = self.client.post(reverse("osquery:delete_pack_query", args=(pack_query.pack.pk, pack_query.pk)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_pack_query",
+                                                args=(pack_query.pack.pk, pack_query.pk)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/pack_detail.html")
         self.assertEqual(response.context["object"], pack_query.pack)
         self.assertNotContains(response, query.name)
         self.assertNotContains(response, f"{pack_query.interval}s")
+        _, metadata = assert_audit_event(self, post_event, "deleted", pack_query, prev_value=prev_value)
+        self.assertEqual(metadata["objects"], {"osquery_pack_query": [str(pack_query.pk)]})

--- a/tests/osquery/test_setup_queries.py
+++ b/tests/osquery/test_setup_queries.py
@@ -6,11 +6,13 @@ from django.utils.text import slugify
 from django.test import TestCase
 
 from accounts.models import User
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import Tag
 from zentral.contrib.osquery.compliance_checks import sync_query_compliance_check
 from zentral.contrib.osquery.models import Pack, PackQuery, Query
 from zentral.core.compliance_checks.models import ComplianceCheck
+from zentral.core.events.base import AuditEvent
 from zentral.core.stores.conf import stores
 from zentral.utils.provisioning import provision
 
@@ -87,14 +89,17 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/query_form.html")
         self.assertFormError(response.context["form"], "name", "Query with this Name already exists.")
 
-    def test_create_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_query_post(self, post_event):
         self.login("osquery.add_query", "osquery.view_query")
         query_name = get_random_string(12)
-        response = self.client.post(reverse("osquery:create_query"),
-                                    {"name": query_name,
-                                     "sql": "select 1 from users;",
-                                     "description": "YOLO"}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:create_query"),
+                                        {"name": query_name,
+                                         "sql": "select 1 from users;",
+                                         "description": "YOLO"}, follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/query_detail.html")
         self.assertContains(response, query_name)
         query = response.context["object"]
@@ -103,6 +108,30 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(query.description, "YOLO")
         self.assertIsNone(query.compliance_check)
         self.assertEqual(query.version, 1)
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(
+            event.payload,
+            {"action": "created",
+             "object": {
+                 "model": "osquery.query",
+                 "pk": str(query.pk),
+                 "new_value": {
+                     "pk": query.pk,
+                     "name": query_name,
+                     "sql": "select 1 from users;",
+                     # the row version, not the minimum osquery version
+                     "version": 1,
+                     "platforms": [],
+                     "description": "YOLO",
+                     "created_at": query.created_at.isoformat(),
+                     "updated_at": query.updated_at.isoformat(),
+                 }
+              }}
+        )
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"osquery_query": [str(query.pk)]})
+        self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
     def test_create_query_with_compliance_check_and_tag_error(self):
         self.login("osquery.add_query", "osquery.view_query")
@@ -153,15 +182,17 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(query.compliance_check.model, "OsqueryCheck")
         self.assertEqual(query.compliance_check.query, query)
 
-    def test_create_query_with_tag(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_query_with_tag(self, post_event):
         self.login("osquery.add_query", "osquery.view_query")
         query_name = get_random_string(12)
         tag = Tag.objects.create(name=get_random_string(12))
-        response = self.client.post(reverse("osquery:create_query"),
-                                    {"name": query_name,
-                                     "sql": "select 'OK' as ztl_status;",
-                                     "tag": tag.pk,
-                                     "description": "YOLO"}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("osquery:create_query"),
+                                        {"name": query_name,
+                                         "sql": "select 'OK' as ztl_status;",
+                                         "tag": tag.pk,
+                                         "description": "YOLO"}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "osquery/query_detail.html")
         self.assertContains(response, query_name)
@@ -170,6 +201,8 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertIsNone(query.compliance_check)
         self.assertEqual(query.version, 1)
         self.assertEqual(query.tag, tag)
+        payload, _ = assert_audit_event(self, post_event, "created", query)
+        self.assertEqual(payload["object"]["new_value"]["tag"], {"pk": tag.pk, "name": tag.name})
 
     # update query
 
@@ -203,17 +236,21 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/query_form.html")
         self.assertFormError(response.context["form"], "name", "Query with this Name already exists.")
 
-    def test_update_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_query_post(self, post_event):
         query = self._force_query()
+        prev_value = query.serialize_for_event()
         self.login("osquery.change_query", "osquery.view_query")
         new_name = get_random_string(12)
         version = query.version
-        response = self.client.post(reverse("osquery:update_query", args=(query.pk,)),
-                                    {"name": new_name,
-                                     "sql": "select 2 from users;",
-                                     "description": "YOLO2"},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:update_query", args=(query.pk,)),
+                                        {"name": new_name,
+                                         "sql": "select 2 from users;",
+                                         "description": "YOLO2"},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/query_detail.html")
         self.assertContains(response, new_name)
         query = response.context["object"]
@@ -221,6 +258,10 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(query.sql, "select 2 from users;")
         self.assertEqual(query.description, "YOLO2")
         self.assertEqual(query.version, version + 1)  # sql changed
+        payload, metadata = assert_audit_event(self, post_event, "updated", query, prev_value=prev_value)
+        self.assertEqual(payload["object"]["prev_value"]["version"], version)
+        self.assertEqual(payload["object"]["new_value"]["version"], version + 1)
+        self.assertEqual(metadata["objects"], {"osquery_query": [str(query.pk)]})
 
     def test_update_query_set_compliance_check_sql_error(self):
         query = self._force_query()
@@ -311,14 +352,20 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/query_confirm_delete.html")
         self.assertContains(response, query.name)
 
-    def test_delete_query_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_query_post(self, post_event):
         query = self._force_query()
+        prev_value = query.serialize_for_event()
         self.login("osquery.delete_query", "osquery.view_query")
-        response = self.client.post(reverse("osquery:delete_query", args=(query.pk,)), follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("osquery:delete_query", args=(query.pk,)), follow=True)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(callbacks), 1)
         self.assertTemplateUsed(response, "osquery/query_list.html")
         self.assertEqual(Query.objects.filter(pk=query.pk).count(), 0)
         self.assertNotContains(response, query.name)
+        _, metadata = assert_audit_event(self, post_event, "deleted", query, prev_value=prev_value)
+        self.assertEqual(metadata["objects"], {"osquery_query": [str(query.pk)]})
 
     def test_delete_query_with_compliance_check(self):
         query = self._force_query(force_compliance_check=True)

--- a/tests/osquery/utils.py
+++ b/tests/osquery/utils.py
@@ -1,6 +1,7 @@
 from django.utils.crypto import get_random_string
 from zentral.contrib.osquery.models import Configuration, Enrollment
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit
+from zentral.core.events.base import AuditEvent
 
 
 def force_configuration():
@@ -27,3 +28,21 @@ def force_enrollment(
         configuration=configuration,
         secret=enrollment_secret
     )
+
+
+def assert_audit_event(test_case, post_event, action, instance, prev_value=None, call_index=0):
+    """Check the audit event at call_index, and give its payload back for further assertions."""
+    test_case.maxDiff = None
+    event = post_event.call_args_list[call_index].args[0]
+    test_case.assertIsInstance(event, AuditEvent)
+    expected = {"action": action,
+                "object": {"model": instance._meta.label_lower,
+                           "pk": str(instance.pk)}}
+    if action in ("created", "updated"):
+        expected["object"]["new_value"] = instance.serialize_for_event()
+    if prev_value is not None:
+        expected["object"]["prev_value"] = prev_value
+    test_case.assertEqual(event.payload, expected)
+    metadata = event.metadata.serialize()
+    test_case.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
+    return event.payload, metadata

--- a/tests/santa/test_setup_views.py
+++ b/tests/santa/test_setup_views.py
@@ -756,6 +756,7 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
                  "pk": str(enrollment_pk),
                  'prev_value': {'configuration': {'name': configuration.name, 'pk': configuration.pk},
                                 'created_at': enrollment.created_at.isoformat(),
+                                'updated_at': enrollment.updated_at.isoformat(),
                                 'enrollment_secret': {'created_at': enrollment_secret.created_at.isoformat(),
                                                       'is_expired': False,
                                                       'is_revoked': False,
@@ -764,7 +765,8 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
                                                                              'pk': mbu.pk},
                                                       'pk': enrollment_secret.pk,
                                                       'request_count': 0},
-                                'pk': enrollment.pk}
+                                'pk': enrollment.pk,
+                                'version': enrollment.version}
               }}
         )
         metadata = event.metadata.serialize()

--- a/tests/turbo/test_setup_enrollments.py
+++ b/tests/turbo/test_setup_enrollments.py
@@ -108,6 +108,8 @@ class TurboSetupEnrollmentsTestCase(TurboSetupTestCase):
         config_keys_only = {"pk": str(enrollment.configuration.pk), "name": enrollment.configuration.name}
         self.assertEqual(event.payload["object"]["prev_value"]["configuration"], config_keys_only)
         self.assertEqual(event.payload["object"]["new_value"]["configuration"], config_keys_only)
+        self.assertEqual(event.payload["object"]["prev_value"]["version"], version)
+        self.assertEqual(event.payload["object"]["new_value"]["version"], version + 1)
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["objects"], {
             "turbo_enrollment": [str(enrollment.pk)],

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -1551,7 +1551,9 @@ class BaseEnrollment(models.Model):
 
     def serialize_for_event(self):
         enrollment_dict = {"pk": self.pk,
-                           "created_at": self.created_at.isoformat()}
+                           "version": self.version,
+                           "created_at": self.created_at.isoformat(),
+                           "updated_at": self.updated_at.isoformat()}
         enrollment_dict.update(self.secret.serialize_for_event())
         distributor = self.distributor
         if distributor and hasattr(distributor, "serialize_for_event"):

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -222,7 +222,7 @@ class PackView(APIView):
         )
 
         # prepare the response
-        pack_update_event["pack"] = pack.serialize_for_event(short=True)
+        pack_update_event["pack"] = pack.serialize_for_event(keys_only=True)
 
         # finally, delete the pack
         pack.delete()

--- a/zentral/contrib/osquery/forms.py
+++ b/zentral/contrib/osquery/forms.py
@@ -6,7 +6,9 @@ from django.utils.text import slugify
 from rest_framework.parsers import JSONParser
 from rest_framework_yaml.parsers import YAMLParser
 
+from zentral.core.events.base import AuditEvent
 from zentral.utils.time import naive_utcnow
+from zentral.utils.views import post_audit_event
 
 from .compliance_checks import sync_query_compliance_check
 from .models import (
@@ -107,6 +109,7 @@ class DistributedQueryForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.query = kwargs.pop("query", None)
+        self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
         self.fields["valid_from"].initial = naive_utcnow()
         if not self.instance.pk:
@@ -139,7 +142,9 @@ class DistributedQueryForm(forms.ModelForm):
 
     def save(self, *args, **kwargs):
         if not self.instance.pk and self.cleaned_data.get("halt_current_runs"):
-            self.query.distributedquery_set.active().update(valid_until=naive_utcnow())
+            for distributed_query, prev_value in DistributedQuery.objects.halt_for_query(self.query):
+                post_audit_event(self.request, distributed_query, AuditEvent.Action.UPDATED,
+                                 prev_value=prev_value)
         return super().save(*args, **kwargs)
 
 
@@ -401,6 +406,9 @@ class QueryForm(forms.ModelForm):
 
     def save(self, *args, **kwargs):
         query = super().save(*args, **kwargs)
+        if not isinstance(query.version, int):
+            # clean_sql() bumped the version with an F() expression, which the caller cannot serialize
+            query.refresh_from_db()
         sync_query_compliance_check(query, self.cleaned_data.get("compliance_check"))
         return query
 

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -133,17 +133,27 @@ class Query(models.Model):
             d["version"] = self.minimum_osquery_version
         return d
 
-    def serialize_for_event(self):
-        d = {"sql": self.sql,
-             "version": self.version}
-        if self.platforms:
-            d["platform"] = ",".join(self.platforms)
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "name": self.name}
+        if keys_only:
+            return d
+        d.update({
+            "sql": self.sql,
+            "version": self.version,
+            "platforms": sorted(self.platforms),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
         if self.minimum_osquery_version:
-            d["version"] = self.minimum_osquery_version
+            d["minimum_osquery_version"] = self.minimum_osquery_version
         if self.description:
             d["description"] = self.description
         if self.value:
             d["value"] = self.value
+        if self.tag:
+            d["tag"] = self.tag.serialize_for_event(keys_only=True)
+        if self.compliance_check:
+            d["compliance_check"] = self.compliance_check.serialize_for_event()
         return d
 
     def delete(self, *args, **kwargs):
@@ -205,16 +215,25 @@ class Pack(models.Model):
             d["shard"] = self.shard
         return d
 
-    def serialize_for_event(self, short=False):
+    def serialize_for_event(self, keys_only=False):
+        # slug, not name: this is also the "pack" key of the standard pack endpoint response
         d = {"pk": self.pk,
              "slug": self.slug}
-        if short:
+        if keys_only:
             return d
-        d["name"] = self.name
+        d.update({
+            "name": self.name,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        if self.description:
+            d["description"] = self.description
         if self.discovery_queries:
             d["discovery_queries"] = self.discovery_queries
         if self.shard:
             d["shard"] = self.shard
+        if self.event_routing_key:
+            d["event_routing_key"] = self.event_routing_key
         return d
 
 
@@ -312,7 +331,7 @@ class PackQuery(models.Model):
     def serialize_for_event(self):
         d = {"pk": self.pk,
              "slug": self.slug,
-             "pack": self.pack.serialize_for_event(short=True),
+             "pack": self.pack.serialize_for_event(keys_only=True),
              "query": self.query.serialize_for_event(),
              "interval": self.interval,
              "log_removed_actions": self.log_removed_actions,

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -12,6 +12,7 @@ from zentral.conf import settings
 from zentral.contrib.inventory.models import BaseEnrollment, Tag
 from zentral.utils.sql import tables_in_query, format_sql
 from zentral.utils.text import shard
+from zentral.utils.time import naive_utcnow
 from .specs import cli_only_flags
 
 
@@ -361,6 +362,22 @@ class FileCategory(models.Model):
     def get_absolute_url(self):
         return reverse("osquery:file_category", args=(self.pk,))
 
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "name": self.name}
+        if keys_only:
+            return d
+        d.update({
+            "slug": self.slug,
+            "description": self.description,
+            "file_paths": sorted(self.file_paths),
+            "exclude_paths": sorted(self.exclude_paths),
+            "file_paths_queries": sorted(self.file_paths_queries),
+            "access_monitoring": self.access_monitoring,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
+
 
 class AutomaticTableConstruction(models.Model):
     name = models.CharField(max_length=256, unique=True)
@@ -391,6 +408,22 @@ class AutomaticTableConstruction(models.Model):
 
     def get_query_html(self):
         return format_sql(self.query)
+
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "name": self.name}
+        if keys_only:
+            return d
+        d.update({
+            "description": self.description,
+            "table_name": self.table_name,
+            "query": self.query,
+            "path": self.path,
+            "columns": self.columns,
+            "platforms": sorted(self.platforms),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
 
 
 class Configuration(models.Model):
@@ -430,6 +463,26 @@ class Configuration(models.Model):
 
     def get_absolute_url(self):
         return reverse("osquery:configuration", args=(self.pk,))
+
+    def serialize_for_event(self, keys_only=False):
+        d = {"pk": self.pk, "name": self.name}
+        if keys_only:
+            return d
+        d.update({
+            "description": self.description,
+            "inventory": self.inventory,
+            "inventory_apps": self.inventory_apps,
+            "inventory_ec2": self.inventory_ec2,
+            "inventory_interval": self.inventory_interval,
+            "options": self.options,
+            "file_categories": [fc.serialize_for_event(keys_only=True)
+                                for fc in self.file_categories.all().order_by("pk")],
+            "automatic_table_constructions": [atc.serialize_for_event(keys_only=True)
+                                              for atc in self.automatic_table_constructions.all().order_by("pk")],
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        return d
 
     def get_all_flags(self):
         flags = {
@@ -516,6 +569,21 @@ class ConfigurationPack(models.Model):
     def get_absolute_url(self):
         return "{}#cp{}".format(self.configuration.get_absolute_url(), self.pk)
 
+    def serialize_for_event(self):
+        return {
+            "pk": self.pk,
+            "configuration": self.configuration.serialize_for_event(keys_only=True),
+            "pack": self.pack.serialize_for_event(keys_only=True),
+            "tags": [t.serialize_for_event(keys_only=True) for t in self.tags.all().order_by("pk")],
+            "excluded_tags": [t.serialize_for_event(keys_only=True)
+                              for t in self.excluded_tags.all().order_by("pk")],
+        }
+
+    def linked_objects_keys_for_event(self):
+        return {"osquery_configuration_pack": ((self.pk,),),
+                "osquery_configuration": ((self.configuration_id,),),
+                "osquery_pack": ((self.pack_id,),)}
+
 
 # Enrollment
 
@@ -529,11 +597,14 @@ class Enrollment(BaseEnrollment):
 
     def serialize_for_event(self):
         enrollment_dict = super().serialize_for_event()
-        enrollment_dict["configuration"] = {"pk": self.configuration.pk,
-                                            "name": self.configuration.name}
+        enrollment_dict["configuration"] = self.configuration.serialize_for_event(keys_only=True)
         if self.osquery_release:
             enrollment_dict["osquery_release"] = self.osquery_release
         return enrollment_dict
+
+    def linked_objects_keys_for_event(self):
+        return {"osquery_enrollment": ((self.pk,),),
+                "osquery_configuration": ((self.configuration_id,),)}
 
     def get_absolute_url(self):
         return "{}#enrollment_{}".format(reverse("osquery:configuration", args=(self.configuration.pk,)), self.pk)
@@ -606,6 +677,22 @@ class DistributedQueryManager(models.Manager):
             if dq.shard == 100 or shard(serial_number, dq.pk) <= dq.shard:
                 yield dq
 
+    def halt_for_query(self, query):
+        """End every active run of the query, and report what was ended.
+
+        Returns (instance, prev_value) per halted run, so that the caller can post the audit
+        events. The rows are read before the update, because the previous valid_until is gone
+        once it is written.
+        """
+        now = naive_utcnow()
+        halted = []
+        for dq in self.active().filter(query=query).order_by("pk"):
+            halted.append((dq, dq.serialize_for_event()))
+            dq.valid_until = now
+        if halted:
+            self.filter(pk__in=[dq.pk for dq, _ in halted]).update(valid_until=now)
+        return halted
+
 
 class DistributedQuery(models.Model):
     query = models.ForeignKey(Query, on_delete=models.SET_NULL, null=True, editable=False)
@@ -676,6 +763,32 @@ class DistributedQuery(models.Model):
         cursor = connection.cursor()
         cursor.execute(query, [self.pk])
         return [t[0] for t in cursor.fetchall()]
+
+    def serialize_for_event(self):
+        # a run has no name of its own, and outlives the query it was launched from
+        d = {"pk": self.pk,
+             "query": self.query.serialize_for_event(keys_only=True) if self.query else None}
+        d.update({
+            "query_version": self.query_version,
+            "sql": self.sql,
+            "platforms": sorted(self.platforms),
+            "valid_from": self.valid_from.isoformat(),
+            "valid_until": self.valid_until.isoformat() if self.valid_until else None,
+            "serial_numbers": sorted(self.serial_numbers),
+            "tags": [t.serialize_for_event(keys_only=True) for t in self.tags.all().order_by("pk")],
+            "shard": self.shard,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        })
+        if self.minimum_osquery_version:
+            d["minimum_osquery_version"] = self.minimum_osquery_version
+        return d
+
+    def linked_objects_keys_for_event(self):
+        keys = {"osquery_distributed_query": ((self.pk,),)}
+        if self.query_id:
+            keys["osquery_query"] = ((self.query_id,),)
+        return keys
 
 
 class DistributedQueryMachine(models.Model):

--- a/zentral/contrib/osquery/packs.py
+++ b/zentral/contrib/osquery/packs.py
@@ -190,5 +190,5 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
         lambda: post_osquery_pack_update_events(request, full_pack_update_event, pack_query_update_events)
     )
 
-    pack_update_event["pack"] = pack.serialize_for_event(short=True)
+    pack_update_event["pack"] = pack.serialize_for_event(keys_only=True)
     return pack_update_event

--- a/zentral/contrib/osquery/views/atcs.py
+++ b/zentral/contrib/osquery/views/atcs.py
@@ -1,7 +1,8 @@
 import logging
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse_lazy
-from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
+from django.views.generic import DetailView, ListView
+from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
 from zentral.contrib.osquery.forms import ATCForm
 from zentral.contrib.osquery.models import AutomaticTableConstruction
 
@@ -19,7 +20,7 @@ class ATCListView(PermissionRequiredMixin, ListView):
         return ctx
 
 
-class CreateATCView(PermissionRequiredMixin, CreateView):
+class CreateATCView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_automatictableconstruction"
     model = AutomaticTableConstruction
     form_class = ATCForm
@@ -36,13 +37,13 @@ class ATCView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateATCView(PermissionRequiredMixin, UpdateView):
+class UpdateATCView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_automatictableconstruction"
     model = AutomaticTableConstruction
     form_class = ATCForm
 
 
-class DeleteATCView(PermissionRequiredMixin, DeleteView):
+class DeleteATCView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_automatictableconstruction"
     model = AutomaticTableConstruction
     success_url = reverse_lazy("osquery:atcs")

--- a/zentral/contrib/osquery/views/configurations.py
+++ b/zentral/contrib/osquery/views/configurations.py
@@ -2,7 +2,8 @@ import logging
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
-from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
+from django.views.generic import DetailView, ListView
+from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
 from zentral.contrib.osquery.forms import ConfigurationForm, ConfigurationPackForm
 from zentral.contrib.osquery.models import Configuration, ConfigurationPack, Pack
 
@@ -20,7 +21,7 @@ class ConfigurationListView(PermissionRequiredMixin, ListView):
         return ctx
 
 
-class CreateConfigurationView(PermissionRequiredMixin, CreateView):
+class CreateConfigurationView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_configuration"
     model = Configuration
     form_class = ConfigurationForm
@@ -54,13 +55,13 @@ class ConfigurationView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateConfigurationView(PermissionRequiredMixin, UpdateView):
+class UpdateConfigurationView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_configuration"
     model = Configuration
     form_class = ConfigurationForm
 
 
-class AddConfigurationPackView(PermissionRequiredMixin, CreateView):
+class AddConfigurationPackView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.change_configuration"
     model = ConfigurationPack
     form_class = ConfigurationPackForm
@@ -80,7 +81,7 @@ class AddConfigurationPackView(PermissionRequiredMixin, CreateView):
         return ctx
 
 
-class UpdateConfigurationPackView(PermissionRequiredMixin, UpdateView):
+class UpdateConfigurationPackView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_configuration"
     model = ConfigurationPack
     form_class = ConfigurationPackForm
@@ -97,7 +98,7 @@ class UpdateConfigurationPackView(PermissionRequiredMixin, UpdateView):
         return ctx
 
 
-class RemoveConfigurationPackView(PermissionRequiredMixin, DeleteView):
+class RemoveConfigurationPackView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.change_configuration"
     model = ConfigurationPack
 

--- a/zentral/contrib/osquery/views/distributed_queries.py
+++ b/zentral/contrib/osquery/views/distributed_queries.py
@@ -8,11 +8,12 @@ from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from zentral.utils.sql import tables_in_query
-from django.views.generic import CreateView, DeleteView, DetailView, UpdateView, TemplateView
+from django.views.generic import DetailView, TemplateView
 from zentral.contrib.osquery.forms import DistributedQueryForm, DistributedQueryMachineSearchForm
 from zentral.contrib.osquery.models import (DistributedQuery, DistributedQueryMachine, DistributedQueryResult,
                                             FileCarvingSession, Query)
-from zentral.utils.views import UserPaginationListView, UserPaginationMixin
+from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit,
+                                 UserPaginationListView, UserPaginationMixin)
 
 
 logger = logging.getLogger('zentral.contrib.osquery.views.distributed_queries')
@@ -78,7 +79,7 @@ class DistributedQueryListView(PermissionRequiredMixin, UserPaginationMixin, Tem
         return ctx
 
 
-class CreateDistributedQueryView(PermissionRequiredMixin, CreateView):
+class CreateDistributedQueryView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_distributedquery"
     model = DistributedQuery
     form_class = DistributedQueryForm
@@ -90,6 +91,7 @@ class CreateDistributedQueryView(PermissionRequiredMixin, CreateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["query"] = self.query
+        kwargs["request"] = self.request
         return kwargs
 
     def get_context_data(self, **kwargs):
@@ -114,7 +116,7 @@ class DistributedQueryView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateDistributedQueryView(PermissionRequiredMixin, UpdateView):
+class UpdateDistributedQueryView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_distributedquery"
     model = DistributedQuery
     form_class = DistributedQueryForm
@@ -125,7 +127,7 @@ class UpdateDistributedQueryView(PermissionRequiredMixin, UpdateView):
         return ctx
 
 
-class DeleteDistributedQueryView(PermissionRequiredMixin, DeleteView):
+class DeleteDistributedQueryView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_distributedquery"
     model = DistributedQuery
     success_url = reverse_lazy("osquery:distributed_queries")

--- a/zentral/contrib/osquery/views/enrollments.py
+++ b/zentral/contrib/osquery/views/enrollments.py
@@ -1,10 +1,12 @@
 import logging
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.shortcuts import get_object_or_404, redirect
-from django.views.generic import DeleteView, TemplateView
+from django.views.generic import TemplateView
 from zentral.contrib.inventory.forms import EnrollmentSecretForm
 from zentral.contrib.osquery.forms import EnrollmentForm
 from zentral.contrib.osquery.models import Configuration, Enrollment
+from zentral.core.events.base import AuditEvent
+from zentral.utils.views import DeleteViewWithAudit, post_audit_event
 
 
 logger = logging.getLogger('zentral.contrib.osquery.views.enrollments')
@@ -47,6 +49,7 @@ class CreateEnrollmentView(PermissionRequiredMixin, TemplateView):
         if self.configuration:
             enrollment.configuration = self.configuration
         enrollment.save()
+        post_audit_event(self.request, enrollment, AuditEvent.Action.CREATED)
         return redirect(enrollment)
 
     def post(self, request, *args, **kwargs):
@@ -57,7 +60,7 @@ class CreateEnrollmentView(PermissionRequiredMixin, TemplateView):
             return self.forms_invalid(secret_form, enrollment_form)
 
 
-class DeleteEnrollmentView(PermissionRequiredMixin, DeleteView):
+class DeleteEnrollmentView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_enrollment"
 
     def get_queryset(self):
@@ -96,5 +99,7 @@ class EnrollmentBumpVersionView(PermissionRequiredMixin, TemplateView):
         return ctx
 
     def post(self, request, *args, **kwargs):
+        prev_value = self.enrollment.serialize_for_event()
         self.enrollment.save()  # will bump the version
+        post_audit_event(request, self.enrollment, AuditEvent.Action.UPDATED, prev_value=prev_value)
         return redirect(self.enrollment)

--- a/zentral/contrib/osquery/views/file_categories.py
+++ b/zentral/contrib/osquery/views/file_categories.py
@@ -1,7 +1,8 @@
 import logging
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse_lazy
-from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
+from django.views.generic import DetailView, ListView
+from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
 from zentral.contrib.osquery.forms import FileCategoryForm
 from zentral.contrib.osquery.models import FileCategory
 
@@ -19,7 +20,7 @@ class FileCategoryListView(PermissionRequiredMixin, ListView):
         return ctx
 
 
-class CreateFileCategoryView(PermissionRequiredMixin, CreateView):
+class CreateFileCategoryView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_filecategory"
     model = FileCategory
     form_class = FileCategoryForm
@@ -36,13 +37,13 @@ class FileCategoryView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateFileCategoryView(PermissionRequiredMixin, UpdateView):
+class UpdateFileCategoryView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_filecategory"
     model = FileCategory
     form_class = FileCategoryForm
 
 
-class DeleteFileCategoryView(PermissionRequiredMixin, DeleteView):
+class DeleteFileCategoryView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_filecategory"
     model = FileCategory
     success_url = reverse_lazy("osquery:file_categories")

--- a/zentral/contrib/osquery/views/packs.py
+++ b/zentral/contrib/osquery/views/packs.py
@@ -6,11 +6,12 @@ from django.db.models import Count
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
-from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
+from django.views.generic import DetailView, ListView, UpdateView
 
 from zentral.contrib.osquery.forms import PackForm, PackQueryForm, UploadPackForm
 from zentral.contrib.osquery.models import Pack, PackQuery, Query
 from zentral.utils.time import naive_utcnow
+from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit
 
 logger = logging.getLogger('zentral.contrib.osquery.views.packs')
 
@@ -29,7 +30,7 @@ class PackListView(PermissionRequiredMixin, ListView):
         return ctx
 
 
-class CreatePackView(PermissionRequiredMixin, CreateView):
+class CreatePackView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_pack"
     model = Pack
     form_class = PackForm
@@ -61,7 +62,7 @@ class PackView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdatePackView(PermissionRequiredMixin, UpdateView):
+class UpdatePackView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_pack"
     model = Pack
     form_class = PackForm
@@ -93,13 +94,13 @@ class UploadPackView(PermissionRequiredMixin, UpdateView):
             return HttpResponseRedirect(self.get_success_url())
 
 
-class DeletePackView(PermissionRequiredMixin, DeleteView):
+class DeletePackView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_pack"
     model = Pack
     success_url = reverse_lazy("osquery:packs")
 
 
-class AddPackQueryView(PermissionRequiredMixin, CreateView):
+class AddPackQueryView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_packquery"
     model = PackQuery
     form_class = PackQueryForm
@@ -125,7 +126,7 @@ class AddPackQueryView(PermissionRequiredMixin, CreateView):
         return response
 
 
-class UpdatePackQueryView(PermissionRequiredMixin, UpdateView):
+class UpdatePackQueryView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_packquery"
     model = PackQuery
     form_class = PackQueryForm
@@ -148,7 +149,7 @@ class UpdatePackQueryView(PermissionRequiredMixin, UpdateView):
         return response
 
 
-class DeletePackQueryView(PermissionRequiredMixin, DeleteView):
+class DeletePackQueryView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_packquery"
     model = PackQuery
 

--- a/zentral/contrib/osquery/views/queries.py
+++ b/zentral/contrib/osquery/views/queries.py
@@ -5,13 +5,13 @@ from django.db import models
 from django.db.models import Case, Q, Sum, Value, When
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
-from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
+from django.views.generic import DetailView
 from zentral.contrib.osquery.forms import QueryForm, QuerySearchForm
 from zentral.contrib.osquery.models import PackQuery, Query
 from zentral.core.stores.conf import stores
 from zentral.core.stores.views import EventsView, FetchEventsView, EventsStoreRedirectView
 from zentral.utils.text import encode_args
-from zentral.utils.views import UserPaginationListView
+from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
 
 
 logger = logging.getLogger('zentral.contrib.osquery.views.queries')
@@ -40,7 +40,7 @@ class QueryListView(PermissionRequiredMixin, UserPaginationListView):
         return ctx
 
 
-class CreateQueryView(PermissionRequiredMixin, CreateView):
+class CreateQueryView(PermissionRequiredMixin, CreateViewWithAudit):
     permission_required = "osquery.add_query"
     model = Query
     form_class = QueryForm
@@ -94,13 +94,13 @@ class QueryView(PermissionRequiredMixin, DetailView):
         return ctx
 
 
-class UpdateQueryView(PermissionRequiredMixin, UpdateView):
+class UpdateQueryView(PermissionRequiredMixin, UpdateViewWithAudit):
     permission_required = "osquery.change_query"
     model = Query
     form_class = QueryForm
 
 
-class DeleteQueryView(PermissionRequiredMixin, DeleteView):
+class DeleteQueryView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "osquery.delete_query"
     model = Query
     success_url = reverse_lazy("osquery:queries")


### PR DESCRIPTION
Osquery was the last large module with no `zentral_audit` event. Creating, updating or deleting a configuration, a pack, a query, an automatic table construction, a file category, an enrollment or a distributed query run from the web console left no record. No test in the module asserted a single event.

The Zentral Terraform provider manages seven of these objects: the automatic table constructions, the configurations, the configuration packs, the enrollments, the file categories, the packs and the queries. They are managed as code, so the event that earns its place is the one for a change that did not come from the Terraform configuration. Distributed query runs are the exception, and section *Decisions* explains why they are audited too.

This is the first of four changes. It covers the models and the management views. The API views, the standard pack import and the missing endpoint for the runs come later.

## Commits

**1. `inventory:` put the version and the update time in the enrollment event payload**

`BaseEnrollment.serialize_for_event()` left the version out, so the audit event of a version bump showed the same value before and after: an event that recorded no change. The Turbo view that only increases the version published one of those on every use. The fix is in the base method, so the five enrollments built on `BaseEnrollment` — Monolith, Munki, Osquery, Santa and Turbo — report the change the same way.

The `enrollment` attribute of the `turbo_request` and `turbo_result` events does not change: the Turbo enrollment answers `keys_only` requests before it calls the base method. The MDM enrollments are separate models.

**2. `osquery:` fix the query payload of the events**

`Query.serialize_for_event()` wrote the version of the query under the `version` key, then replaced it with the minimum Osquery version when the query had one. The two values are unrelated. A consumer of the `osquery_pack_query_update` events read the wrong number for every query that restricts its Osquery version. The payload also had no `pk`, no `name`, no tag and no compliance check, so an event could not name the query that changed.

**3. `osquery:` publish audit events from the management views**

Twenty-four views move to the `CreateViewWithAudit` / `UpdateViewWithAudit` / `DeleteViewWithAudit` bases. The two enrollment views that drive two forms or implement `post()` themselves call `post_audit_event()`. Five models had no `serialize_for_event()` at all, and `AuditEvent.build()` calls it with no fallback, so they come first.

## Two defects found while the events were connected

**"Halt current runs" ended other runs with no record.** The option is on by default. It closed every other active run of the query with a queryset update: no `save()`, no signal, no instance, and so no event from a view that only knows its own object. Creating one run stopped three others and the trail recorded one change. `DistributedQuery.objects.halt_for_query()` reads the rows before the update and reports them, so each stopped run gets its own event.

**`QueryForm` put a database expression in the payload.** It increases the version with an `F()` expression when the SQL changes, and never refreshed the instance. `sync_query_compliance_check()` refreshes it, but only when the compliance check is on, so every other update carried a `CombinedExpression` where a number belongs.

## Decisions

Distributed query runs are audited although the Terraform provider does not manage them. A run executes operator SQL on the machines, which is the most audit-worthy action in the module. The `osquery_distributed_query` resource does not exist, and this change does not ask for one: a run is an action, and not a declared state.

Two effects of a change stay silent, and the documentation says so: a configuration change increases the version of each of its enrollments, and a pack query change sets the update time of its pack. They are consequences of a change that already has an event. Stopping a run is different — it changes another object that the operator did not name — so it gets its own event.

The pack upload view keeps the `osquery_pack_update` events for now. It goes through `update_or_create_pack`, which needs its own change.

## Tests

7977 tests pass. Patch coverage is 100%, verified line by line against the diff. Each of the three commits passes the full suite on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
