### PR TITLE
Always link an audit event to the object it reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The `version` attribute of an Osquery query in an event payload is the version o
 ### Bug fixes
 
 
+Fixed the `zentral_audit` events of the Santa enrollments and the Santa enrolled machines, which were not linked to the object they report. A model that declares the parents of an object replaced the link to the object itself, and the events of that object did not reach its page. A model keeps control of its own key when it declares one, because the MDM commands are linked by UUID and not by primary key.
+
 Fixed the version of an Osquery query in the events published when a user changed the query from the web console. The version was a database expression, and not a number.
 
 Fixed the `zentral_audit` event published when a user increases the version of an enrollment. The enrollment payload had no version, so the event showed the same value before and after the change. The payload has the `version` and `updated_at` attributes now, for the Monolith, Munki, Osquery, Santa and Turbo enrollments.

--- a/server/accounts/models.py
+++ b/server/accounts/models.py
@@ -320,6 +320,9 @@ class APIToken(models.Model):
 
 
 class OIDCAPITokenIssuer(models.Model):
+    # the verbose name of this model gives "accounts_oidcapi_token_issuer"
+    linked_objects_key = "accounts_oidc_api_token_issuer"
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=256, unique=True)
@@ -369,10 +372,6 @@ class OIDCAPITokenIssuer(models.Model):
         if self.description:
             d["description"] = self.description
         return d
-
-    def linked_objects_keys_for_event(self):
-        # to override the default key
-        return {"accounts_oidc_api_token_issuer": ((str(self.pk),),)}
 
     def get_discovery_uri(self):
         return get_discovery_uri_from_issuer_uri(self.issuer_uri)

--- a/tests/core_events/test_audit_event_objects.py
+++ b/tests/core_events/test_audit_event_objects.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+from zentral.core.events.base import AuditEvent, linked_objects_key
+
+
+class FakeMeta:
+    def __init__(self, app_label, verbose_name):
+        self.app_label = app_label
+        self.verbose_name = verbose_name
+        self.label_lower = f"{app_label}.{verbose_name.replace(' ', '')}"
+
+
+class FakeInstance:
+    """The part of a model that AuditEvent.build() reads."""
+
+    def __init__(self, pk, app_label="osquery", verbose_name="file category"):
+        self.pk = pk
+        self._meta = FakeMeta(app_label, verbose_name)
+
+
+class ParentsOnlyInstance(FakeInstance):
+    def linked_objects_keys_for_event(self):
+        return {"osquery_configuration": ((42,),)}
+
+
+class OwnKeyInstance(FakeInstance):
+    """Links itself by something other than its primary key, like the MDM device commands."""
+
+    def linked_objects_keys_for_event(self):
+        return {"osquery_file_category": ((f"uuid-{self.pk}",),)}
+
+
+class RenamedKeyInstance(FakeInstance):
+    linked_objects_key = "accounts_oidc_api_token_issuer"
+
+
+class LinkedObjectsKeyTestCase(TestCase):
+    def test_key_from_the_verbose_name(self):
+        self.assertEqual(linked_objects_key(FakeInstance(1)), "osquery_file_category")
+
+    def test_inventory_keys_have_no_app_label(self):
+        self.assertEqual(linked_objects_key(FakeInstance(1, app_label="inventory", verbose_name="tag")), "tag")
+
+    def test_declared_key_wins(self):
+        self.assertEqual(linked_objects_key(RenamedKeyInstance(1)), "accounts_oidc_api_token_issuer")
+
+
+class AuditEventObjectsTestCase(TestCase):
+    def _objects(self, instance):
+        event = AuditEvent.build(instance, AuditEvent.Action.DELETED, prev_value={"pk": instance.pk})
+        return event.metadata.objects
+
+    def test_object_without_linked_objects_is_linked_to_itself(self):
+        self.assertEqual(self._objects(FakeInstance(1)), {"osquery_file_category": [(1,)]})
+
+    def test_parents_do_not_replace_the_link_to_the_object(self):
+        self.assertEqual(
+            self._objects(ParentsOnlyInstance(2)),
+            {"osquery_file_category": [(2,)],
+             "osquery_configuration": [(42,)]}
+        )
+
+    def test_a_declared_own_key_keeps_control_of_its_arguments(self):
+        self.assertEqual(self._objects(OwnKeyInstance(3)), {"osquery_file_category": [("uuid-3",)]})
+
+    def test_a_renamed_key_is_used_for_the_object(self):
+        self.assertEqual(self._objects(RenamedKeyInstance(4)), {"accounts_oidc_api_token_issuer": [(4,)]})

--- a/tests/santa/test_api_views.py
+++ b/tests/santa/test_api_views.py
@@ -292,7 +292,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertIsNone(event.payload["object"]["prev_value"]["forced_sync_type"])
         self.assertEqual(event.payload["object"]["new_value"]["forced_sync_type"], "CLEAN_ALL")
         self.assertEqual(event.metadata.objects,
-                         {"santa_configuration": [(self.configuration.pk,)]})
+                         {"santa_enrolled_machine": [(enrolled_machine.pk,)],
+                          "santa_configuration": [(self.configuration.pk,)]})
 
     def test_force_clean_sync_defaults_to_clean(self):
         enrolled_machine = self.force_enrolled_machine()

--- a/tests/santa/test_setup_views.py
+++ b/tests/santa/test_setup_views.py
@@ -770,7 +770,9 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"santa_configuration": [str(configuration.pk)]})
+        self.assertEqual(metadata["objects"],
+                         {"santa_enrollment": [str(enrollment_pk)],
+                          "santa_configuration": [str(configuration.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["santa", "zentral"])
 
     # create voting group

--- a/zentral/core/events/base.py
+++ b/zentral/core/events/base.py
@@ -545,6 +545,20 @@ register_event_type(BaseEvent)
 # Zentral audit event
 
 
+def linked_objects_key(instance):
+    """The metadata objects key of a model instance.
+
+    A model sets linked_objects_key to override it, for a verbose name that does not read well.
+    """
+    key = getattr(instance, "linked_objects_key", None)
+    if key:
+        return key
+    key = instance._meta.verbose_name.replace(" ", "_")
+    if instance._meta.app_label != "inventory":  # shorter names for the inventory objects
+        key = f"{instance._meta.app_label}_{key}"
+    return key
+
+
 class AuditEvent(BaseEvent):
 
     class Action(Enum):
@@ -572,13 +586,15 @@ class AuditEvent(BaseEvent):
         if machine_serial_number:
             em_kwargs["machine_serial_number"] = machine_serial_number
         metadata = EventMetadata(**em_kwargs)
-        try:
-            metadata.add_objects(instance.linked_objects_keys_for_event())
-        except AttributeError:
-            key = instance._meta.verbose_name.replace(" ", "_")
-            if instance._meta.app_label != "inventory":  # shorter names for the inventory objects
-                key = f"{instance._meta.app_label}_{key}"
-            metadata.add_objects({key: ((instance.pk,),)})
+        # the object the event is about is always linked. a model that declares its own key keeps
+        # control of it — DeviceCommand links itself by uuid, not by pk — but a model that only
+        # declares its parents no longer drops the link to itself.
+        get_extra_keys = getattr(instance, "linked_objects_keys_for_event", None)
+        extra_keys = get_extra_keys() if get_extra_keys is not None else {}
+        own_key = linked_objects_key(instance)
+        if own_key not in extra_keys:
+            metadata.add_objects({own_key: ((instance.pk,),)})
+        metadata.add_objects(extra_keys)
         # payload
         payload = {
             "action": action.value,


### PR DESCRIPTION
`AuditEvent.build()` invents a metadata `objects` key from the model when the model has no `linked_objects_keys_for_event()`, so that the event reaches the page of the object it is about. A model that declares the method replaced that key instead of adding to it. A model that only declares its parents therefore dropped the link to itself, and nothing showed that it had.

## What was lost

Three models in the code base declare the method without their own key. Two of them are audited:

| Model | The event reached | The event did not reach |
|---|---|---|
| `santa.Enrollment` | the configuration | the enrollment |
| `santa.EnrolledMachine` | the configuration | the enrolled machine |

So the audit event of a deleted Santa enrollment did not appear on the enrollment, and the audit event of a forced clean sync did not appear on the enrolled machine.

## The fix

The automatic key is added first, and `linked_objects_keys_for_event()` adds to it. A model cannot remove the link to itself by accident any more.

A model that declares its own key keeps control of it. This is necessary: `mdm.DeviceCommand` links itself by UUID and not by primary key, and the first version of this change gave it two identifiers under the same key. The rule is now "you cannot lose your own link, but you can define it".

The third model, `accounts.OIDCAPITokenIssuer`, declared the method for one reason: its verbose name gives `accounts_oidcapi_token_issuer`, which does not read well. It sets the new `linked_objects_key` attribute instead. The encoded value does not change, because `encode_args()` already converts the UUID to a string.

## One more thing

The call was in a `try` / `except AttributeError` block. That block also caught an `AttributeError` raised inside the method, and answered it with the automatic key. An error in a `linked_objects_keys_for_event()` implementation was therefore invisible. The code asks for the attribute with `getattr()` now, so only a missing method takes the automatic path.

## Tests

`tests/core_events/test_audit_event_objects.py` pins the four rules: the key from the verbose name, the key without an app label for the inventory objects, the parents that do not replace the object, and the declared key that keeps its arguments.

7984 tests pass. Patch coverage is 100% on the two source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
