### PR TITLE
Publish audit events from the Munki and Santa enrollment API views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The Osquery API publishes the same `zentral_audit` events as the web console now
 
 #### Santa
 
+The Santa API publishes the same `zentral_audit` events as the web console now, for the enrollments.
+
 A clean sync — `CLEAN` or `CLEAN_ALL` — can be queued for an enrolled machine from its machine page or from the API, and cancelled before its next preflight. The new `Santa::Action::"forceCleanSync"` PBAC action gives the permission, and accepts a meta business unit and a sync type.
 
 New `/api/santa/enrolled_machines/` endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Zentral adds a `default_installs` package to the `optional_installs` of the sub 
 The Monolith API publishes the same `zentral_audit` events as the web console now. The catalogs, the conditions, the enrollments and the manifest enrollment packages changed with no record of it.
 
 
+#### Munki
+
+The Munki API publishes the same `zentral_audit` events as the web console now, for the enrollments.
+
+
 #### Osquery
 
 Zentral publishes a `zentral_audit` event when a user creates, updates or deletes an Osquery object from the web console: automatic table constructions, configurations, configuration packs, enrollments, file categories, packs, pack queries, queries and distributed query runs. Each event carries the full value of the object before and after the change, and the user, the source IP and the request that made it.

--- a/tests/munki/test_api_views.py
+++ b/tests/munki/test_api_views.py
@@ -15,7 +15,7 @@ from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit,
 from zentral.contrib.munki.models import Configuration, Enrollment, ScriptCheck
 from zentral.core.compliance_checks.models import ComplianceCheck
 from zentral.core.events.base import AuditEvent
-from .utils import force_script_check
+from .utils import assert_audit_event, force_script_check
 
 
 class APIViewsTestCase(TestCase, LoginCase, RequestCase):
@@ -562,21 +562,23 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             {'configuration': ['This field is required.'], 'secret': ['This field is required.']}
         )
 
-    def test_create_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrollment(self, post_event):
         configuration = self.force_configuration()
         self.set_permissions("munki.add_enrollment")
         tags = [Tag.objects.create(name=get_random_string(12)) for _ in range(1)]
         serial_numbers = [get_random_string(12) for _ in range(1)]
         uuids = [str(uuid.uuid4()) for _ in range(1)]
-        response = self.post(
-            reverse("munki_api:enrollments"),
-            {'configuration': configuration.pk,
-             'secret': {'meta_business_unit': self.mbu.pk,
-                        'serial_numbers': serial_numbers,
-                        'tags': [t.id for t in tags],
-                        'udids': uuids,
-                        'quota': 19}}
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                reverse("munki_api:enrollments"),
+                {'configuration': configuration.pk,
+                 'secret': {'meta_business_unit': self.mbu.pk,
+                            'serial_numbers': serial_numbers,
+                            'tags': [t.id for t in tags],
+                            'udids': uuids,
+                            'quota': 19}}
+            )
         self.assertEqual(response.status_code, 201)
         enrollment = configuration.enrollment_set.first()
         fqdn = settings["api"]["fqdn"]
@@ -601,6 +603,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'updated_at': enrollment.updated_at.isoformat()},
             {}
         )
+        assert_audit_event(self, post_event, "created", enrollment)
 
     # get enrollment
 
@@ -658,21 +661,24 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.put(reverse("munki_api:enrollment", args=(enrollment.pk,)), {})
         self.assertEqual(response.status_code, 403)
 
-    def test_update_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_enrollment(self, post_event):
         enrollment = self.force_enrollment()
+        prev_value = enrollment.serialize_for_event()
         self.set_permissions("munki.change_enrollment")
         tags = [Tag.objects.create(name=get_random_string(12)) for _ in range(1)]
         serial_numbers = [get_random_string(12) for _ in range(1)]
         uuids = [str(uuid.uuid4()) for _ in range(1)]
-        response = self.put(
-            reverse("munki_api:enrollment", args=(enrollment.pk,)),
-            {'configuration': enrollment.configuration.pk,
-             'secret': {'meta_business_unit': self.mbu.pk,
-                        'serial_numbers': serial_numbers,
-                        'tags': [t.id for t in tags],
-                        'udids': uuids,
-                        'quota': 19}}
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(
+                reverse("munki_api:enrollment", args=(enrollment.pk,)),
+                {'configuration': enrollment.configuration.pk,
+                 'secret': {'meta_business_unit': self.mbu.pk,
+                            'serial_numbers': serial_numbers,
+                            'tags': [t.id for t in tags],
+                            'udids': uuids,
+                            'quota': 19}}
+            )
         self.assertEqual(response.status_code, 200)
         enrollment.refresh_from_db()
         fqdn = settings["api"]["fqdn"]
@@ -697,6 +703,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'updated_at': enrollment.updated_at.isoformat()},
             {}
         )
+        payload, _ = assert_audit_event(self, post_event, "updated", enrollment, prev_value=prev_value)
+        # the version is in the payload of the base enrollment, so the event shows the bump
+        self.assertEqual(payload["object"]["prev_value"]["version"], 1)
+        self.assertEqual(payload["object"]["new_value"]["version"], 2)
 
     # delete enrollment
 
@@ -710,12 +720,16 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.delete(reverse("munki_api:enrollment", args=(enrollment.pk,)))
         self.assertEqual(response.status_code, 403)
 
-    def test_delete_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_enrollment(self, post_event):
         enrollment = self.force_enrollment()
+        prev_value = enrollment.serialize_for_event()
         self.set_permissions("munki.delete_enrollment")
-        response = self.delete(reverse("munki_api:enrollment", args=(enrollment.pk,)))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(reverse("munki_api:enrollment", args=(enrollment.pk,)))
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Enrollment.objects.filter(pk=enrollment.pk).count(), 0)
+        assert_audit_event(self, post_event, "deleted", enrollment, prev_value=prev_value)
 
     # get enrollment package
 

--- a/tests/munki/utils.py
+++ b/tests/munki/utils.py
@@ -1,4 +1,6 @@
 from django.utils.crypto import get_random_string
+
+from zentral.core.events.base import AuditEvent
 from zentral.contrib.inventory.models import EnrollmentSecret, MachineTag, MetaBusinessUnit, Tag
 from zentral.contrib.munki.compliance_checks import MunkiScriptCheck
 from zentral.contrib.munki.models import Configuration, Enrollment, EnrolledMachine, MunkiState, ScriptCheck
@@ -84,3 +86,21 @@ def force_munki_state(serial_number=None):
         munki_version="6.5.1",
         user_agent="Zentral/munkipostflight 0.14",
     )
+
+
+def assert_audit_event(test_case, post_event, action, instance, prev_value=None, call_index=0):
+    """Check the audit event at call_index, and give its payload back for more assertions."""
+    test_case.maxDiff = None
+    event = post_event.call_args_list[call_index].args[0]
+    test_case.assertIsInstance(event, AuditEvent)
+    expected = {"action": action,
+                "object": {"model": instance._meta.label_lower,
+                           "pk": str(instance.pk)}}
+    if action in ("created", "updated"):
+        expected["object"]["new_value"] = instance.serialize_for_event()
+    if prev_value is not None:
+        expected["object"]["prev_value"] = prev_value
+    test_case.assertEqual(event.payload, expected)
+    metadata = event.metadata.serialize()
+    test_case.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
+    return event.payload, metadata

--- a/tests/santa/test_api_views.py
+++ b/tests/santa/test_api_views.py
@@ -19,7 +19,8 @@ from zentral.contrib.santa.models import (Configuration, EnrolledMachine, Rule, 
                                           Enrollment)
 from zentral.core.events.base import AuditEvent
 from zentral.utils.payloads import get_payload_identifier
-from .utils import force_rule, new_cdhash, new_sha256, new_signing_id_identifier, new_team_id
+from .utils import (assert_audit_event, force_rule, new_cdhash, new_sha256,
+                    new_signing_id_identifier, new_team_id)
 
 
 class APIViewsTestCase(TestCase, LoginCase, RequestCase):
@@ -2702,16 +2703,18 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
 
     # create enrollment
 
-    def test_create_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrollment(self, post_event):
         config = self.force_configuration()
         self.set_permissions("santa.add_enrollment")
         tags = [Tag.objects.create(name=get_random_string(12)) for _ in range(2)]
-        response = self.post(
-            reverse('santa_api:enrollments'),
-            {'configuration': config.pk,
-             'secret': {"meta_business_unit": self.mbu.pk,
-                        "tags": [t.id for t in tags]}}
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(
+                reverse('santa_api:enrollments'),
+                {'configuration': config.pk,
+                 'secret': {"meta_business_unit": self.mbu.pk,
+                            "tags": [t.id for t in tags]}}
+            )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Enrollment.objects.filter(configuration__name=config.name).count(), 1)
         enrollment = Enrollment.objects.get(configuration__name=config.name)
@@ -2720,6 +2723,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             set(enrollment.secret.tags.all()),
             set(tags)
         )
+        assert_audit_event(self, post_event, "created", enrollment)
 
     def test_create_enrollment_unauthorized(self):
         data = {'name': 'Configuration0'}
@@ -2734,8 +2738,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
 
     # update enrollment
 
-    def test_update_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_enrollment(self, post_event):
         enrollment, _ = self.force_enrollment(tag_count=2)
+        prev_value = enrollment.serialize_for_event()
         enrollment_secret = enrollment.secret
         self.assertEqual(enrollment.secret.quota, None)
         self.assertEqual(enrollment.secret.serial_numbers, None)
@@ -2751,7 +2757,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         data = {"configuration": enrollment.configuration.pk,
                 "secret": secret_data}
         self.set_permissions("santa.change_enrollment")
-        response = self.put(reverse('santa_api:enrollment', args=(enrollment.pk,)), data)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.put(reverse('santa_api:enrollment', args=(enrollment.pk,)), data)
         self.assertEqual(response.status_code, 200)
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.secret, enrollment_secret)
@@ -2762,6 +2769,10 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             set(enrollment.secret.tags.all()),
             set(tags)
         )
+        payload, _ = assert_audit_event(self, post_event, "updated", enrollment, prev_value=prev_value)
+        # the version is in the payload of the base enrollment, so the event shows the bump
+        self.assertEqual(payload["object"]["prev_value"]["version"], 1)
+        self.assertEqual(payload["object"]["new_value"]["version"], 2)
 
     def test_update_enrollment_unauthorized(self):
         enrollment, _ = self.force_enrollment()
@@ -2815,11 +2826,15 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
 
     # delete enrollment
 
-    def test_delete_enrollment(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_enrollment(self, post_event):
         enrollment, _ = self.force_enrollment()
+        prev_value = enrollment.serialize_for_event()
         self.set_permissions("santa.delete_enrollment")
-        response = self.delete(reverse('santa_api:enrollment', args=(enrollment.pk,)))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.delete(reverse('santa_api:enrollment', args=(enrollment.pk,)))
         self.assertEqual(response.status_code, 204)
+        assert_audit_event(self, post_event, "deleted", enrollment, prev_value=prev_value)
 
     def test_delete_enrollment_unauthorized(self):
         enrollment, _ = self.force_enrollment()

--- a/tests/santa/utils.py
+++ b/tests/santa/utils.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from realms.models import Realm, RealmGroup, RealmUser
 
+from zentral.core.events.base import AuditEvent
 from zentral.contrib.inventory.models import (
     EnrollmentSecret,
     File,
@@ -546,3 +547,21 @@ class SantaSyncClient:
         if postflight:
             return self.postflight(rules)
         return self.last_response
+
+
+def assert_audit_event(test_case, post_event, action, instance, prev_value=None, call_index=0):
+    """Check the audit event at call_index, and give its payload back for more assertions."""
+    test_case.maxDiff = None
+    event = post_event.call_args_list[call_index].args[0]
+    test_case.assertIsInstance(event, AuditEvent)
+    expected = {"action": action,
+                "object": {"model": instance._meta.label_lower,
+                           "pk": str(instance.pk)}}
+    if action in ("created", "updated"):
+        expected["object"]["new_value"] = instance.serialize_for_event()
+    if prev_value is not None:
+        expected["object"]["prev_value"] = prev_value
+    test_case.assertEqual(event.payload, expected)
+    metadata = event.metadata.serialize()
+    test_case.assertEqual(sorted(metadata["tags"]), ["santa", "zentral"])
+    return event.payload, metadata

--- a/zentral/contrib/munki/api_views.py
+++ b/zentral/contrib/munki/api_views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
-from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.views import APIView
 from accounts.api_authentication import APITokenAuthentication
@@ -31,17 +30,14 @@ class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
 # enrollments
 
 
-class EnrollmentList(generics.ListCreateAPIView):
+class EnrollmentList(ListCreateAPIViewWithAudit):
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ("configuration_id",)
 
 
-class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
+class EnrollmentDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
 
 

--- a/zentral/contrib/santa/api_views.py
+++ b/zentral/contrib/santa/api_views.py
@@ -52,23 +52,20 @@ class ConfigurationDetail(RetrieveUpdateDestroyAPIViewWithAudit):
             return super().perform_destroy(instance)
 
 
-class EnrollmentList(generics.ListCreateAPIView):
+class EnrollmentList(ListCreateAPIViewWithAudit):
     """
     List all Enrollments or create a new Enrollment
     """
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('configuration_id',)
 
 
-class EnrollmentDetail(generics.RetrieveUpdateDestroyAPIView):
+class EnrollmentDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, update or delete an Enrollment instance.
     """
     queryset = Enrollment.objects.all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = EnrollmentSerializer
 
     def perform_destroy(self, instance):


### PR DESCRIPTION
The Munki API and the Santa API created, updated and deleted an enrollment with no record of it. The web console publishes a `zentral_audit` event for the same object. This continues the work of #1644 for the Osquery API and #1647 for the Monolith API.

One commit for each module.

### The views

| module | list | detail |
|---|---|---|
| Munki | `/api/munki/enrollments/` | `/api/munki/enrollments/<pk>/` |
| Santa | `/api/santa/enrollments/` | `/api/santa/enrollments/<pk>/` |

The four views move to `ListCreateAPIViewWithAudit` and `RetrieveUpdateDestroyAPIViewWithAudit`, which give the permission classes and the filter backend. The Santa `perform_destroy` that refuses to delete an enrollment in use calls `super()`, so its check runs before the audit event.

`generics` is not used in the Munki API views anymore, so the import goes.

### PATCH

These endpoints answer a `PATCH` with a `405` now, because the bases accept only the full updates. This is the same change as the Osquery API and the Monolith API.

### The Santa rules keep their views

A rule change already publishes a `santa_rule_update` event, and a rule set publishes one for each rule it changes. An audit event there is a decision about one event or two, and not a new base class, so the rules are not part of this PR.

### Tests

The full test suite, as CI does it: **8026 tests, OK**. All the added lines in `zentral/` have test coverage: 4 added lines, and 0 lines without coverage.

Six audit assertions were added, three for each module. Each module has an `assert_audit_event` helper in its test utils, like the Monolith and the Osquery ones.

The test of the update also checks the version in the payload of the event, before and after. `BaseEnrollment.serialize_for_event()` puts the version there since #1642, and an update of an enrollment increases it. The helper compares the event with the same `serialize_for_event()` that the event used, so it cannot find a payload that lost an attribute. To make sure that this new check can fail, the version was taken out of the base method, and the two tests of the update gave a `KeyError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
