### PR TITLE
Publish audit events from the Monolith API views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ A sub manifest package can use more than one key, one time for each key, and eac
 
 Zentral adds a `default_installs` package to the `optional_installs` of the sub manifest, because munki installs it only if it is an optional install too. If the sub manifest has its own `optional_installs` package with the same name and the same condition, Zentral keeps that one, with its own scope.
 
+The Monolith API publishes the same `zentral_audit` events as the web console now. The catalogs, the conditions, the enrollments and the manifest enrollment packages changed with no record of it.
+
 
 #### Osquery
 
@@ -66,6 +68,10 @@ The list endpoints of the Osquery API answer with a page and not with an array. 
 
 The `version` attribute of an Osquery query in an event payload is the version of the query again. It was the minimum Osquery version of the query, which replaced the query version when the query had one. The minimum Osquery version has its own `minimum_osquery_version` attribute now. The query payload also has the `pk`, `name` and `tag` attributes, and the compliance check of the query. This payload is a part of the `osquery_pack_query_update` events.
 
+
+#### 🧨 PATCH on the Monolith API
+
+`PATCH` gives a `405 Method Not Allowed` on the Monolith catalog, condition, enrollment and manifest enrollment package endpoints. Use `PUT`, and send all the attributes of the object.
 
 #### 🧨 Santa enrolled machines metrics
 

--- a/tests/monolith/test_api_views.py
+++ b/tests/monolith/test_api_views.py
@@ -32,10 +32,12 @@ from zentral.utils.time import naive_utcnow
 
 from .utils import (
     CLOUDFRONT_PRIVKEY_PEM,
+    assert_audit_event,
     force_catalog,
     force_condition,
     force_enrollment,
     force_manifest,
+    force_manifest_enrollment_package,
     force_name,
     force_pkg_info,
     force_repository,
@@ -1225,15 +1227,17 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             'repository': ['Not a virtual repository.'],
         })
 
-    def test_create_catalog(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_catalog(self, post_event):
         self.set_permissions("monolith.add_catalog")
         name = get_random_string(12)
         repository = force_repository(virtual=True)
-        response = self.post(reverse("monolith_api:catalogs"), data={
-            'repository': repository.pk,
-            'name': name,
-            'archived_at': naive_utcnow().isoformat(),
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("monolith_api:catalogs"), data={
+                'repository': repository.pk,
+                'name': name,
+                'archived_at': naive_utcnow().isoformat(),
+            })
         self.assertEqual(response.status_code, 201)
         catalog = Catalog.objects.get(name=name)
         self.assertEqual(response.json(), {
@@ -1246,6 +1250,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         })
         self.assertEqual(catalog.repository, repository)
         self.assertEqual(catalog.name, name)
+        assert_audit_event(self, post_event, "created", catalog)
 
     # update catalog
 
@@ -1308,15 +1313,18 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
              ]}
         )
 
-    def test_update_catalog(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_catalog(self, post_event):
         repository = force_repository(virtual=True)
         catalog = force_catalog(repository=repository)
+        prev_value = catalog.serialize_for_event()
         self.set_permissions("monolith.change_catalog")
         new_name = get_random_string(12)
-        response = self.put(reverse("monolith_api:catalog", args=(catalog.pk,)), data={
-            'repository': catalog.repository.pk,
-            'name': new_name,
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse("monolith_api:catalog", args=(catalog.pk,)), data={
+                'repository': catalog.repository.pk,
+                'name': new_name,
+            })
         self.assertEqual(response.status_code, 200)
         catalog.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -1328,6 +1336,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             'archived_at': None
         })
         self.assertEqual(catalog.name, new_name)
+        assert_audit_event(self, post_event, "updated", catalog, prev_value=prev_value)
 
     # delete catalog
 
@@ -1353,12 +1362,48 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), ['This catalog cannot be deleted'])
 
-    def test_delete_catalog(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_catalog(self, post_event):
         repository = force_repository(virtual=True)
         catalog = force_catalog(repository=repository)
+        prev_value = catalog.serialize_for_event()
         self.set_permissions("monolith.delete_catalog")
-        response = self.delete(reverse("monolith_api:catalog", args=(catalog.pk,)))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(reverse("monolith_api:catalog", args=(catalog.pk,)))
         self.assertEqual(response.status_code, 204)
+        assert_audit_event(self, post_event, "deleted", catalog, prev_value=prev_value)
+
+    # http methods
+
+    def test_patch_is_not_allowed(self):
+        """Zentral only does full updates.
+
+        A partial update leaves a declared field out of validated_data, and the serializers read
+        those fields directly: the monolith EnrollmentSerializer reads data["manifest"] and
+        data["secret"] in validate().
+        """
+        self.set_permissions(
+            "monolith.change_catalog",
+            "monolith.change_condition",
+            "monolith.change_enrollment",
+            "monolith.change_manifestenrollmentpackage",
+        )
+        enrollment, _ = force_enrollment(mbu=self.mbu)
+        targets = (
+            ("catalog", force_catalog()),
+            ("condition", force_condition()),
+            ("enrollment", enrollment),
+            ("manifest_enrollment_package", force_manifest_enrollment_package()),
+        )
+        for url_name, obj in targets:
+            with self.subTest(url_name):
+                response = self.client.patch(
+                    reverse(f"monolith_api:{url_name}", args=(obj.pk,)),
+                    data="{}",
+                    content_type="application/json",
+                    HTTP_AUTHORIZATION=f"Token {self._get_api_key()}",
+                )
+                self.assertEqual(response.status_code, 405)
 
     # list conditions
 
@@ -1450,14 +1495,16 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             'predicate': ['This field is required.'],
         })
 
-    def test_create_condition(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_condition(self, post_event):
         self.set_permissions("monolith.add_condition")
         name = get_random_string(12)
         predicate = get_random_string(12)
-        response = self.post(reverse("monolith_api:conditions"), data={
-            'name': name,
-            'predicate': predicate,
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("monolith_api:conditions"), data={
+                'name': name,
+                'predicate': predicate,
+            })
         self.assertEqual(response.status_code, 201)
         condition = Condition.objects.get(name=name)
         self.assertEqual(response.json(), {
@@ -1468,6 +1515,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             'updated_at': condition.updated_at.isoformat(),
         })
         self.assertEqual(condition.predicate, predicate)
+        assert_audit_event(self, post_event, "created", condition)
 
     def test_create_condition_name_conflict(self):
         condition = force_condition()
@@ -1507,8 +1555,10 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             'predicate': ['This field may not be blank.'],
         })
 
-    def test_update_condition(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_condition(self, post_event):
         condition = force_condition()
+        prev_value = condition.serialize_for_event()
         manifest = force_manifest()
         sub_manifest = force_sub_manifest(manifest=manifest)
         self.assertEqual(manifest.version, 1)
@@ -1520,10 +1570,11 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.set_permissions("monolith.change_condition")
         new_name = get_random_string(12)
         new_predicate = get_random_string(12)
-        response = self.put(reverse("monolith_api:condition", args=(condition.pk,)), data={
-            'name': new_name,
-            'predicate': new_predicate,
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse("monolith_api:condition", args=(condition.pk,)), data={
+                'name': new_name,
+                'predicate': new_predicate,
+            })
         self.assertEqual(response.status_code, 200)
         condition.refresh_from_db()
         self.assertEqual(response.json(), {
@@ -1537,6 +1588,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(condition.predicate, new_predicate)
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
+        assert_audit_event(self, post_event, "updated", condition, prev_value=prev_value)
 
     def test_update_condition_name_conflict(self):
         condition1 = force_condition()
@@ -1576,11 +1628,15 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), ['This condition cannot be deleted'])
 
-    def test_delete_condition(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_condition(self, post_event):
         condition = force_condition()
+        prev_value = condition.serialize_for_event()
         self.set_permissions("monolith.delete_condition")
-        response = self.delete(reverse("monolith_api:condition", args=(condition.pk,)))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(reverse("monolith_api:condition", args=(condition.pk,)))
         self.assertEqual(response.status_code, 204)
+        assert_audit_event(self, post_event, "deleted", condition, prev_value=prev_value)
 
     # list enrollments
 
@@ -1738,18 +1794,20 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             'secret': ['This field is required.'],
         })
 
-    def test_create_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrollment(self, post_event):
         self.set_permissions("monolith.add_enrollment")
         manifest = force_manifest(mbu=self.mbu)
         self.assertEqual(manifest.version, 1)
         tags = [Tag.objects.create(name=get_random_string(12)) for _ in range(1)]
-        response = self.post(reverse("monolith_api:enrollments"), data={
-            'manifest': manifest.pk,
-            'secret': {
-                'meta_business_unit': self.mbu.pk,
-                'tags': [t.id for t in tags]
-            }
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("monolith_api:enrollments"), data={
+                'manifest': manifest.pk,
+                'secret': {
+                    'meta_business_unit': self.mbu.pk,
+                    'tags': [t.id for t in tags]
+                }
+            })
         self.assertEqual(response.status_code, 201)
         enrollment = Enrollment.objects.get(manifest=manifest)
         self.assertEqual(response.json(), {
@@ -1780,6 +1838,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         })
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
+        assert_audit_event(self, post_event, "created", enrollment)
 
     def test_create_enrollment_mbu_conflict(self):
         self.set_permissions("monolith.add_enrollment")
@@ -1810,8 +1869,10 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.put(reverse("monolith_api:enrollment", args=(9999,)), data={})
         self.assertEqual(response.status_code, 404)
 
-    def test_update_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_enrollment(self, post_event):
         enrollment, _ = force_enrollment(mbu=self.mbu, tag_count=2)
+        prev_value = enrollment.serialize_for_event()
         enrollment_secret = enrollment.secret
         self.assertEqual(enrollment.secret.quota, None)
         self.assertEqual(enrollment.secret.serial_numbers, None)
@@ -1827,10 +1888,11 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         tags = [Tag.objects.create(name=get_random_string(12)) for _ in range(2)]
         secret_data["tags"] = [t.id for t in tags]
         self.set_permissions("monolith.change_enrollment")
-        response = self.put(reverse("monolith_api:enrollment", args=(enrollment.pk,)), data={
-            'manifest': enrollment.manifest.pk,
-            'secret': secret_data
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse("monolith_api:enrollment", args=(enrollment.pk,)), data={
+                'manifest': enrollment.manifest.pk,
+                'secret': secret_data
+            })
         self.assertEqual(response.status_code, 200)
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.secret, enrollment_secret)
@@ -1843,6 +1905,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         )
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
+        assert_audit_event(self, post_event, "updated", enrollment, prev_value=prev_value)
 
     # delete enrollment
 
@@ -1859,15 +1922,19 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.delete(reverse("monolith_api:enrollment", args=(9999,)))
         self.assertEqual(response.status_code, 404)
 
-    def test_delete_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_enrollment(self, post_event):
         enrollment, _ = force_enrollment(mbu=self.mbu)
+        prev_value = enrollment.serialize_for_event()
         manifest = enrollment.manifest
         self.assertEqual(manifest.version, 1)
         self.set_permissions("monolith.delete_enrollment")
-        response = self.delete(reverse("monolith_api:enrollment", args=(enrollment.pk,)))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(reverse("monolith_api:enrollment", args=(enrollment.pk,)))
         self.assertEqual(response.status_code, 204)
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
+        assert_audit_event(self, post_event, "deleted", enrollment, prev_value=prev_value)
 
     # enrollment plist
 

--- a/tests/monolith/test_monolith_enrollment_package_api_views.py
+++ b/tests/monolith/test_monolith_enrollment_package_api_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
@@ -10,7 +12,7 @@ from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import Tag
 from zentral.contrib.monolith.models import ManifestEnrollmentPackage
 from zentral.contrib.munki.models import Enrollment as MunkiEnrollment
-from .utils import force_manifest, force_manifest_enrollment_package
+from .utils import assert_audit_event, force_manifest, force_manifest_enrollment_package
 
 
 class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
@@ -240,18 +242,20 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {'enrollment_pk': ['This enrollment already has a distributor']})
 
-    def test_create_manifest_enrollment_package(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_manifest_enrollment_package(self, post_event):
         self.set_permissions("monolith.add_manifestenrollmentpackage")
         manifest = force_manifest()
         self.assertEqual(manifest.version, 1)
         enrollment = force_munki_enrollment(meta_business_unit=manifest.meta_business_unit)
         tag = Tag.objects.create(name=get_random_string(12))
-        response = self.post(reverse("monolith_api:manifest_enrollment_packages"), data={
-            'manifest': manifest.pk,
-            'builder': 'zentral.contrib.munki.osx_package.builder.MunkiZentralEnrollPkgBuilder',
-            'enrollment_pk': enrollment.pk,
-            'tags': [tag.pk],
-        })
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("monolith_api:manifest_enrollment_packages"), data={
+                'manifest': manifest.pk,
+                'builder': 'zentral.contrib.munki.osx_package.builder.MunkiZentralEnrollPkgBuilder',
+                'enrollment_pk': enrollment.pk,
+                'tags': [tag.pk],
+            })
         self.assertEqual(response.status_code, 201)
         mep = ManifestEnrollmentPackage.objects.get(
             manifest=manifest,
@@ -271,6 +275,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(list(t.pk for t in mep.tags.all()), [tag.pk])
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
+        assert_audit_event(self, post_event, "created", mep)
 
     # update manifest enrollment package
 
@@ -288,24 +293,27 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.put(reverse("monolith_api:manifest_enrollment_package", args=(9999,)), data={})
         self.assertEqual(response.status_code, 404)
 
-    def test_update_manifest_enrollment_package(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_manifest_enrollment_package(self, post_event):
         tags = [Tag.objects.create(name=get_random_string(12))]
         mep = force_manifest_enrollment_package(tags=tags)
+        prev_value = mep.serialize_for_event()
         self.assertEqual(mep.tags.count(), 1)
         self.assertEqual(mep.version, 1)
         manifest = mep.manifest
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
         self.set_permissions("monolith.change_manifestenrollmentpackage")
-        response = self.put(
-            reverse("monolith_api:manifest_enrollment_package", args=(mep.pk,)),
-            data={
-                'manifest': manifest.pk,
-                'builder': mep.builder,
-                'enrollment_pk': mep.enrollment_pk,
-                'tags': [],
-            }
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(
+                reverse("monolith_api:manifest_enrollment_package", args=(mep.pk,)),
+                data={
+                    'manifest': manifest.pk,
+                    'builder': mep.builder,
+                    'enrollment_pk': mep.enrollment_pk,
+                    'tags': [],
+                }
+            )
         self.assertEqual(response.status_code, 200)
         test_mep = ManifestEnrollmentPackage.objects.get(
             manifest=manifest,
@@ -326,6 +334,7 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(test_mep.tags.count(), 0)
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 3)
+        assert_audit_event(self, post_event, "updated", test_mep, prev_value=prev_value)
 
     def test_update_manifest_enrollment_package_update_enrollment(self):
         mep = force_manifest_enrollment_package()
@@ -385,15 +394,20 @@ class MonolithAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.delete(reverse("monolith_api:manifest_enrollment_package", args=(9999,)))
         self.assertEqual(response.status_code, 404)
 
-    def test_delete_manifest_enrollment_package(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_manifest_enrollment_package(self, post_event):
         mep = force_manifest_enrollment_package()
+        prev_value = mep.serialize_for_event()
         enrollment = mep.get_enrollment()
         manifest = mep.manifest
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 2)
         self.set_permissions("monolith.delete_manifestenrollmentpackage")
-        response = self.delete(reverse("monolith_api:manifest_enrollment_package", args=(mep.pk,)))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(reverse("monolith_api:manifest_enrollment_package", args=(mep.pk,)))
         self.assertEqual(response.status_code, 204)
         manifest.refresh_from_db()
         self.assertEqual(manifest.version, 3)
+        # the API takes an enrollment it did not create, so the delete releases it
         self.assertTrue(MunkiEnrollment.objects.filter(pk=enrollment.pk).exists())
+        assert_audit_event(self, post_event, "deleted", mep, prev_value=prev_value)

--- a/tests/monolith/utils.py
+++ b/tests/monolith/utils.py
@@ -1,5 +1,7 @@
 from django.utils.crypto import get_random_string
 
+from zentral.core.events.base import AuditEvent
+
 from tests.munki.utils import force_enrollment as force_munki_enrollment
 from tests.osquery.utils import force_enrollment as force_osquery_enrollment
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit, Tag
@@ -243,3 +245,21 @@ def force_manifest_enrollment_package(manifest=None, tags=None, module="munki", 
         for required_pkg_name in mep.get_requires():
             _force_pkg_info(name=required_pkg_name, catalog=catalog)
     return mep
+
+
+def assert_audit_event(test_case, post_event, action, instance, prev_value=None, call_index=0):
+    """Check the audit event at call_index, and give its payload back for more assertions."""
+    test_case.maxDiff = None
+    event = post_event.call_args_list[call_index].args[0]
+    test_case.assertIsInstance(event, AuditEvent)
+    expected = {"action": action,
+                "object": {"model": instance._meta.label_lower,
+                           "pk": str(instance.pk)}}
+    if action in ("created", "updated"):
+        expected["object"]["new_value"] = instance.serialize_for_event()
+    if prev_value is not None:
+        expected["object"]["prev_value"] = prev_value
+    test_case.assertEqual(event.payload, expected)
+    metadata = event.metadata.serialize()
+    test_case.assertEqual(sorted(metadata["tags"]), ["monolith", "zentral"])
+    return event.payload, metadata

--- a/tests/utils/test_audit_views.py
+++ b/tests/utils/test_audit_views.py
@@ -26,3 +26,20 @@ class AuditViewHookTestCase(SimpleTestCase):
                 return "0123456789"
 
         self.assertEqual(MachineScopedView().get_audit_machine_serial_number(), "0123456789")
+
+
+class PerformDestroyKwargsTestCase(SimpleTestCase):
+    """get_perform_destroy_kwargs() has to default to an empty dict, so that the views that delete
+    their object with no argument — every one of them but the Monolith manifest enrollment
+    packages — keep working untouched."""
+
+    def test_the_default_is_empty(self):
+        self.assertEqual(RetrieveUpdateDestroyAPIViewWithAudit().get_perform_destroy_kwargs(), {})
+
+    def test_an_override_is_picked_up(self):
+        class KeepTheEnrollmentView(RetrieveUpdateDestroyAPIViewWithAudit):
+            def get_perform_destroy_kwargs(self):
+                return {"delete_enrollment": False}
+
+        self.assertEqual(KeepTheEnrollmentView().get_perform_destroy_kwargs(),
+                         {"delete_enrollment": False})

--- a/zentral/contrib/monolith/api_views.py
+++ b/zentral/contrib/monolith/api_views.py
@@ -139,19 +139,16 @@ class RepositoryDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # catalogs
 
 
-class CatalogList(generics.ListCreateAPIView):
+class CatalogList(ListCreateAPIViewWithAudit):
     queryset = Catalog.objects.all()
     serializer_class = CatalogSerializer
-    permission_classes = (DefaultDjangoModelPermissions,)
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name', 'repository')
     pagination_class = MaxLimitOffsetPagination
 
 
-class CatalogDetail(generics.RetrieveUpdateDestroyAPIView):
+class CatalogDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = Catalog.objects.all()
     serializer_class = CatalogSerializer
-    permission_classes = (DefaultDjangoModelPermissions,)
 
     def perform_destroy(self, instance):
         if not instance.can_be_deleted():
@@ -162,18 +159,15 @@ class CatalogDetail(generics.RetrieveUpdateDestroyAPIView):
 # conditions
 
 
-class ConditionList(generics.ListCreateAPIView):
+class ConditionList(ListCreateAPIViewWithAudit):
     queryset = Condition.objects.all()
     serializer_class = ConditionSerializer
-    permission_classes = (DefaultDjangoModelPermissions,)
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('name',)
 
 
-class ConditionDetail(generics.RetrieveUpdateDestroyAPIView):
+class ConditionDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = Condition.objects.all()
     serializer_class = ConditionSerializer
-    permission_classes = (DefaultDjangoModelPermissions,)
 
     def perform_destroy(self, instance):
         if not instance.can_be_deleted():
@@ -184,23 +178,20 @@ class ConditionDetail(generics.RetrieveUpdateDestroyAPIView):
 # enrollments
 
 
-class EnrollmentList(generics.ListCreateAPIView):
+class EnrollmentList(ListCreateAPIViewWithAudit):
     """
     List all Enrollments or create a new Enrollment
     """
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('manifest_id',)
 
 
-class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
+class EnrollmentDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, update or delete an Enrollment
     """
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
 
     def perform_destroy(self, instance):
@@ -292,22 +283,23 @@ class ManifestCatalogDetail(RetrieveUpdateDestroyAPIViewWithAudit):
         return response
 
 
-class ManifestEnrollmentPackageList(generics.ListCreateAPIView):
+class ManifestEnrollmentPackageList(ListCreateAPIViewWithAudit):
     queryset = ManifestEnrollmentPackage.objects.all()
     serializer_class = ManifestEnrollmentPackageSerializer
-    permission_classes = [DefaultDjangoModelPermissions]
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("manifest_id", "builder")
 
 
-class ManifestEnrollmentPackageDetail(generics.RetrieveUpdateDestroyAPIView):
+class ManifestEnrollmentPackageDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = ManifestEnrollmentPackage.objects.all()
     serializer_class = ManifestEnrollmentPackageSerializer
-    permission_classes = [DefaultDjangoModelPermissions]
+
+    def get_perform_destroy_kwargs(self):
+        # the API takes an enrollment it did not create, so it releases it instead of deleting it
+        return {"delete_enrollment": False}
 
     def perform_destroy(self, instance):
         manifest = instance.manifest
-        instance.delete(delete_enrollment=False)
+        super().perform_destroy(instance)
         manifest.bump_version()
 
 

--- a/zentral/utils/drf.py
+++ b/zentral/utils/drf.py
@@ -133,10 +133,19 @@ class RetrieveUpdateDestroyAPIViewWithAudit(RetrieveUpdateAPIViewWithAudit,
                                             generics.RetrieveUpdateDestroyAPIView):
     http_method_names = RetrieveUpdateAPIViewWithAudit.http_method_names + ["delete"]
 
+    def get_perform_destroy_kwargs(self):
+        """The keyword arguments for the delete() of the object.
+
+        DestroyModelMixin calls delete() with no argument. A model that accepts an argument to keep
+        an object it did not create — the Monolith manifest enrollment packages and their
+        enrollments — needs the audit event and that argument at the same time.
+        """
+        return {}
+
     def perform_destroy(self, instance):
         prev_pk = instance.pk
         prev_value = instance.serialize_for_event()
-        super().perform_destroy(instance)
+        instance.delete(**self.get_perform_destroy_kwargs())
 
         def on_commit_callback():
             instance.pk = prev_pk  # re-hydrate the primary key


### PR DESCRIPTION
The Monolith API changed a catalog, a condition, an enrollment or a manifest enrollment package with no record of it. The web console publishes a `zentral_audit` event for the same objects, so the API was the only way to change them without a trace. This is the same change as the Osquery API in #1644.

### The views

Eight views move to `ListCreateAPIViewWithAudit` and `RetrieveUpdateDestroyAPIViewWithAudit`:

| model | list | detail |
|---|---|---|
| Catalog | `/api/monolith/catalogs/` | `/api/monolith/catalogs/<pk>/` |
| Condition | `/api/monolith/conditions/` | `/api/monolith/conditions/<pk>/` |
| Enrollment | `/api/monolith/enrollments/` | `/api/monolith/enrollments/<pk>/` |
| ManifestEnrollmentPackage | `/api/monolith/manifest_enrollment_packages/` | `/api/monolith/manifest_enrollment_packages/<pk>/` |

The bases give the permission classes and the filter backend, so the views do not declare them again. The three `perform_destroy` methods that refuse to delete an object in use call `super()`, so their check runs first and the audit event follows.

### The delete of a manifest enrollment package

`ManifestEnrollmentPackageDetail.perform_destroy` calls `delete(delete_enrollment=False)`, so it could not use the `perform_destroy` of the base, and its delete had no audit event.

`RetrieveUpdateDestroyAPIViewWithAudit` calls `delete()` with the keyword arguments of the new `get_perform_destroy_kwargs()` now. The default is an empty dict, and `DestroyModelMixin.perform_destroy` calls `delete()` with no argument, so nothing changes for the other views. Two tests in `tests/utils/test_audit_views.py` keep this contract: the default is empty, and an override is used.

Why the argument is necessary, from `e4c85c5` (#974): the console creates the enrollment together with the package, and deletes the two of them together. The API takes an `enrollment_pk` for an enrollment that already exists, made by the Munki enrollments API or by Terraform, so it must only release it. The delete test asserts the audit event **and** that the Munki enrollment is still there, so a change to a plain `super()` call cannot pass.

### PATCH

These endpoints answer a `PATCH` with a `405` now, because the bases accept only the full updates. This is the same change as the Osquery API. The new `test_patch_is_not_allowed` covers the four detail endpoints.

### Tests

The full test suite, as CI does it: **8026 tests, OK**. All the added lines in `zentral/` have test coverage: 23 added lines, and 0 lines without coverage.

Twelve audit assertions were added to the tests: three for the catalogs, three for the conditions, three for the enrollments, and three for the manifest enrollment packages. To make sure that they can fail, one view was put back on its old base, and the test of the create of a catalog failed because there was no event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
