### PR TITLE
Publish audit events from the Osquery API views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Zentral publishes a `zentral_audit` event when a user creates, updates or delete
 
 A run that stops other runs of the same query — the "Halt current runs" option — now publishes one event for each stopped run. Before, the other runs ended with no record of it.
 
+The Osquery API publishes the same `zentral_audit` events as the web console now. The nine endpoints of the automatic table constructions, the configurations, the configuration packs, the enrollments, the file categories, the packs and the queries were the last ones that changed an object with no record of it.
+
 
 #### Santa
 
@@ -28,6 +30,11 @@ The enrolled machine and sync state metrics are bucketed by the age of the last 
 
 
 ### Backward incompatibilities
+
+
+#### 🧨 PATCH on the Osquery API
+
+`PATCH` gives a `405 Method Not Allowed` on the Osquery API. Use `PUT`, and send all the attributes of the object. A `PATCH` did not do a correct partial update: it gave a 500 on the queries and on the enrollments, and it renamed a file category or a pack, because the slug was computed from a name that the request did not contain.
 
 
 #### 🧨 Osquery query payload in events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ The enrolled machine and sync state metrics are bucketed by the age of the last 
 ### Backward incompatibilities
 
 
+#### 🧨 Osquery API list endpoints
+
+The list endpoints of the Osquery API answer with a page and not with an array. Read the objects in the `results` attribute, and follow `next` to read the pages that come after the first one. The `limit` and the `offset` query parameters select a page. The default limit is 50, and the maximum limit is 500.
+
+
 #### 🧨 PATCH on the Osquery API
 
 `PATCH` gives a `405 Method Not Allowed` on the Osquery API. Use `PUT`, and send all the attributes of the object. A `PATCH` did not do a correct partial update: it gave a 500 on the queries and on the enrollments, and it renamed a file category or a pack, because the slug was computed from a name that the request did not contain.

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -46,6 +46,22 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 #### Methods
 
 Use `PUT` to update an object, and send all its attributes. `PATCH` is not available, and gives a `405 Method Not Allowed`.
+
+#### Paginated lists
+
+The list endpoints answer with a page and not with an array:
+
+```json
+{
+  "count": 132,
+  "next": "https://zentral.example.com/api/osquery/queries/?limit=50&offset=50",
+  "previous": null,
+  "results": []
+}
+```
+
+Use the `limit` and the `offset` query parameters to select a page. The default limit is 50, and the maximum limit is 500. Read `next` until it is `null` to get all the objects.
+
 ### /api/osquery/atcs/
 
 #### List all ATCs.

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -8,7 +8,7 @@ To activate the osquery module, you need to add a `zentral.contrib.osquery` sect
 
 ## Audit events
 
-Zentral publishes a `zentral_audit` event when a user creates, updates or deletes an Osquery object from the web console: automatic table constructions, configurations, configuration packs, enrollments, file categories, packs, pack queries, queries, and distributed query runs. Each event carries the value of the object before and after the change, with the user, the source IP and the request that made it.
+Zentral publishes a `zentral_audit` event when a user creates, updates or deletes an Osquery object from the web console or from the API: automatic table constructions, configurations, configuration packs, enrollments, file categories, packs, pack queries, queries, and distributed query runs. Each event carries the value of the object before and after the change, with the user, the source IP and the request that made it.
 
 Most of these objects are managed with the Zentral Terraform provider: the automatic table constructions, the configurations, the configuration packs, the enrollments, the file categories, the packs and the queries. For these objects, the event records a change that did not come from the Terraform configuration.
 
@@ -43,6 +43,9 @@ Zentral will parse the body of the request based on the `Content-Type` HTTP head
 * `Content-Type: application/x-osquery-conf`
 * `Content-Type: application/yaml`
 
+#### Methods
+
+Use `PUT` to update an object, and send all its attributes. `PATCH` is not available, and gives a `405 Method Not Allowed`.
 ### /api/osquery/atcs/
 
 #### List all ATCs.

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -242,7 +242,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'), data={"name": get_random_string(24)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_atcs_filter_by_configuration_id_not_found(self):
         self.set_permissions("osquery.view_automatictableconstruction")
@@ -258,8 +258,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'), data={"name": atc.name})
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "platforms": ["darwin", "windows"],
             "updated_at": atc.updated_at.isoformat(),
             "columns": ["un", "deux"],
@@ -279,8 +279,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'), data={"configuration_id": configuration.id})
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "platforms": ["darwin", "windows"],
             "updated_at": atc.updated_at.isoformat(),
             "columns": ["un", "deux"],
@@ -298,8 +298,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_automatictableconstruction")
         response = self.get(reverse('osquery_api:atcs'))
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "platforms": ["darwin", "windows"],
             "updated_at": atc.updated_at.isoformat(),
             "columns": ["un", "deux"],
@@ -573,7 +573,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_filecategory")
         response = self.get(reverse('osquery_api:file_categories'), data={"name": get_random_string(35)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_file_categories_filter_by_configuration_id_not_found(self):
         self.set_permissions("osquery.view_filecategory")
@@ -589,7 +589,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_filecategory")
         response = self.get(reverse('osquery_api:file_categories'), data={"name": file_category.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "name": file_category.name,
             "slug": file_category.slug,
             "id": file_category.id,
@@ -610,7 +610,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse('osquery_api:file_categories'),
                             data={"configuration_id": configuration.id})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "name": file_category.name,
             "slug": file_category.slug,
             "id": file_category.id,
@@ -628,8 +628,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_filecategory")
         response = self.get(reverse('osquery_api:file_categories'))
         self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-        self.assertEqual(response.json(), [{
+        self.assertIsInstance(response.json()["results"], list)
+        self.assertEqual(response.json()["results"], [{
             "name": file_category.name,
             "slug": file_category.slug,
             "id": file_category.id,
@@ -903,7 +903,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_configuration")
         response = self.get(reverse("osquery_api:configurations"), {"name": get_random_string(32)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_configurations_filter_by_name(self):
         for _ in range(3):
@@ -912,7 +912,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_configuration")
         response = self.get(reverse("osquery_api:configurations"), {"name": configuration.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration.id,
             "name": configuration.name,
             "description": "",
@@ -932,7 +932,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_configuration")
         response = self.get(reverse('osquery_api:configurations'))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, [{
+        self.assertEqual(response.data["results"], [{
             "id": configuration.pk,
             "name": configuration.name,
             'description': "",
@@ -1332,7 +1332,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'script_download_url': f'https://{fqdn}/api/osquery/enrollments/{enrollment.pk}/script/',
              'created_at': enrollment.created_at.isoformat(),
              'updated_at': enrollment.updated_at.isoformat()},
-            response.json()
+            response.json()["results"]
         )
 
     # get enrollment
@@ -1673,7 +1673,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"), {"name": get_random_string(12)})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_packs_filter_by_configuration_id_not_found(self):
         self.set_permissions("osquery.view_pack")
@@ -1689,7 +1689,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration = self.force_configuration()
         response = self.get(reverse("osquery_api:packs"), {"configuration_id": configuration.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        self.assertEqual(response.json(), {'count': 0, 'next': None, 'previous': None, 'results': []})
 
     def test_get_packs_filter_by_name(self):
         for _ in range(3):
@@ -1698,7 +1698,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"), {"name": pack.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": pack.pk,
             "name": pack.name,
             "slug": slugify(pack.name),
@@ -1717,7 +1717,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"), {"configuration_id": configuration.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": pack.pk,
             "name": pack.name,
             "slug": slugify(pack.name),
@@ -1734,7 +1734,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_pack")
         response = self.get(reverse("osquery_api:packs"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": pack.pk,
             "name": pack.name,
             "slug": slugify(pack.name),
@@ -2586,7 +2586,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_query")
         response = self.get(reverse("osquery_api:queries"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(),
+        self.assertEqual(response.json()["results"],
                          [{"id": query.pk,
                            "name": query.name,
                            "version": 1,
@@ -2618,7 +2618,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_query")
         response = self.get(reverse("osquery_api:queries"), {"name": query.name})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(),
+        self.assertEqual(response.json()["results"],
                          [{"id": query.pk,
                            "name": query.name,
                            "version": 1,
@@ -2643,7 +2643,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("osquery.view_query")
         response = self.get(reverse("osquery_api:queries"), {"pack_id": pack.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(),
+        self.assertEqual(response.json()["results"],
                          [{"id": query.pk,
                            "name": query.name,
                            "version": 1,
@@ -3421,7 +3421,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration, pack, configuration_pack = self.force_configuration(force_pack=True)
         response = self.get(reverse("osquery_api:configuration_packs"), {"configuration_id": configuration.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration_pack.pk,
             "configuration": configuration.pk,
             "tags": [],
@@ -3436,7 +3436,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration, pack, configuration_pack = self.force_configuration(force_pack=True)
         response = self.get(reverse("osquery_api:configuration_packs"), {"pack_id": pack.pk})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration_pack.pk,
             "configuration": configuration.pk,
             "tags": [],
@@ -3449,7 +3449,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         configuration_pack = self.force_configuration_pack()
         response = self.get(reverse("osquery_api:configuration_packs"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{
+        self.assertEqual(response.json()["results"], [{
             "id": configuration_pack.pk,
             "configuration": configuration_pack.configuration.pk,
             "tags": [],

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -9,6 +9,7 @@ from django.utils.crypto import get_random_string
 from django.utils.http import http_date
 from django.utils.text import slugify
 
+from tests.osquery.utils import assert_audit_event
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.conf import settings
@@ -188,6 +189,45 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "osquery.delete_packquery",
         )
 
+    # http methods
+
+    def test_patch_is_not_allowed(self):
+        """Zentral only does full updates.
+
+        A partial update leaves a declared field out of validated_data, and the serializers read
+        those fields directly: QuerySerializer pops compliance_check_enabled, EnrollmentSerializer
+        pops secret, and the file category and the pack serializers slugify a name that is not
+        there, which renames the object.
+        """
+        self.set_permissions(
+            "osquery.change_automatictableconstruction",
+            "osquery.change_configuration",
+            "osquery.change_configurationpack",
+            "osquery.change_enrollment",
+            "osquery.change_filecategory",
+            "osquery.change_pack",
+            "osquery.change_query",
+        )
+        configuration_pack = self.force_configuration_pack()
+        targets = (
+            ("atc", self.force_atc()),
+            ("configuration", self.force_configuration()),
+            ("configuration_pack", configuration_pack),
+            ("enrollment", self.force_enrollment()[0]),  # force_enrollment gives (enrollment, tags)
+            ("file_category", self.force_file_category()),
+            ("pack", self.force_pack()),
+            ("query", self.force_query()),
+        )
+        for url_name, obj in targets:
+            with self.subTest(url_name):
+                response = self.client.patch(
+                    reverse(f"osquery_api:{url_name}", args=[obj.pk]),
+                    data="{}",
+                    content_type="application/json",
+                    HTTP_AUTHORIZATION=f"Token {self._get_api_key()}",
+                )
+                self.assertEqual(response.status_code, 405)
+
     # list atcs
 
     def test_get_atcs_unauthorized(self):
@@ -366,7 +406,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "detail": "No AutomaticTableConstruction matches the given query."
         })
 
-    def test_update_atc(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_atc(self, post_event):
         atc = self.force_atc()
         self.set_permissions("osquery.change_automatictableconstruction")
         data = {
@@ -378,7 +419,9 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "columns": ["un", "deux", "trois"],
             "platforms": ["darwin"]
         }
-        response = self.put(reverse("osquery_api:atc", args=[atc.id]), data)
+        prev_value = atc.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse("osquery_api:atc", args=[atc.id]), data)
         self.assertEqual(response.status_code, 200)
         atc.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -399,6 +442,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(atc.columns, ["un", "deux", "trois"])
         self.assertEqual(atc.platforms, ["darwin"])
         self.assertEqual(atc.description, "yolo changed")
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", atc, prev_value=prev_value)
 
     # create atc
 
@@ -447,17 +492,19 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "columns": ["This list may not be empty."]
         })
 
-    def test_create_atc(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_atc(self, post_event):
         self.set_permissions("osquery.add_automatictableconstruction")
-        response = self.post(reverse("osquery_api:atcs"), {
-            "name": "yolo",
-            "description": "yolo",
-            "table_name": "yolo",
-            "query": "select 1 from yo;",
-            "columns": ["un", "deux"],
-            "platforms": ["darwin", "windows"],
-            "path": "/home/yolo"
-        })
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("osquery_api:atcs"), {
+                "name": "yolo",
+                "description": "yolo",
+                "table_name": "yolo",
+                "query": "select 1 from yo;",
+                "columns": ["un", "deux"],
+                "platforms": ["darwin", "windows"],
+                "path": "/home/yolo"
+            })
         self.assertEqual(response.status_code, 201)
         atc = AutomaticTableConstruction.objects.first()
         self.assertEqual(response.json(), {
@@ -479,6 +526,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(atc.columns, ["un", "deux"])
         self.assertEqual(atc.platforms, ["darwin", "windows"])
         self.assertEqual(atc.path, "/home/yolo")
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", atc)
 
     # delete atc
 
@@ -498,12 +547,17 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "detail": "No AutomaticTableConstruction matches the given query."
         })
 
-    def test_delete_atc(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_atc(self, post_event):
         atc = self.force_atc()
         self.set_permissions("osquery.delete_automatictableconstruction")
-        response = self.delete(reverse("osquery_api:atc", args=[atc.id]))
+        prev_value = atc.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("osquery_api:atc", args=[atc.id]))
         self.assertEqual(response.status_code, 204)
         self.assertFalse(AutomaticTableConstruction.objects.exists())
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", atc, prev_value=prev_value)
 
     # list file categories
 
@@ -682,7 +736,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "detail": "No FileCategory matches the given query."
         })
 
-    def test_update_file_category(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_file_category(self, post_event):
         file_category = self.force_file_category()
         self.set_permissions("osquery.change_filecategory")
         data = {
@@ -693,7 +748,9 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "file_paths_queries": [],
             "access_monitoring": True
         }
-        response = self.put(reverse("osquery_api:file_category", args=[file_category.id]), data=data)
+        prev_value = file_category.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse("osquery_api:file_category", args=[file_category.id]), data=data)
         self.assertEqual(response.status_code, 200)
         file_category.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -715,6 +772,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(file_category.access_monitoring, True)
         self.assertEqual(file_category.description, "description of the example file category")
         self.assertEqual(file_category.file_paths_queries, [])
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", file_category, prev_value=prev_value)
 
     # create file category
 
@@ -763,7 +822,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "access_monitoring": ["This field may not be null."],
         })
 
-    def test_create_file_category(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_file_category(self, post_event):
         self.set_permissions("osquery.add_filecategory")
         data = {
             "name": "file category name",
@@ -772,7 +832,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "description": "description of the example file category",
             "file_paths_queries": ['select * from file_paths where path like "/home/yo/*.bin";'],
         }
-        response = self.post(reverse("osquery_api:file_categories"), data=data)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("osquery_api:file_categories"), data=data)
         file_category = FileCategory.objects.first()
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json(), {
@@ -795,6 +856,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(file_category.description, "description of the example file category")
         self.assertEqual(file_category.file_paths_queries,
                          ['select * from file_paths where path like "/home/yo/*.bin";'])
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", file_category)
 
     # delete file category
 
@@ -814,12 +877,17 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "detail": "No FileCategory matches the given query."
         })
 
-    def test_delete_file_category(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_file_category(self, post_event):
         file_category = self.force_file_category()
         self.set_permissions("osquery.delete_filecategory")
-        response = self.delete(reverse("osquery_api:file_category", args=[file_category.id]))
+        prev_value = file_category.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("osquery_api:file_category", args=[file_category.id]))
         self.assertEqual(response.status_code, 204)
         self.assertEqual(FileCategory.objects.count(), 0)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", file_category, prev_value=prev_value)
 
     # list configurations
 
@@ -969,7 +1037,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "file_categories": ['Invalid pk "9999" - object does not exist.']
         })
 
-    def test_create_configuration(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_configuration(self, post_event):
         atc = self.force_atc()
         file_category = self.force_file_category()
         self.set_permissions("osquery.add_configuration")
@@ -986,7 +1055,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                 'foo': 'bar'
             }
         }
-        response = self.post(reverse('osquery_api:configurations'), data)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse('osquery_api:configurations'), data)
         self.assertEqual(response.status_code, 201)
         configuration = Configuration.objects.get(name="Configuration0")
         self.assertEqual(response.json(), {
@@ -1014,6 +1084,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(configuration.automatic_table_constructions.all()[0], atc)
         self.assertEqual(configuration.file_categories.all()[0], file_category)
         self.assertEqual(configuration.options, {'foo': 'bar'})
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", configuration)
 
     # update configuration
 
@@ -1133,7 +1205,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         })
         self.assertEqual(configuration.file_categories.all()[0], file_category)
 
-    def test_update_configuration(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_configuration(self, post_event):
         configuration = self.force_configuration()
         new_name = get_random_string(12)
         atc = self.force_atc()
@@ -1152,7 +1225,9 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             }
         }
         self.set_permissions("osquery.change_configuration")
-        response = self.put(reverse('osquery_api:configuration', args=(configuration.pk,)), data)
+        prev_value = configuration.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse('osquery_api:configuration', args=(configuration.pk,)), data)
         self.assertEqual(response.status_code, 200)
         configuration.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -1178,6 +1253,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(configuration.automatic_table_constructions.count(), 1)
         self.assertEqual(configuration.file_categories.count(), 1)
         self.assertEqual(configuration.options, {"foo": "bar"})
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", configuration, prev_value=prev_value)
 
     # delete configuration
 
@@ -1206,11 +1283,16 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), ["This configuration cannot be deleted"])
 
-    def test_delete_configuration(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_configuration(self, post_event):
         configuration = self.force_configuration()
         self.set_permissions("osquery.delete_configuration")
-        response = self.delete(reverse('osquery_api:configuration', args=(configuration.pk,)))
+        prev_value = configuration.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse('osquery_api:configuration', args=(configuration.pk,)))
         self.assertEqual(response.status_code, 204)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", configuration, prev_value=prev_value)
 
     # list enrollments
 
@@ -1482,16 +1564,18 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
 
     # create enrollment
 
-    def test_create_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrollment(self, post_event):
         config = self.force_configuration()
         self.set_permissions("osquery.add_enrollment")
         tags = [Tag.objects.create(name=get_random_string(12)) for _ in range(2)]
-        response = self.post(
-            reverse('osquery_api:enrollments'),
-            {'configuration': config.pk,
-             'secret': {"meta_business_unit": self.mbu.pk,
-                        "tags": [t.id for t in tags]}}
-        )
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(
+                reverse('osquery_api:enrollments'),
+                {'configuration': config.pk,
+                 'secret': {"meta_business_unit": self.mbu.pk,
+                            "tags": [t.id for t in tags]}}
+            )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Enrollment.objects.filter(configuration__name=config.name).count(), 1)
         enrollment = Enrollment.objects.get(configuration__name=config.name)
@@ -1500,10 +1584,13 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             set(enrollment.secret.tags.all()),
             set(tags)
         )
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", enrollment)
 
     # update enrollment
 
-    def test_update_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_enrollment(self, post_event):
         enrollment, _ = self.force_enrollment(tag_count=2)
         enrollment_secret = enrollment.secret
         self.assertEqual(enrollment.osquery_release, "")
@@ -1523,7 +1610,9 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                 "osquery_release": new_osquery_release,
                 "secret": secret_data}
         self.set_permissions("osquery.change_enrollment")
-        response = self.put(reverse('osquery_api:enrollment', args=(enrollment.pk,)), data)
+        prev_value = enrollment.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse('osquery_api:enrollment', args=(enrollment.pk,)), data)
         self.assertEqual(response.status_code, 200)
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.osquery_release, new_osquery_release)
@@ -1535,6 +1624,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             set(enrollment.secret.tags.all()),
             set(tags)
         )
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", enrollment, prev_value=prev_value)
 
     # delete enrollment
 
@@ -1548,11 +1639,16 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.delete(reverse('osquery_api:enrollment', args=(enrollment.pk,)))
         self.assertEqual(response.status_code, 403)
 
-    def test_delete_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_enrollment(self, post_event):
         enrollment, _ = self.force_enrollment()
         self.set_permissions("osquery.delete_enrollment")
-        response = self.delete(reverse('osquery_api:enrollment', args=(enrollment.pk,)))
+        prev_value = enrollment.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse('osquery_api:enrollment', args=(enrollment.pk,)))
         self.assertEqual(response.status_code, 204)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", enrollment, prev_value=prev_value)
 
     @patch("zentral.contrib.osquery.models.BaseEnrollment.can_be_deleted")
     def test_delete_enrollment_cannot_be_deleted(self, can_be_deleted):
@@ -1761,7 +1857,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "shard": ["Ensure this value is less than or equal to 100."]
         })
 
-    def test_update_pack(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_pack(self, post_event):
         pack = self.force_pack()
         self.set_permissions("osquery.change_pack")
         data = {
@@ -1771,7 +1868,9 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "shard": 1,
             "event_routing_key": "pack_updated"
         }
-        response = self.put(reverse("osquery_api:pack", args=(pack.pk,)), data)
+        prev_value = pack.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse("osquery_api:pack", args=(pack.pk,)), data)
         self.assertEqual(response.status_code, 200)
         pack.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -1791,6 +1890,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(pack.discovery_queries, ["select * from osquery_info"])
         self.assertEqual(pack.shard, 1)
         self.assertEqual(pack.event_routing_key, "pack_updated")
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", pack, prev_value=prev_value)
 
     # create pack
 
@@ -1847,7 +1948,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "shard": ["Ensure this value is less than or equal to 100."]
         })
 
-    def test_create_pack(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_pack(self, post_event):
         self.set_permissions("osquery.add_pack")
         data = {
             "name": "pack created",
@@ -1856,7 +1958,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "shard": 1,
             "event_routing_key": "pack_created"
         }
-        response = self.post(reverse("osquery_api:packs"), data)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("osquery_api:packs"), data)
         self.assertEqual(response.status_code, 201)
         pack = Pack.objects.first()
         self.assertEqual(response.json(), {
@@ -1876,6 +1979,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(pack.discovery_queries, ["select * from osquery_info"])
         self.assertEqual(pack.shard, 1)
         self.assertEqual(pack.event_routing_key, "pack_created")
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", pack)
 
     # delete pack <int:pk>
 
@@ -1892,12 +1997,17 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.delete(reverse("osquery_api:pack", args=(9999,)))
         self.assertEqual(response.status_code, 404)
 
-    def test_delete_pack_by_pk(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_pack_by_pk(self, post_event):
         self.set_permissions("osquery.delete_pack")
         pack = self.force_pack()
-        response = self.delete(reverse("osquery_api:pack", args=(pack.pk,)))
+        prev_value = pack.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("osquery_api:pack", args=(pack.pk,)))
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Pack.objects.filter(pk=pack.pk).exists())
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", pack, prev_value=prev_value)
 
     # put pack <slug:slug>
 
@@ -2570,14 +2680,16 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {'name': ['query with this name already exists.']})
 
-    def test_create_query(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_query(self, post_event):
         data = {
             "name": "test_query01",
             "sql": "select * from osquery_info;",
             "compliance_check_enabled": False
         }
         self.set_permissions("osquery.add_query")
-        response = self.post(reverse("osquery_api:queries"), data)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("osquery_api:queries"), data)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Query.objects.filter(name='test_query01').count(), 1)
         query = Query.objects.get(name='test_query01')
@@ -2597,6 +2709,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "created_at": query.created_at.isoformat(),
                           "updated_at": query.updated_at.isoformat()
                           })
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", query)
 
     def test_create_query_with_scheduling(self):
         name = get_random_string(12)
@@ -2931,16 +3045,21 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {'name': ['query with this name already exists.']})
 
-    def test_update_query(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_query(self, post_event):
         query = self.force_query()
         new_name = get_random_string(12)
         data = {"name": new_name, "sql": query.sql}
         self.set_permissions("osquery.change_query")
-        response = self.put(reverse("osquery_api:query", args=(query.pk,)), data)
+        prev_value = query.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse("osquery_api:query", args=(query.pk,)), data)
         self.assertEqual(response.status_code, 200)
         query.refresh_from_db()
         self.assertEqual(Query.objects.filter(name=new_name).count(), 1)
         self.assertEqual(query.name, new_name)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", query, prev_value=prev_value)
 
     def test_update_query_add_scheduling(self):
         pack = self.force_pack()
@@ -3240,12 +3359,17 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
 
     # delete query
 
-    def test_delete_query(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_query(self, post_event):
         query = self.force_query()
         self.set_permissions("osquery.delete_query")
-        response = self.delete(reverse("osquery_api:query", args=(query.pk,)))
+        prev_value = query.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("osquery_api:query", args=(query.pk,)))
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Query.objects.filter(pk=query.pk).count(), 0)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", query, prev_value=prev_value)
 
     def test_delete_query_with_pack_query(self):
         query = self.force_query(pack_query_mode="diff")
@@ -3422,7 +3546,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "non_field_errors": [f"'{tag.name}' cannot be both included and excluded"]
         })
 
-    def test_update_configuration_pack(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_configuration_pack(self, post_event):
         self.set_permissions("osquery.change_configurationpack")
         configuration_pack = self.force_configuration_pack(force_tags=True)
         new_configuration = self.force_configuration()
@@ -3434,7 +3559,9 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "tags": [new_tag.id],
             "excluded_tags": [new_excluded_tag.id]
         }
-        response = self.put(reverse("osquery_api:configuration_pack", args=(configuration_pack.pk,)), data)
+        prev_value = configuration_pack.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.put(reverse("osquery_api:configuration_pack", args=(configuration_pack.pk,)), data)
         self.assertEqual(response.status_code, 200)
         configuration_pack.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -3448,6 +3575,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(configuration_pack.tags.count(), 1)
         self.assertEqual(configuration_pack.excluded_tags.count(), 1)
         self.assertEqual(configuration_pack.pack, new_pack)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "updated", configuration_pack, prev_value=prev_value)
 
     # create configuration pack
 
@@ -3528,7 +3657,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         })
         self.assertEqual(configuration_pack.configuration, configuration)
 
-    def test_create_configuration_pack(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_configuration_pack(self, post_event):
         self.set_permissions("osquery.add_configurationpack")
         configuration = self.force_configuration()
         pack = self.force_pack()
@@ -3539,7 +3669,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             "tags": [tag.id],
             "excluded_tags":  [excluded_tag.id],
         }
-        response = self.post(reverse("osquery_api:configuration_packs"), data)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.post(reverse("osquery_api:configuration_packs"), data)
         self.assertEqual(response.status_code, 201)
         configuration_pack = ConfigurationPack.objects.first()
         self.assertEqual(response.json(), {
@@ -3553,6 +3684,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(configuration_pack.pack, pack)
         self.assertEqual(configuration_pack.tags.count(), 1)
         self.assertEqual(configuration_pack.excluded_tags.count(), 1)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "created", configuration_pack)
 
     # delete configuration pack
 
@@ -3569,12 +3702,17 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.delete(reverse("osquery_api:configuration_pack", args=(9999,)))
         self.assertEqual(response.status_code, 404)
 
-    def test_delete_configuration_pack(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_configuration_pack(self, post_event):
         self.set_permissions("osquery.delete_configurationpack")
         configuration_pack = self.force_configuration_pack()
-        response = self.delete(reverse("osquery_api:configuration_pack", args=(configuration_pack.pk,)))
+        prev_value = configuration_pack.serialize_for_event()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.delete(reverse("osquery_api:configuration_pack", args=(configuration_pack.pk,)))
         self.assertEqual(response.status_code, 204)
         self.assertEqual(ConfigurationPack.objects.count(), 0)
+        self.assertEqual(len(callbacks), 1)
+        assert_audit_event(self, post_event, "deleted", configuration_pack, prev_value=prev_value)
 
     # terraform export
 

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -12,7 +12,7 @@ from rest_framework.views import APIView
 from rest_framework_yaml.parsers import YAMLParser
 from accounts.api_authentication import APITokenAuthentication
 from zentral.utils.drf import (DjangoPermissionRequired, ListCreateAPIViewWithAudit,
-                               RetrieveUpdateDestroyAPIViewWithAudit)
+                               MaxLimitOffsetPagination, RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import post_osquery_pack_update_events
 from .models import Configuration, ConfigurationPack, Enrollment, Pack, Query, AutomaticTableConstruction, FileCategory
 from .linux_script.builder import OsqueryZentralEnrollScriptBuilder
@@ -34,9 +34,10 @@ class AutomaticTableConstructionList(ListCreateAPIViewWithAudit):
     """
     List all AutomaticTableConstructions or create a new AutomaticTableConstruction
     """
-    queryset = AutomaticTableConstruction.objects.all()
+    queryset = AutomaticTableConstruction.objects.all().order_by("name")
     serializer_class = AutomaticTableConstructionSerializer
     filterset_class = AutomaticTableConstructionFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class AutomaticTableConstructionDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -51,9 +52,10 @@ class ConfigurationList(ListCreateAPIViewWithAudit):
     """
     List all Configurations, search Configuration by name, or create a new Configuration.
     """
-    queryset = Configuration.objects.all()
+    queryset = Configuration.objects.all().order_by("name")
     serializer_class = ConfigurationSerializer
     filterset_fields = ('name',)
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -74,8 +76,9 @@ class EnrollmentList(ListCreateAPIViewWithAudit):
     """
     List all Enrollments or create a new Enrollment
     """
-    queryset = Enrollment.objects.all()
+    queryset = Enrollment.objects.all().order_by("pk")
     serializer_class = EnrollmentSerializer
+    pagination_class = MaxLimitOffsetPagination
 
 
 class EnrollmentDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -148,9 +151,10 @@ class FileCategoryList(ListCreateAPIViewWithAudit):
     """
     List, Create file categories, search by name or configuration_id
     """
-    queryset = FileCategory.objects.all()
+    queryset = FileCategory.objects.all().order_by("name")
     serializer_class = FileCategorySerializer
     filterset_class = FileCategoryFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class FileCategoryDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -247,9 +251,10 @@ class PackFilter(filters.FilterSet):
 
 
 class PackList(ListCreateAPIViewWithAudit):
-    queryset = Pack.objects.all()
+    queryset = Pack.objects.all().order_by("name")
     serializer_class = PackSerializer
     filterset_class = PackFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class PackDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -266,9 +271,10 @@ class QueryFilter(filters.FilterSet):
 
 
 class QueryList(ListCreateAPIViewWithAudit):
-    queryset = Query.objects.all()
+    queryset = Query.objects.all().order_by("name")
     serializer_class = QuerySerializer
     filterset_class = QueryFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class QueryDetail(RetrieveUpdateDestroyAPIViewWithAudit):
@@ -285,9 +291,10 @@ class ConfigurationPackFilter(filters.FilterSet):
 
 
 class ConfigurationPackList(ListCreateAPIViewWithAudit):
-    queryset = ConfigurationPack.objects.all()
+    queryset = ConfigurationPack.objects.all().order_by("pk")
     serializer_class = ConfigurationPackSerializer
     filterset_class = ConfigurationPackFilter
+    pagination_class = MaxLimitOffsetPagination
 
 
 class ConfigurationPackDetail(RetrieveUpdateDestroyAPIViewWithAudit):

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from django_filters import rest_framework as filters
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from rest_framework import generics, status
+from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import JSONParser
@@ -11,7 +11,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_yaml.parsers import YAMLParser
 from accounts.api_authentication import APITokenAuthentication
-from zentral.utils.drf import DefaultDjangoModelPermissions, DjangoPermissionRequired
+from zentral.utils.drf import (DjangoPermissionRequired, ListCreateAPIViewWithAudit,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import post_osquery_pack_update_events
 from .models import Configuration, ConfigurationPack, Enrollment, Pack, Query, AutomaticTableConstruction, FileCategory
 from .linux_script.builder import OsqueryZentralEnrollScriptBuilder
@@ -29,43 +30,37 @@ class AutomaticTableConstructionFilter(filters.FilterSet):
     name = filters.CharFilter()
 
 
-class AutomaticTableConstructionList(generics.ListCreateAPIView):
+class AutomaticTableConstructionList(ListCreateAPIViewWithAudit):
     """
     List all AutomaticTableConstructions or create a new AutomaticTableConstruction
     """
     queryset = AutomaticTableConstruction.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = AutomaticTableConstructionSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = AutomaticTableConstructionFilter
 
 
-class AutomaticTableConstructionDetail(generics.RetrieveUpdateDestroyAPIView):
+class AutomaticTableConstructionDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, update or delete an AutomaticTableConstruction instance.
     """
     queryset = AutomaticTableConstruction.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = AutomaticTableConstructionSerializer
 
 
-class ConfigurationList(generics.ListCreateAPIView):
+class ConfigurationList(ListCreateAPIViewWithAudit):
     """
     List all Configurations, search Configuration by name, or create a new Configuration.
     """
     queryset = Configuration.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = ConfigurationSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
 
 
-class ConfigurationDetail(generics.RetrieveUpdateDestroyAPIView):
+class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, update or delete a Configuration instance.
     """
     queryset = Configuration.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = ConfigurationSerializer
 
     def perform_destroy(self, instance):
@@ -75,21 +70,19 @@ class ConfigurationDetail(generics.RetrieveUpdateDestroyAPIView):
             return super().perform_destroy(instance)
 
 
-class EnrollmentList(generics.ListCreateAPIView):
+class EnrollmentList(ListCreateAPIViewWithAudit):
     """
     List all Enrollments or create a new Enrollment
     """
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
 
 
-class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
+class EnrollmentDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, update or delete an Enrollment instance.
     """
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
 
     def perform_destroy(self, instance):
@@ -151,23 +144,20 @@ class FileCategoryFilter(filters.FilterSet):
     name = filters.CharFilter()
 
 
-class FileCategoryList(generics.ListCreateAPIView):
+class FileCategoryList(ListCreateAPIViewWithAudit):
     """
     List, Create file categories, search by name or configuration_id
     """
     queryset = FileCategory.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = FileCategorySerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = FileCategoryFilter
 
 
-class FileCategoryDetail(generics.RetrieveUpdateDestroyAPIView):
+class FileCategoryDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, Update, Delete a file category
     """
     queryset = FileCategory.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = FileCategorySerializer
 
 
@@ -256,17 +246,14 @@ class PackFilter(filters.FilterSet):
     name = filters.CharFilter()
 
 
-class PackList(generics.ListCreateAPIView):
+class PackList(ListCreateAPIViewWithAudit):
     queryset = Pack.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = PackSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = PackFilter
 
 
-class PackDetail(generics.RetrieveUpdateDestroyAPIView):
+class PackDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = Pack.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = PackSerializer
 
 
@@ -278,17 +265,14 @@ class QueryFilter(filters.FilterSet):
     name = filters.CharFilter()
 
 
-class QueryList(generics.ListCreateAPIView):
+class QueryList(ListCreateAPIViewWithAudit):
     queryset = Query.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = QuerySerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = QueryFilter
 
 
-class QueryDetail(generics.RetrieveUpdateDestroyAPIView):
+class QueryDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = Query.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = QuerySerializer
 
 
@@ -300,15 +284,12 @@ class ConfigurationPackFilter(filters.FilterSet):
                                                  queryset=Configuration.objects.all())
 
 
-class ConfigurationPackList(generics.ListCreateAPIView):
+class ConfigurationPackList(ListCreateAPIViewWithAudit):
     queryset = ConfigurationPack.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = ConfigurationPackSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = ConfigurationPackFilter
 
 
-class ConfigurationPackDetail(generics.RetrieveUpdateDestroyAPIView):
+class ConfigurationPackDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = ConfigurationPack.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = ConfigurationPackSerializer


### PR DESCRIPTION
The web console records every change to an Osquery object since [#1642](https://github.com/zentralopensource/zentral/pull/1642). The API changed the same objects with no record of it, so an operator could not tell which of the two made a change, or that a change came from a service account at all.

This is the second of four changes. The models and the management views came first. The standard pack import and the missing endpoint for the runs come later.

## Commits

**1. `osquery:` publish audit events from the API views**

The seven list views move to `ListCreateAPIViewWithAudit`, and the seven detail views to `RetrieveUpdateDestroyAPIViewWithAudit`. The bases set the permission classes and the filter backend, so those lines come out of each view. The two views that refuse to delete an object still in use keep their `perform_destroy()`: the audited base deletes and then publishes, in that order.

**2. `osquery:` paginate the API list endpoints**

The seven list endpoints answered with the whole table. They answer with a page now: 50 objects by default, 500 at most.

## PATCH is a 405

The audited base only accepts the full update. This is a fix and not only a rule, because the serializers assume every declared field is there:

| Endpoint | What a PATCH did |
|---|---|
| `/queries/<pk>/` | `KeyError` on `compliance_check_enabled` → **500** |
| `/enrollments/<pk>/` | `KeyError` on `secret` → **500** |
| `/file_categories/<pk>/` | slug computed from a name that is absent → **the object was renamed to `none`** |
| `/packs/<pk>/` | the same |

`slugify(None)` gives `"none"`, because `slugify()` calls `str()` on its argument first. A `PATCH` that carried only a description therefore renamed the object, or was refused because another object already had the slug `none`. No test in the suite sent a `PATCH`.

## Orderings

Pagination needs a total ordering. An ordering on a column that is not unique lets a row move between two pages, and the client reads it twice or not at all.

| Endpoint | Ordering | Total because |
|---|---|---|
| ATCs, configurations, file categories, packs, queries | `name` | the name is unique on those models |
| Enrollments, configuration packs | `pk` | those models have no name |

## Effect on the open pull requests

The orderings and the list assertions are the ones of [#1628](https://github.com/zentralopensource/zentral/pull/1628), taken from that branch. Its Osquery part is a deletion now, and not a merge. The Osquery part of [#1641](https://github.com/zentralopensource/zentral/pull/1641) is a deletion as well: the audited base sets the same method list.

## Tests

7985 tests pass. Patch coverage is 100%. The 21 create, update and delete tests assert the event, and one test walks the seven detail endpoints to check the 405. The first commit passes the full suite on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
