### PR TITLE
Split the Osquery pack import events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Zentral publishes a `zentral_audit` event when a user creates, updates or delete
 
 A run that stops other runs of the same query — the "Halt current runs" option — now publishes one event for each stopped run. Before, the other runs ended with no record of it.
 
+An import of a standard Osquery pack publishes a `zentral_audit` event for each object it changes, next to the `osquery_pack_update` event that reports the import. The import changed packs, queries and pack queries with no audit trail, and it is the only way to change several of them at once.
+
 The Osquery API publishes the same `zentral_audit` events as the web console now. The nine endpoints of the automatic table constructions, the configurations, the configuration packs, the enrollments, the file categories, the packs and the queries were the last ones that changed an object with no record of it.
 
 
@@ -30,6 +32,15 @@ The enrolled machine and sync state metrics are bucketed by the age of the last 
 
 
 ### Backward incompatibilities
+
+
+#### 🧨 Osquery pack import events
+
+The `osquery_pack_query_update` events are removed. The import of a standard pack publishes a `zentral_audit` event for each pack query it changes, and one for each pack and each query as well. Read those instead: they carry the whole value of the object before and after the change, where the removed event carried a partial difference, and they reach the page of the object.
+
+The `osquery_pack_update` event does not carry the `updates` attribute anymore, for the same reason: the audit event of the pack carries the two values. The response of `PUT /api/osquery/packs/<slug>/` is unchanged and still carries `updates`.
+
+An `osquery_pack_query_update` event reported a change to a pack query and a change to the query it schedules together, with the SQL of the query under the `query` key. These are two audit events now, one for each object.
 
 
 #### 🧨 Osquery API list endpoints

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -21,6 +21,14 @@ Two effects of a change have no event of their own:
 
 The "Halt current runs" option of a new run stops the other runs of the same query. Each stopped run has its own event.
 
+### Standard pack imports
+
+An import of a standard pack — a `PUT` on `/api/osquery/packs/<slug>/`, or an upload in the web console — changes several objects at once. It publishes one `osquery_pack_update` event that reports the import, and one `zentral_audit` event for each object it changed. They share one event UUID, and the report is the first of them, so a reader can gather the whole import from any one of its events.
+
+The report answers what the audit events cannot: what the import did as a whole. Its `result` is `created`, `updated`, `present` or `deleted`, and `present` says that the import ran and changed nothing. Its `query_results` counts the pack queries the import created, updated, deleted, or left as they were.
+
+The report does not carry the difference between the two values of an object. The audit event of that object carries the whole value before and after the change.
+
 ## HTTP API
 
 ### Requests

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -27,7 +27,9 @@ from zentral.contrib.osquery.models import (
     PackQuery,
     Query,
 )
+from zentral.contrib.osquery.events import OsqueryPackUpdateEvent
 from zentral.core.compliance_checks.models import ComplianceCheck
+from zentral.core.events.base import AuditEvent
 from zentral.utils.time import naive_utcnow
 
 
@@ -2459,6 +2461,155 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             response.json(),
             {"pack": {"slug": slug}, "result": "absent"}
         )
+
+    # standard pack import events
+
+    def _import_pack(self, url, pack, post_event):
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(url, pack)
+        self.assertEqual(response.status_code, 200)
+        events = [c.args[0] for c in post_event.call_args_list]
+        post_event.reset_mock()
+        return response.json(), events
+
+    def _minimal_pack(self):
+        return {
+            "queries": {
+                "Query1": {
+                    "query": "select 1 from users;",
+                    "interval": "3600",
+                }
+            }
+        }
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_import_pack_events(self, post_event):
+        self.set_pack_endpoint_put_permissions()
+        slug = get_random_string(12)
+        url = reverse("osquery_api:pack", args=(slug,))
+
+        # a first import creates the pack, the query and the pack query
+        body, events = self._import_pack(url, self._minimal_pack(), post_event)
+        self.assertEqual(body["result"], "created")
+        self.assertEqual(body["query_results"], {"created": 1, "deleted": 0, "present": 0, "updated": 0})
+        report, *audit_events = events
+        self.assertIsInstance(report, OsqueryPackUpdateEvent)
+        self.assertEqual(report.payload["result"], "created")
+        # the report does not carry the difference anymore, the audit events do
+        self.assertNotIn("updates", report.payload)
+        self.assertEqual([e.payload["object"]["model"] for e in audit_events],
+                         ["osquery.pack", "osquery.query", "osquery.packquery"])
+        self.assertTrue(all(isinstance(e, AuditEvent) for e in audit_events))
+        self.assertTrue(all(e.payload["action"] == "created" for e in audit_events))
+        # one import is one group of events, the report first
+        self.assertTrue(all(e.metadata.uuid == report.metadata.uuid for e in audit_events))
+        self.assertEqual([e.metadata.index for e in audit_events], [1, 2, 3])
+        self.assertEqual(report.metadata.index, 0)
+        pack = Pack.objects.get(slug=slug)
+        self.assertEqual(report.metadata.objects, {"osquery_pack": [(pack.pk,)]})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_import_pack_again_changes_nothing(self, post_event):
+        self.set_pack_endpoint_put_permissions()
+        url = reverse("osquery_api:pack", args=(get_random_string(12),))
+        self._import_pack(url, self._minimal_pack(), post_event)
+
+        # the same file again: the import runs and touches nothing
+        body, events = self._import_pack(url, self._minimal_pack(), post_event)
+        self.assertEqual(body["result"], "present")
+        self.assertEqual(body["query_results"], {"created": 0, "deleted": 0, "present": 1, "updated": 0})
+        # only the report. an audit event here would mean the import wrote something it did not
+        # have to: adopting a query used to save it whatever the file said.
+        self.assertEqual(len(events), 1)
+        self.assertIsInstance(events[0], OsqueryPackUpdateEvent)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_import_pack_updates_the_query(self, post_event):
+        self.set_pack_endpoint_put_permissions()
+        url = reverse("osquery_api:pack", args=(get_random_string(12),))
+        self._import_pack(url, self._minimal_pack(), post_event)
+
+        pack = self._minimal_pack()
+        pack["queries"]["Query1"]["query"] = "select 2 from users;"
+        body, events = self._import_pack(url, pack, post_event)
+        self.assertEqual(body["query_results"], {"created": 0, "deleted": 0, "present": 0, "updated": 1})
+        report, audit_event = events
+        self.assertIsInstance(report, OsqueryPackUpdateEvent)
+        self.assertEqual(audit_event.payload["object"]["model"], "osquery.query")
+        self.assertEqual(audit_event.payload["action"], "updated")
+        self.assertEqual(audit_event.payload["object"]["prev_value"]["sql"], "select 1 from users;")
+        self.assertEqual(audit_event.payload["object"]["new_value"]["sql"], "select 2 from users;")
+        # the version is a number, and not the database expression that increased it
+        self.assertEqual(audit_event.payload["object"]["new_value"]["version"],
+                         audit_event.payload["object"]["prev_value"]["version"] + 1)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_import_pack_removes_a_query(self, post_event):
+        self.set_pack_endpoint_put_permissions()
+        url = reverse("osquery_api:pack", args=(get_random_string(12),))
+        pack = self._minimal_pack()
+        pack["queries"]["Query2"] = {"query": "select 3 from users;", "interval": "3600"}
+        self._import_pack(url, pack, post_event)
+
+        body, events = self._import_pack(url, self._minimal_pack(), post_event)
+        self.assertEqual(body["query_results"], {"created": 0, "deleted": 1, "present": 1, "updated": 0})
+        report, audit_event = events
+        self.assertIsInstance(report, OsqueryPackUpdateEvent)
+        self.assertEqual(audit_event.payload["object"]["model"], "osquery.packquery")
+        self.assertEqual(audit_event.payload["action"], "deleted")
+        # the pack query is gone, the event still names it
+        self.assertEqual(audit_event.payload["object"]["pk"],
+                         str(audit_event.payload["object"]["prev_value"]["pk"]))
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_import_pack_adopting_an_unchanged_query_does_not_report_a_change(self, post_event):
+        """A query can outlive the pack query that scheduled it.
+
+        The import then finds it by name instead of creating it. It used to save that query
+        whatever the file said, because the flag that recorded the change was set before the
+        comparison. That write is invisible on its own, but it makes an audit event whose value
+        before and after are the same.
+        """
+        self.set_pack_endpoint_put_permissions()
+        slug = get_random_string(12)
+        url = reverse("osquery_api:pack", args=(slug,))
+        self._import_pack(url, self._minimal_pack(), post_event)
+        query = Query.objects.get(name=f"{slug}{Pack.DELIMITER}Query1")
+        updated_at = query.updated_at
+        PackQuery.objects.get(query=query).delete()
+
+        # the same file again: the query is adopted, unchanged
+        body, events = self._import_pack(url, self._minimal_pack(), post_event)
+        self.assertEqual(body["query_results"], {"created": 1, "deleted": 0, "present": 0, "updated": 0})
+        report, audit_event = events
+        self.assertIsInstance(report, OsqueryPackUpdateEvent)
+        self.assertEqual(audit_event.payload["object"]["model"], "osquery.packquery")
+        self.assertEqual(audit_event.payload["action"], "created")
+        query.refresh_from_db()
+        self.assertEqual(query.updated_at, updated_at)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_pack_events(self, post_event):
+        self.set_pack_endpoint_put_permissions()
+        slug = get_random_string(12)
+        url = reverse("osquery_api:pack", args=(slug,))
+        self._import_pack(url, self._minimal_pack(), post_event)
+        pack = Pack.objects.get(slug=slug)
+        pack_query = pack.packquery_set.get()
+
+        self.set_pack_endpoint_delete_permissions()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["result"], "deleted")
+        report, *audit_events = [c.args[0] for c in post_event.call_args_list]
+        self.assertIsInstance(report, OsqueryPackUpdateEvent)
+        self.assertEqual(report.payload["query_results"]["deleted"], 1)
+        self.assertEqual([e.payload["object"]["model"] for e in audit_events],
+                         ["osquery.packquery", "osquery.pack"])
+        self.assertTrue(all(e.payload["action"] == "deleted" for e in audit_events))
+        self.assertEqual([e.payload["object"]["pk"] for e in audit_events],
+                         [str(pack_query.pk), str(pack.pk)])
 
     def test_delete_pack(self):
         slug = get_random_string(12)

--- a/tests/osquery/test_events.py
+++ b/tests/osquery/test_events.py
@@ -2,10 +2,22 @@ from django.test import TestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit
 from zentral.contrib.osquery.events import (_filter_status_logs, _iter_grouped_status_logs,
-                                            OsqueryRequestEvent,
+                                            OsqueryPackUpdateEvent, OsqueryRequestEvent,
                                             STATUS_LOG_TRUNCATION_FILENAME,
                                             STATUS_LOG_TRUNCATION_SEVERITY)
+from zentral.core.events.base import EventMetadata
 from zentral.contrib.osquery.models import Configuration, EnrolledMachine, Enrollment
+
+
+class OsqueryPackUpdateEventTestCase(TestCase):
+    def test_report_links_the_pack(self):
+        event = OsqueryPackUpdateEvent(EventMetadata(), {"pack": {"pk": 42, "slug": "yolo"}, "result": "created"})
+        self.assertEqual(event.get_linked_objects_keys(), {"osquery_pack": [(42,)]})
+
+    def test_report_without_a_pack_links_nothing(self):
+        # a stored event from before the pack was added to the report
+        event = OsqueryPackUpdateEvent(EventMetadata(), {"result": "created"})
+        self.assertEqual(event.get_linked_objects_keys(), {})
 
 
 class OsqueryEventsTestCase(TestCase):

--- a/tests/osquery/test_setup_distributed_queries.py
+++ b/tests/osquery/test_setup_distributed_queries.py
@@ -122,7 +122,7 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["objects"],
-                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                         {"osquery_run": [str(distributed_query.pk)],
                           "osquery_query": [str(query.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
@@ -220,7 +220,7 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(halt_payload["object"]["new_value"]["valid_until"],
                          distributed_query.valid_until.isoformat())
         self.assertEqual(halt_metadata["objects"],
-                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                         {"osquery_run": [str(distributed_query.pk)],
                           "osquery_query": [str(distributed_query.query.pk)]})
         assert_audit_event(self, post_event, "created", distributed_query2, call_index=1)
 
@@ -269,7 +269,7 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertIsNone(payload["object"]["prev_value"]["valid_until"])
         self.assertEqual(payload["object"]["new_value"]["valid_until"], "2021-02-18T20:55:00")
         self.assertEqual(metadata["objects"],
-                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                         {"osquery_run": [str(distributed_query.pk)],
                           "osquery_query": [str(distributed_query.query.pk)]})
 
     def test_update_distributed_query_valid_until_less_than_valid_from(self):
@@ -364,7 +364,7 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertNotIn(distributed_query, response.context["distributed_queries"])
         _, metadata = assert_audit_event(self, post_event, "deleted", distributed_query, prev_value=prev_value)
         self.assertEqual(metadata["objects"],
-                         {"osquery_distributed_query": [str(distributed_query.pk)],
+                         {"osquery_run": [str(distributed_query.pk)],
                           "osquery_query": [str(distributed_query.query.pk)]})
 
     # distributed query machines

--- a/tests/osquery/test_setup_distributed_queries.py
+++ b/tests/osquery/test_setup_distributed_queries.py
@@ -351,6 +351,23 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.context["object"], distributed_query)
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_distributed_query_without_query_post(self, post_event):
+        # a run outlives the query it was launched from
+        distributed_query = self._force_distributed_query()
+        distributed_query.query.delete()
+        distributed_query.refresh_from_db()
+        self.assertIsNone(distributed_query.query)
+        prev_value = distributed_query.serialize_for_event()
+        self.assertIsNone(prev_value["query"])
+        self.login("osquery.delete_distributedquery", "osquery.view_distributedquery")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("osquery:delete_distributed_query", args=(distributed_query.pk,)),
+                                        follow=True)
+        self.assertEqual(response.status_code, 200)
+        _, metadata = assert_audit_event(self, post_event, "deleted", distributed_query, prev_value=prev_value)
+        self.assertEqual(metadata["objects"], {"osquery_run": [str(distributed_query.pk)]})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_delete_distributed_query_post(self, post_event):
         distributed_query = self._force_distributed_query()
         prev_value = distributed_query.serialize_for_event()

--- a/tests/osquery/test_setup_packs.py
+++ b/tests/osquery/test_setup_packs.py
@@ -11,6 +11,7 @@ from tests.zentral_test_utils.login_case import LoginCase
 from django.utils.text import slugify
 from zentral.contrib.osquery.compliance_checks import sync_query_compliance_check
 from zentral.contrib.osquery.models import Pack, PackQuery, Query
+from zentral.contrib.osquery.events import OsqueryPackUpdateEvent
 from zentral.core.events.base import AuditEvent
 
 
@@ -171,7 +172,8 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "osquery/pack_upload.html")
 
-    def test_upload_yaml_pack_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_upload_yaml_pack_post(self, post_event):
         pack = self._force_pack()
         self.login("osquery.change_pack", "osquery.view_pack", "osquery.view_packquery")
         pack_file = BytesIO(
@@ -189,10 +191,11 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
             "    value: Artifact used by this malware - 🔥\n".encode("utf-8")
         )
         pack_file.name = get_random_string(12)
-        response = self.client.post(reverse("osquery:upload_pack", args=(pack.pk,)),
-                                    {"file": pack_file,
-                                     "update_and_create_only": "on"},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("osquery:upload_pack", args=(pack.pk,)),
+                                        {"file": pack_file,
+                                         "update_and_create_only": "on"},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "osquery/pack_detail.html")
         self.assertContains(response, "WireLurker")
@@ -201,6 +204,12 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertEqual(pack.packquery_set.count(), 1)
         query = pack.packquery_set.first().query
         self.assertEqual(query.name, f"{pack.slug}/WireLurker")
+        # an upload publishes the same events as the API import
+        report, *audit_events = [c.args[0] for c in post_event.call_args_list]
+        self.assertIsInstance(report, OsqueryPackUpdateEvent)
+        self.assertEqual([e.payload["object"]["model"] for e in audit_events],
+                         ["osquery.query", "osquery.packquery"])
+        self.assertTrue(all(e.metadata.uuid == report.metadata.uuid for e in audit_events))
 
     def test_upload_bad_file(self):
         pack = self._force_pack()
@@ -374,7 +383,10 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         payload, metadata = assert_audit_event(self, post_event, "created", pack_query)
         self.assertEqual(payload["object"]["new_value"]["interval"], 3456)
         self.assertEqual(payload["object"]["new_value"]["pack"], {"pk": pack.pk, "slug": pack.slug})
-        self.assertEqual(metadata["objects"], {"osquery_pack_query": [str(pack_query.pk)]})
+        self.assertEqual(metadata["objects"],
+                         {"osquery_pack_query": [str(pack_query.pk)],
+                          "osquery_pack": [str(pack_query.pack_id)],
+                          "osquery_query": [str(pack_query.query_id)]})
 
     def test_add_pack_query_with_slug_conflict(self):
         query_name = get_random_string(16)
@@ -475,7 +487,10 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         pack_query.refresh_from_db()
         payload, metadata = assert_audit_event(self, post_event, "updated", pack_query, prev_value=prev_value)
         self.assertEqual(payload["object"]["new_value"]["interval"], 12345)
-        self.assertEqual(metadata["objects"], {"osquery_pack_query": [str(pack_query.pk)]})
+        self.assertEqual(metadata["objects"],
+                         {"osquery_pack_query": [str(pack_query.pk)],
+                          "osquery_pack": [str(pack_query.pack_id)],
+                          "osquery_query": [str(pack_query.query_id)]})
 
     def test_update_pack_query_with_compliance_check(self):
         query = self._force_query(force_pack=True, force_compliance_check=True)
@@ -531,4 +546,7 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
         self.assertNotContains(response, query.name)
         self.assertNotContains(response, f"{pack_query.interval}s")
         _, metadata = assert_audit_event(self, post_event, "deleted", pack_query, prev_value=prev_value)
-        self.assertEqual(metadata["objects"], {"osquery_pack_query": [str(pack_query.pk)]})
+        self.assertEqual(metadata["objects"],
+                         {"osquery_pack_query": [str(pack_query.pk)],
+                          "osquery_pack": [str(pack_query.pack_id)],
+                          "osquery_query": [str(pack_query.query_id)]})

--- a/zentral/contrib/osquery/api_views.py
+++ b/zentral/contrib/osquery/api_views.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_yaml.parsers import YAMLParser
 from accounts.api_authentication import APITokenAuthentication
+from zentral.core.events.base import AuditEvent
 from zentral.utils.drf import (DjangoPermissionRequired, ListCreateAPIViewWithAudit,
                                MaxLimitOffsetPagination, RetrieveUpdateDestroyAPIViewWithAudit)
 from .events import post_osquery_pack_update_events
@@ -188,15 +189,13 @@ class PackView(APIView):
             return Response({"pack": {"slug": kwargs["slug"]}, "result": "absent"},
                             status=status.HTTP_404_NOT_FOUND)
 
-        # prepare the events
+        # the objects have to be read before they are deleted
+        audit_events = []
         pack_queries_deleted = 0
-        pack_query_update_events = []
         for pack_query in pack.packquery_set.select_related("pack", "query").all():
-            pack_query_update_events.append({
-                "pack_query": pack_query.serialize_for_event(),
-                "result": "deleted"
-            })
+            audit_events.append((pack_query, AuditEvent.Action.DELETED, pack_query.serialize_for_event()))
             pack_queries_deleted += 1
+        audit_events.append((pack, AuditEvent.Action.DELETED, pack.serialize_for_event()))
 
         pack_update_event = {
             "result": "deleted",
@@ -205,21 +204,19 @@ class PackView(APIView):
                 "deleted": pack_queries_deleted,
                 "present": 0,
                 "updated": 0
-            }
+            },
+            "pack": pack.serialize_for_event(keys_only=True),
         }
 
-        full_pack_update_event = pack_update_event.copy()
-        full_pack_update_event["pack"] = pack.serialize_for_event()
+        # the cascade only clears the primary key of the instance delete() is called on. the pack
+        # queries were read into their own instances, and keep theirs.
+        pack_pk = pack.pk
+        pack.delete()
+        pack.pk = pack_pk
 
         transaction.on_commit(
-            lambda: post_osquery_pack_update_events(request, full_pack_update_event, pack_query_update_events)
+            lambda: post_osquery_pack_update_events(request, pack_update_event, audit_events)
         )
-
-        # prepare the response
-        pack_update_event["pack"] = pack.serialize_for_event(keys_only=True)
-
-        # finally, delete the pack
-        pack.delete()
 
         return Response(pack_update_event)
 

--- a/zentral/contrib/osquery/events/__init__.py
+++ b/zentral/contrib/osquery/events/__init__.py
@@ -4,7 +4,8 @@ import uuid
 from zentral.contrib.osquery.compliance_checks import ComplianceCheckStatusAggregator
 from zentral.contrib.osquery.models import EnrolledMachine, PackQuery, QueryType, parse_result_name
 from zentral.contrib.osquery.tags import TagUpdateAggregator
-from zentral.core.events.base import BaseEvent, EventMetadata, EventRequest, register_event_type
+from zentral.core.events.base import (AuditEvent, BaseEvent, EventMetadata, EventRequest,
+                                      register_event_type)
 from zentral.utils.time import naive_utcfromtimestamp
 
 logger = logging.getLogger('zentral.contrib.osquery.events')
@@ -117,21 +118,27 @@ class OsqueryStatusEvent(OsqueryEvent):
 register_event_type(OsqueryStatusEvent)
 
 
-# Audit trail events
+# Pack import
 
 
 class OsqueryPackUpdateEvent(OsqueryEvent):
+    """The report of a pack import.
+
+    What each object became is in the zentral_audit events the import publishes beside this one.
+    This event answers the question they cannot: what the import as a whole did, including the
+    "present" result, which says that the import ran and changed nothing.
+    """
+
     event_type = "osquery_pack_update"
+
+    def get_linked_objects_keys(self):
+        pack_pk = self.payload.get("pack", {}).get("pk")
+        if pack_pk:
+            return {"osquery_pack": [(pack_pk,)]}
+        return {}
 
 
 register_event_type(OsqueryPackUpdateEvent)
-
-
-class OsqueryPackQueryUpdateEvent(OsqueryEvent):
-    event_type = "osquery_pack_query_update"
-
-
-register_event_type(OsqueryPackQueryUpdateEvent)
 
 
 class OsqueryCheckStatusUpdated(BaseEvent):
@@ -319,13 +326,18 @@ def post_results(msn, results, request):
 # Utility function for the audit trail
 
 
-def post_osquery_pack_update_events(request, pack_data, pack_queries_data):
+def post_osquery_pack_update_events(request, sync_report, audit_events):
+    """Publish the report of a pack import and the audit event of each object it changed.
+
+    They share one event UUID, and the report is the first of them, so that a reader can gather
+    the whole import from any one of its events.
+    """
     event_request = EventRequest.build_from_request(request)
-    pack_update_event_metadata = EventMetadata(request=event_request)
-    pack_update_event = OsqueryPackUpdateEvent(pack_update_event_metadata, pack_data)
-    pack_update_event.post()
-    for idx, pack_query_data in enumerate(pack_queries_data):
-        pack_query_update_event_metadata = EventMetadata(request=event_request,
-                                                         uuid=pack_update_event_metadata.uuid, index=idx + 1)
-        pack_query_update_event = OsqueryPackQueryUpdateEvent(pack_query_update_event_metadata, pack_query_data)
-        pack_query_update_event.post()
+    metadata = EventMetadata(request=event_request)
+    OsqueryPackUpdateEvent(metadata, sync_report).post()
+    for index, (instance, action, prev_value) in enumerate(audit_events, start=1):
+        AuditEvent.build(
+            instance, action, prev_value,
+            event_uuid=metadata.uuid, event_index=index,
+            event_request=event_request,
+        ).post()

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -333,7 +333,7 @@ class PackQuery(models.Model):
         d = {"pk": self.pk,
              "slug": self.slug,
              "pack": self.pack.serialize_for_event(keys_only=True),
-             "query": self.query.serialize_for_event(),
+             "query": self.query.serialize_for_event(keys_only=True),
              "interval": self.interval,
              "log_removed_actions": self.log_removed_actions,
              "snapshot_mode": self.snapshot_mode,
@@ -341,6 +341,10 @@ class PackQuery(models.Model):
         if self.shard and self.shard != 100:
             d["shard"] = self.shard
         return d
+
+    def linked_objects_keys_for_event(self):
+        return {"osquery_pack": ((self.pack_id,),),
+                "osquery_query": ((self.query_id,),)}
 
 
 class FileCategory(models.Model):

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -695,6 +695,9 @@ class DistributedQueryManager(models.Manager):
 
 
 class DistributedQuery(models.Model):
+    # the compliance check status events have always called a distributed query a run
+    linked_objects_key = "osquery_run"
+
     query = models.ForeignKey(Query, on_delete=models.SET_NULL, null=True, editable=False)
     query_version = models.IntegerField(editable=False)
     sql = models.TextField(editable=False)
@@ -785,10 +788,10 @@ class DistributedQuery(models.Model):
         return d
 
     def linked_objects_keys_for_event(self):
-        keys = {"osquery_distributed_query": ((self.pk,),)}
+        # the object itself is linked under linked_objects_key
         if self.query_id:
-            keys["osquery_query"] = ((self.query_id,),)
-        return keys
+            return {"osquery_query": ((self.query_id,),)}
+        return {}
 
 
 class DistributedQueryMachine(models.Model):

--- a/zentral/contrib/osquery/packs.py
+++ b/zentral/contrib/osquery/packs.py
@@ -6,6 +6,7 @@ from django.db.models import F
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import BaseParser
+from zentral.core.events.base import AuditEvent
 from .compliance_checks import sync_query_compliance_check
 from .events import post_osquery_pack_update_events
 from .models import Pack, PackQuery, Query
@@ -38,6 +39,10 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
     serializer = OsqueryPackSerializer(data=data)
     serializer.is_valid(raise_exception=True)
 
+    # (instance, action, prev_value) for each object the import changes. the events are built after
+    # the commit, so that the new value they carry is the state the whole import settled on.
+    audit_events = []
+
     if not pack:
         # create or update pack
         pack_defaults = serializer.get_pack_defaults(slug)
@@ -54,8 +59,12 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
     pack_update_event = {}
     if pack_created:
         pack_update_event["result"] = "created"
+        audit_events.append((pack, AuditEvent.Action.CREATED, None))
     else:
+        pack_prev_value = pack.serialize_for_event()
         pack_updated = False
+        # the response of the standard pack endpoint carries this difference, so it is still built
+        # here. the audit event of the pack carries the whole value before and after instead.
         pack_updates = {}
         for attr, new_val in pack_defaults.items():
             old_val = getattr(pack, attr)
@@ -70,12 +79,12 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
             pack.save()
             pack_update_event["result"] = "updated"
             pack_update_event["updates"] = pack_updates
+            audit_events.append((pack, AuditEvent.Action.UPDATED, pack_prev_value))
         else:
             pack_update_event["result"] = "present"
 
     # create update or delete pack queries
     pack_queries_created = pack_queries_deleted = pack_queries_present = pack_queries_updated = 0
-    pack_query_update_events = []
     found_query_slugs = []
     for query_slug, pack_query_defaults, query_defaults in serializer.iter_query_defaults(slug):
         found_query_slugs.append(query_slug)
@@ -86,14 +95,16 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
             # update or create query
             query_name = query_defaults.pop("name")
             query, query_created = Query.objects.get_or_create(name=query_name, defaults=query_defaults)
+            query_prev_value = None
+            query_updated = False
             if not query_created:
-                query_updated = False
+                query_prev_value = query.serialize_for_event()
                 query_sql_updated = False
                 for attr, new_val in query_defaults.items():
-                    query_updated = True
                     old_val = getattr(query, attr)
                     if old_val != new_val:
                         setattr(query, attr, new_val)
+                        query_updated = True
                         if attr == "sql":
                             query_sql_updated = True
                             query.version = F("version") + 1
@@ -103,27 +114,25 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
                         query.refresh_from_db()
 
             # create, update or delete compliance check
-            sync_query_compliance_check(query, compliance_check)
+            cc_created, cc_updated, cc_deleted = sync_query_compliance_check(query, compliance_check)
+
+            if query_created:
+                audit_events.append((query, AuditEvent.Action.CREATED, None))
+            elif query_updated or cc_created or cc_updated or cc_deleted:
+                audit_events.append((query, AuditEvent.Action.UPDATED, query_prev_value))
 
             # create pack query
             pack_query = PackQuery.objects.create(pack=pack, query=query, **pack_query_defaults)
             pack_queries_created += 1
-            pack_query_update_events.append({
-                "pack_query": pack_query.serialize_for_event(),
-                "result": "created"
-            })
+            audit_events.append((pack_query, AuditEvent.Action.CREATED, None))
             continue
 
         # update pack query
+        pack_query_prev_value = pack_query.serialize_for_event()
         pack_query_updated = False
-        pack_query_updates = {}
         for attr, new_val in pack_query_defaults.items():
             old_val = getattr(pack_query, attr)
             if old_val != new_val:
-                if old_val:
-                    pack_query_updates.setdefault("removed", {})[attr] = old_val
-                if new_val:
-                    pack_query_updates.setdefault("added", {})[attr] = new_val
                 setattr(pack_query, attr, new_val)
                 pack_query_updated = True
         if pack_query_updated:
@@ -131,23 +140,17 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
 
         # update query
         query = pack_query.query
+        query_prev_value = query.serialize_for_event()
         query_updated = False
         query_sql_updated = False
         for attr, new_val in query_defaults.items():
             old_val = getattr(query, attr)
             if old_val != new_val:
-                reported_attr = attr
+                setattr(query, attr, new_val)
+                query_updated = True
                 if attr == "sql":
                     query_sql_updated = True
-                    reported_attr = "query"
-                if old_val:
-                    pack_query_updates.setdefault("removed", {})[reported_attr] = old_val
-                if new_val:
-                    pack_query_updates.setdefault("added", {})[reported_attr] = new_val
-                setattr(query, attr, new_val)
-                if query_sql_updated:
                     query.version = F("version") + 1
-                query_updated = True
         if query_updated:
             query.save()
             if query_sql_updated:
@@ -156,24 +159,24 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
         # create, update or delete compliance check
         cc_created, cc_updated, cc_deleted = sync_query_compliance_check(query, compliance_check)
 
+        if query_updated or cc_created or cc_updated or cc_deleted:
+            audit_events.append((query, AuditEvent.Action.UPDATED, query_prev_value))
+        if pack_query_updated:
+            audit_events.append((pack_query, AuditEvent.Action.UPDATED, pack_query_prev_value))
+
         if pack_query_updated or query_updated or cc_created or cc_updated or cc_deleted:
             pack_queries_updated += 1
-            pack_query_update_events.append({
-                "pack_query": pack_query.serialize_for_event(),
-                "result": "updated",
-                "updates": pack_query_updates
-            })
         else:
             pack_queries_present += 1
 
     # delete extra pack queries
     if delete_extra_queries:
         for pack_query in pack.packquery_set.select_related("pack", "query").exclude(slug__in=found_query_slugs):
-            pack_query_update_events.append({
-                "pack_query": pack_query.serialize_for_event(),
-                "result": "deleted"
-            })
+            pack_query_prev_value = pack_query.serialize_for_event()
+            pack_query_pk = pack_query.pk
             pack_query.delete()
+            pack_query.pk = pack_query_pk  # re-hydrate the primary key for the event
+            audit_events.append((pack_query, AuditEvent.Action.DELETED, pack_query_prev_value))
             pack_queries_deleted += 1
 
     pack_update_event["query_results"] = {
@@ -182,13 +185,13 @@ def update_or_create_pack(request, data, slug=None, pack=None, delete_extra_quer
         "present": pack_queries_present,
         "updated": pack_queries_updated
     }
+    pack_update_event["pack"] = pack.serialize_for_event(keys_only=True)
 
-    full_pack_update_event = pack_update_event.copy()
-    full_pack_update_event["pack"] = pack.serialize_for_event()
-
+    # the difference stays in the response, and comes out of the event: the audit event of the pack
+    # carries the value before and after, which says more
+    sync_report = {k: v for k, v in pack_update_event.items() if k != "updates"}
     transaction.on_commit(
-        lambda: post_osquery_pack_update_events(request, full_pack_update_event, pack_query_update_events)
+        lambda: post_osquery_pack_update_events(request, sync_report, audit_events)
     )
 
-    pack_update_event["pack"] = pack.serialize_for_event(keys_only=True)
     return pack_update_event


### PR DESCRIPTION
An import of a standard pack changes a pack, its pack queries, the queries they schedule and their compliance checks, in one request. It reported that with two event types of its own, written two years before `AuditEvent` existed, under a comment that called them the audit trail.

This is the third of four changes. The models, the management views and the API views came first. The missing endpoint for the runs comes last.

## The two events did two jobs

**A job only they can do.** The report of the import: the result as a whole, including `present`, which says that the import ran and changed nothing, and the counts of the pack queries created, updated, deleted and left alone. `AuditEvent` has no action for a change that did not happen, and it describes one object at a time.

**A job `AuditEvent` does better.** The record of each object. The removed events carried a partial difference instead of the two values, they never declared their linked objects, so they did not reach the page of the object they reported, and `osquery_pack_query_update` reported a pack query and the query it schedules together, with the SQL of the query under a `query` key.

So the report keeps the first job, and audit events take the second. `osquery_pack_query_update` is removed. An import publishes one report and one audit event per changed object, under one event UUID, the report first, so a reader can gather the whole import from any one of its events.

The upload in the web console goes through the same code, so it publishes the same events. It was the last way to change a pack with no audit trail.

## The response does not change

`PUT /api/osquery/packs/<slug>/` still answers with `result`, `query_results`, `pack` and `updates`. `updates` comes out of the *event* only — the audit event of the pack carries the whole value before and after, which says more.

## A write that should not have happened

The import adopts a query that already exists when a pack query is missing. It saved that query whatever the file said, because the flag that recorded the change was set before the comparison and not inside it:

```python
for attr, new_val in query_defaults.items():
    query_updated = True          # before the comparison
    old_val = getattr(query, attr)
    if old_val != new_val:
        ...
```

That write was invisible. As an audit event it is a change whose value before and after are the same, published on every import. `test_import_pack_adopting_an_unchanged_query_does_not_report_a_change` covers it, and fails when the flag is put back where it was.

## One more thing

The first commit fixes a defect from [#1642](https://github.com/zentralopensource/zentral/pull/1642). The compliance check status events have always linked a distributed query under `osquery_run`. The audit events of the runs used `osquery_distributed_query`, the key built from the verbose name, so the two halves of the history of a run never met. The model declares `linked_objects_key` now — the attribute added in [#1643](https://github.com/zentralopensource/zentral/pull/1643) for exactly this. `osquery_run` wins because it is the older key, because the web console calls these objects runs, and because no released version wrote the other one.

Tell me if you want that commit in its own pull request.

## Tests

7994 tests pass. Patch coverage is 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
