### PR TITLE
Monolith: document the install and the uninstall of the same package

### DIFF
--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -62,13 +62,15 @@ It's important to note that, unlike how tagging works for catalogs, enrollments 
 
 ### Add software via sub-manifests
 
-You can now add software to your manifest. With monolith, we have decided to only allow software to be added in sub-manifests. Go to `Monolith > Sub manifests` to create your first sub-manifest, say `Optional browsers`. Open it and click on `Create new Package` to add a repository package: pick a PkgInfo name and a key (`managed_installs`, `managed_uninstalls`, `default_installs`, `optional_installs`, or `managed_updates`), optionally scoped with a condition, featured flag, and per-tag shards.
+You can now add software to your manifest. With monolith, we have decided to only allow software to be added in sub-manifests. Go to `Monolith > Sub manifests` to create your first sub-manifest, say `Optional browsers`. Open it and click on `Create new Package` to add a repository package: pick a PkgInfo name and a key (`managed_installs`, `managed_uninstalls`, `default_installs`, `optional_installs`, or `managed_updates`), optionally scoped with a condition, excluded tags and per-tag shards. You can also feature a `default_installs` or an `optional_installs` package in Managed Software Center.
 
 Once you have a sub-manifest, add it to the manifest (from the manifest, click on `Add` in the sub-manifest section). If you pick one or many tags, only the machine carrying any of the tags applied will be offered it.
 
 A package can use more than one key in the same sub-manifest, one time for each key, and each key keeps its own condition, excluded tags and shards. For example, use `optional_installs` and `managed_updates` together. Managed Software Center then offers the package, and Zentral keeps it up to date after a user installs it. Munki updates a `managed_updates` package only if a version of it is already installed.
 
-Do not add the same package with the `managed_installs` and the `managed_uninstalls` keys. You also see warnings if you add a package to a sub-manifest before it is in all the applicable catalogs. Use [Conditions](https://github.com/munki/munki/wiki/Conditional-Items) with the munki `catalog` NSPredicate logic to prevent those warnings.
+Do not add the same package with the `managed_installs` and the `managed_uninstalls` keys. Zentral does not prevent it, in one sub-manifest or in two. Munki keeps the install: it does not remove a package that is in the list of managed installs, and it writes a warning.
+
+You also see warnings if you add a package to a sub-manifest before it is in all the applicable catalogs. Use [Conditions](https://github.com/munki/munki/wiki/Conditional-Items) with the munki `catalog` NSPredicate logic to prevent those warnings.
 
 Munki installs a `default_installs` package only if it is an `optional_installs` package too. Zentral adds a `default_installs` package to the two keys. If the sub-manifest has its own `optional_installs` package with the same name and the same condition, Zentral keeps that one, with its own scope.
 

--- a/tests/monolith/test_munki_api_views.py
+++ b/tests/monolith/test_munki_api_views.py
@@ -550,6 +550,49 @@ class MonolithAPIViewsTestCase(TestCase):
             {'managed_updates': ['deuxième nom']}
         )
 
+    def test_sub_manifest_managed_uninstalls_one_tag_shard_excluded(self):
+        _, catalog, sub_manifest = self._force_smpi(name="premier nom")
+        self._force_smpi(
+            name="deuxième nom",
+            catalog=catalog,
+            sub_manifest=sub_manifest,
+            sub_manifest_key="managed_uninstalls",
+            smo_options={"excluded_tags": ["EXCL1", "EXCL2"],
+                         "shards": {"default": 0, "tags": {"INCL1": 0, "INCL2": 76}}}  # NAME + SN → 77
+        )
+        response = self._make_munki_request(
+            reverse("monolith_public:repository_manifest", args=(sub_manifest.get_munki_name(),)),
+            serial_number="12345678",
+            tags=["INCL2"]
+        )
+        self.assertEqual(response.status_code, 200)
+        sub_manifest = plistlib.loads(response.content)
+        # the machine keeps the package, the removal is out of its shard
+        self.assertEqual(
+            sub_manifest,
+            {'managed_installs': ['premier nom'],
+             'managed_uninstalls': []}
+        )
+
+    def test_sub_manifest_managed_uninstalls_one_tag_shard_included(self):
+        _, _, sub_manifest = self._force_smpi(
+            name="deuxième nom",
+            sub_manifest_key="managed_uninstalls",
+            smo_options={"excluded_tags": ["EXCL1", "EXCL2"],
+                         "shards": {"default": 0, "tags": {"INCL1": 0, "INCL2": 78}}}  # NAME + SN → 77
+        )
+        response = self._make_munki_request(
+            reverse("monolith_public:repository_manifest", args=(sub_manifest.get_munki_name(),)),
+            serial_number="12345678",
+            tags=["INCL2"]
+        )
+        self.assertEqual(response.status_code, 200)
+        sub_manifest = plistlib.loads(response.content)
+        self.assertEqual(
+            sub_manifest,
+            {'managed_uninstalls': ['deuxième nom']}
+        )
+
     def test_sub_manifest_default_installs_one_tag_shard_excluded(self):
         _, catalog, sub_manifest = self._force_smpi(name="premier nom")
         self._force_smpi(


### PR DESCRIPTION
Two follow-ups to #1646.

## The install and the uninstall of the same package

`unique_together = (sub_manifest, pkg_info_name)` made it impossible to add a package with the `managed_installs` key and with the `managed_uninstalls` key in one sub-manifest. `UniqueConstraint(sub_manifest, pkg_info_name, key)` allows it now. Across two sub-manifests it was always possible.

The documentation said not to do it. It did not say that nothing prevents it, or what munki does. Munki keeps the install: `processRemoval()` reads `processed_installs`, and it does not remove a package that is in that list. It writes a warning instead.

There is no check in the form or in the API. A check can only cover one sub-manifest, and the same conflict is possible across two, so it gives partial protection that reads as complete.

The paragraph also held the catalog warnings, which are a different subject. "You also see warnings" read as a result of the conflict. They move to their own paragraph.

The scope list of the first paragraph left out the excluded tags, and it offered the featured flag for every key. The form accepts that flag only for the `default_installs` and the `optional_installs` keys.

## The shards of a managed uninstall

The `managed_uninstalls` key carries the excluded tags and the shards since #1646. A test covered the excluded tags in a served sub manifest, but nothing covered the shards. The two new tests match the ones of the `managed_updates` key: a machine out of the shard keeps the package, and a machine in the shard removes it.

## Tests

Full suite: 8028 tests, OK. `mkdocs build --strict` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
