### PR TITLE
Publish audit events from the inventory JMESPath check views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ### Features
 
 
+#### Inventory
+
+The inventory JMESPath compliance check publishes the same `zentral_audit` events as the other objects now, from the web console and from the API.
+
+
 #### MDM
 
 A data asset can be created and updated with its content in the request now, base 64 encoded in the new `source` attribute, and not only with a `file_uri` that points to an object in an S3 bucket. `file_uri` and `source` are mutually exclusive, and one of them is required. Zentral computes `file_sha256` from a `source`, and requires it only with a `file_uri`. A `file_sha256` given with a `source` is verified against the content. A data asset created from a `source` has no filename.
@@ -79,6 +84,10 @@ The `version` attribute of an Osquery query in an event payload is the version o
 #### 🧨 PATCH on the Monolith API
 
 `PATCH` gives a `405 Method Not Allowed` on the Monolith catalog, condition, enrollment and manifest enrollment package endpoints. Use `PUT`, and send all the attributes of the object.
+
+#### 🧨 Inventory JMESPath compliance check events
+
+The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `inventory_jmespath_check_deleted` events do not exist anymore. The JMESPath compliance checks publish `zentral_audit` events, like the other objects. A probe or a query on the three event types must use `zentral_audit` with the `inventory.jmespathcheck` model. The events are still linked to the compliance check and to the JMESPath check, so the events page of a check does not change. The `inventory_jmespath_check_status_updated` event does not change.
 
 #### 🧨 Santa enrolled machines metrics
 

--- a/tests/inventory/test_compliance_checks_api.py
+++ b/tests/inventory/test_compliance_checks_api.py
@@ -7,7 +7,7 @@ from django.utils.crypto import get_random_string
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
-from zentral.contrib.inventory.events import JMESPathCheckCreated, JMESPathCheckDeleted, JMESPathCheckUpdated
+from zentral.core.events.base import AuditEvent
 from zentral.contrib.inventory.models import JMESPathCheck, Tag
 from zentral.contrib.inventory.compliance_checks import InventoryJMESPathCheck
 from zentral.core.compliance_checks.models import ComplianceCheck
@@ -127,8 +127,14 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         # event
         self.assertEqual(len(post_event.call_args.args), 1)
         event = post_event.call_args.args[0]
-        self.assertIsInstance(event, JMESPathCheckCreated)
-        self.assertEqual(event.payload["pk"], jpcc.compliance_check.pk)
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "inventory.jmespathcheck")
+        self.assertEqual(event.payload["object"]["pk"], str(jpcc.pk))
+        # the event still reaches the compliance check
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(jpcc.compliance_check.pk)])
+        self.assertEqual(metadata["objects"]["inventory_jmespath_check"], [str(jpcc.pk)])
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_jpcc_empty_description(self, post_event):
@@ -160,8 +166,14 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         # event
         self.assertEqual(len(post_event.call_args.args), 1)
         event = post_event.call_args.args[0]
-        self.assertIsInstance(event, JMESPathCheckCreated)
-        self.assertEqual(event.payload["pk"], jpcc.compliance_check.pk)
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "inventory.jmespathcheck")
+        self.assertEqual(event.payload["object"]["pk"], str(jpcc.pk))
+        # the event still reaches the compliance check
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(jpcc.compliance_check.pk)])
+        self.assertEqual(metadata["objects"]["inventory_jmespath_check"], [str(jpcc.pk)])
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_jpcc_missing_description(self, post_event):
@@ -192,8 +204,14 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         # event
         self.assertEqual(len(post_event.call_args.args), 1)
         event = post_event.call_args.args[0]
-        self.assertIsInstance(event, JMESPathCheckCreated)
-        self.assertEqual(event.payload["pk"], jpcc.compliance_check.pk)
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["model"], "inventory.jmespathcheck")
+        self.assertEqual(event.payload["object"]["pk"], str(jpcc.pk))
+        # the event still reaches the compliance check
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(jpcc.compliance_check.pk)])
+        self.assertEqual(metadata["objects"]["inventory_jmespath_check"], [str(jpcc.pk)])
 
     # get compliance check
 
@@ -279,8 +297,11 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         # event
         self.assertEqual(len(post_event.call_args.args), 1)
         event = post_event.call_args.args[0]
-        self.assertIsInstance(event, JMESPathCheckUpdated)
-        self.assertEqual(event.payload["pk"], jpcc.compliance_check.pk)
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["pk"], str(jpcc.pk))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(jpcc.compliance_check.pk)])
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_update_jpcc_same_name_no_platforms_no_tags(self, post_event):
@@ -304,8 +325,11 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         # event
         self.assertEqual(len(post_event.call_args.args), 1)
         event = post_event.call_args.args[0]
-        self.assertIsInstance(event, JMESPathCheckUpdated)
-        self.assertEqual(event.payload["pk"], jpcc.compliance_check.pk)
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["pk"], str(jpcc.pk))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(jpcc.compliance_check.pk)])
 
     # delete compliance check
 
@@ -326,8 +350,11 @@ class JMESPathCheckAPITests(TestCase, LoginCase, RequestCase):
         # event
         self.assertEqual(len(post_event.call_args.args), 1)
         event = post_event.call_args.args[0]
-        self.assertIsInstance(event, JMESPathCheckDeleted)
-        self.assertEqual(event.payload["pk"], cc_pk)
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "deleted")
+        self.assertEqual(event.payload["object"]["pk"], str(jpcc.pk))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(cc_pk)])
 
     # list compliance check
 

--- a/tests/inventory/test_compliance_checks_views.py
+++ b/tests/inventory/test_compliance_checks_views.py
@@ -11,6 +11,7 @@ from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.compliance_checks import InventoryJMESPathCheck
 from zentral.contrib.inventory.models import JMESPathCheck, MachineSnapshotCommit, MachineTag, MetaMachine, Source, Tag
 from zentral.core.compliance_checks.models import ComplianceCheck, MachineStatus, Status
+from zentral.core.events.base import AuditEvent
 from zentral.core.stores.conf import stores
 from zentral.utils.provisioning import provision
 from zentral.utils.time import naive_utcnow
@@ -147,21 +148,31 @@ class InventoryComplianceChecksViewsTestCase(TestCase, LoginCase):
         self.assertEqual(form.initial["source_name"], source_name)
         self.assertEqual(form.initial["jmespath_expression"], jmespath_expression)
 
-    def test_create_compliance_check_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_compliance_check_post(self, post_event):
         self.login("inventory.add_jmespathcheck", "inventory.view_jmespathcheck")
         name = get_random_string(12)
-        response = self.client.post(reverse("inventory:create_compliance_check"),
-                                    {"ccf-name": name,
-                                     "ccf-description": get_random_string(12),
-                                     "jcf-source_name": get_random_string(12),
-                                     "jcf-platforms": ["MACOS"],
-                                     "jcf-jmespath_expression": "contains(profiles[*].uuid, `yolo`)"},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("inventory:create_compliance_check"),
+                                        {"ccf-name": name,
+                                         "ccf-description": get_random_string(12),
+                                         "jcf-source_name": get_random_string(12),
+                                         "jcf-platforms": ["MACOS"],
+                                         "jcf-jmespath_expression": "contains(profiles[*].uuid, `yolo`)"},
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "inventory/compliancecheck_detail.html")
         self.assertContains(response, name)
         jmespath_check = response.context["object"]
         self.assertEqual(jmespath_check.platforms, ["MACOS"])
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "created")
+        self.assertEqual(event.payload["object"]["pk"], str(jmespath_check.pk))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["inventory_jmespath_check"], [str(jmespath_check.pk)])
+        self.assertEqual(metadata["objects"]["compliance_check"],
+                         [str(jmespath_check.compliance_check.pk)])
 
     def test_create_compliance_check_post_name_collision(self):
         cc = self._force_jmespath_check()
@@ -330,19 +341,23 @@ class InventoryComplianceChecksViewsTestCase(TestCase, LoginCase):
         self.assertEqual(cc.compliance_check.name, name)
         self.assertEqual(cc.compliance_check.version, old_version)  # only the name changed → same version
 
-    def test_update_compliance_check_post_updated_version(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_update_compliance_check_post_updated_version(self, post_event):
         cc = self._force_jmespath_check()
+        prev_value = cc.serialize_for_event()
         old_version = cc.compliance_check.version
         self.login("inventory.change_jmespathcheck", "inventory.view_jmespathcheck")
         source_name = get_random_string(12)
-        response = self.client.post(reverse("inventory:update_compliance_check", args=(cc.pk,)),
-                                    {"ccf-name": cc.compliance_check.name,
-                                     "ccf-description": cc.compliance_check.description,
-                                     "jcf-source_name": source_name,
-                                     "jcf-platforms": ["IPADOS", "MACOS"],
-                                     "initial-jcf-platforms": cc.platforms,  # required for has_changed() to work!
-                                     "jcf-jmespath_expression": cc.jmespath_expression},
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("inventory:update_compliance_check", args=(cc.pk,)),
+                {"ccf-name": cc.compliance_check.name,
+                 "ccf-description": cc.compliance_check.description,
+                 "jcf-source_name": source_name,
+                 "jcf-platforms": ["IPADOS", "MACOS"],
+                 "initial-jcf-platforms": cc.platforms,  # required for has_changed() to work!
+                 "jcf-jmespath_expression": cc.jmespath_expression},
+                follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "inventory/compliancecheck_detail.html")
         self.assertNotContains(response, cc.source_name)
@@ -353,6 +368,13 @@ class InventoryComplianceChecksViewsTestCase(TestCase, LoginCase):
         # source name and platforms changed → version updated
         self.assertEqual(cc.compliance_check.version, old_version + 1)
         self.assertEqual(sorted(cc.platforms), ["IPADOS", "MACOS"])
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "updated")
+        self.assertEqual(event.payload["object"]["prev_value"], prev_value)
+        # the previous value is read before the forms validate, so it is the value before the post
+        self.assertNotEqual(event.payload["object"]["prev_value"]["source_name"],
+                            event.payload["object"]["new_value"]["source_name"])
 
     def test_update_compliance_check_post_name_collision(self):
         cc0 = self._force_jmespath_check()
@@ -388,17 +410,29 @@ class InventoryComplianceChecksViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "inventory/compliancecheck_confirm_delete.html")
         self.assertContains(response, cc.compliance_check.name)
 
-    def test_delete_compliance_check_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_compliance_check_post(self, post_event):
         cc0 = self._force_jmespath_check()
         cc = self._force_jmespath_check()
         cc_pk = cc.pk
+        prev_cc_pk = cc.compliance_check.pk
         self.login('inventory.delete_jmespathcheck', 'inventory.view_jmespathcheck')
-        response = self.client.post(reverse("inventory:delete_compliance_check", args=(cc_pk,)), follow=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(reverse("inventory:delete_compliance_check", args=(cc_pk,)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "inventory/compliancecheck_list.html")
         self.assertNotContains(response, reverse('inventory:compliance_check', args=(cc_pk,)))
         self.assertContains(response, cc0.compliance_check.name)
         self.assertContains(response, reverse('inventory:compliance_check', args=(cc0.pk,)))
+        # the compliance check goes with the JMESPath check
+        self.assertFalse(ComplianceCheck.objects.filter(pk=prev_cc_pk).exists())
+        event = post_event.call_args_list[0].args[0]
+        self.assertIsInstance(event, AuditEvent)
+        self.assertEqual(event.payload["action"], "deleted")
+        self.assertEqual(event.payload["object"]["pk"], str(cc_pk))
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"]["compliance_check"], [str(prev_cc_pk)])
 
     # devtool
 

--- a/tests/munki/test_api_views.py
+++ b/tests/munki/test_api_views.py
@@ -1093,7 +1093,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)]})
+        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)],
+                                               "compliance_check": [str(script_check.compliance_check.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
         self.assertEqual(len(callbacks), 1)
 
@@ -1251,7 +1252,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)]})
+        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)],
+                                               "compliance_check": [str(script_check.compliance_check.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
         self.assertEqual(len(callbacks), 1)
 
@@ -1342,6 +1344,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
     def test_delete_script_check(self, post_event):
         script_check = force_script_check()
         prev_pk = script_check.pk
+        prev_cc_pk = script_check.compliance_check.pk
         prev_name = script_check.compliance_check.name
         prev_value = script_check.serialize_for_event()
         self.set_permissions("munki.delete_scriptcheck")
@@ -1362,6 +1365,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"munki_script_check": [str(prev_pk)]})
+        self.assertEqual(metadata["objects"], {"munki_script_check": [str(prev_pk)],
+                                               "compliance_check": [str(prev_cc_pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
         self.assertEqual(len(callbacks), 1)

--- a/tests/munki/test_script_check_views.py
+++ b/tests/munki/test_script_check_views.py
@@ -335,7 +335,8 @@ class MunkiScriptCheckViewsTestCase(TestCase, LoginCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)]})
+        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)],
+                                               "compliance_check": [str(script_check.compliance_check.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
 
     # view
@@ -554,7 +555,8 @@ class MunkiScriptCheckViewsTestCase(TestCase, LoginCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)]})
+        self.assertEqual(metadata["objects"], {"munki_script_check": [str(script_check.pk)],
+                                               "compliance_check": [str(script_check.compliance_check.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
 
     # delete
@@ -606,7 +608,8 @@ class MunkiScriptCheckViewsTestCase(TestCase, LoginCase):
               }}
         )
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"munki_script_check": [str(prev_pk)]})
+        self.assertEqual(metadata["objects"], {"munki_script_check": [str(prev_pk)],
+                                               "compliance_check": [str(prev_cc_pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
 
     # events

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -2903,14 +2903,16 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "updated_at": query.updated_at.isoformat()
                           })
 
-    def test_create_compliance_check_query(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_compliance_check_query(self, post_event):
         data = {
             "name": "test_query01",
             "sql": "select 'OK' ztl_status;",
             "compliance_check_enabled": True
         }
         self.set_permissions("osquery.add_query")
-        response = self.post(reverse("osquery_api:queries"), data)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("osquery_api:queries"), data)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Query.objects.filter(name='test_query01').count(), 1)
         query = Query.objects.get(name='test_query01')
@@ -2930,6 +2932,11 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                           "created_at": query.created_at.isoformat(),
                           "updated_at": query.updated_at.isoformat()
                           })
+        # a query that is a compliance check links it, so the events of the check are complete
+        event = post_event.call_args_list[0].args[0]
+        metadata = event.metadata.serialize()
+        self.assertEqual(metadata["objects"], {"osquery_query": [str(query.pk)],
+                                               "compliance_check": [str(query.compliance_check.pk)]})
 
     def test_create_tag_update_query(self):
         tag = Tag.objects.create(name=get_random_string(12))

--- a/tests/turbo/test_api_mscp_checks.py
+++ b/tests/turbo/test_api_mscp_checks.py
@@ -41,7 +41,8 @@ class TurboMSCPCheckAPITestCase(TurboAPITestCase):
         self.assertEqual(audit_events[0].payload["action"], "created")
         self.assertEqual(audit_events[0].payload["object"]["model"], "turbo.mscpcheck")
         metadata = audit_events[0].metadata.serialize()
-        self.assertEqual(metadata["objects"], {"turbo_mscp_check": [str(mscp_check.pk)]})
+        self.assertEqual(metadata["objects"], {"turbo_mscp_check": [str(mscp_check.pk)],
+                                               "compliance_check": [str(mscp_check.compliance_check.pk)]})
 
     def test_create_mscp_check_baseline(self):
         self.set_permissions("turbo.add_mscpcheck")

--- a/tests/turbo/test_api_scripts.py
+++ b/tests/turbo/test_api_scripts.py
@@ -55,7 +55,7 @@ class TurboScriptAPITestCase(TurboAPITestCase):
         script = Script.objects.get(pk=response.json()["id"])
         self.assertIsNotNone(script.compliance_check)
         self.assertEqual(script.tag, tag)
-        # the audit event links the script + the tagging tag, deliberately NOT the compliance check
+        # the audit event links the script, the tagging tag and the compliance check
         audit_events = self._audit_events(post_event)
         self.assertEqual(len(audit_events), 1)
         self.assertEqual(audit_events[0].payload["object"]["model"], "turbo.script")
@@ -63,6 +63,7 @@ class TurboScriptAPITestCase(TurboAPITestCase):
         self.assertEqual(metadata["objects"], {
             "turbo_script": [str(script.pk)],
             "tag": [str(tag.pk)],
+            "compliance_check": [str(script.compliance_check.pk)],
         })
 
     def test_list_scripts(self):

--- a/tests/turbo/test_setup_mscp_checks.py
+++ b/tests/turbo/test_setup_mscp_checks.py
@@ -143,7 +143,8 @@ class TurboSetupMSCPChecksTestCase(TurboSetupTestCase):
         self.assertEqual(event.payload["object"]["pk"], str(mscp_check.pk))
         self.assertEqual(event.payload["object"]["new_value"]["version"], 1)
         metadata = event.metadata.serialize()
-        self.assertEqual(metadata["objects"], {"turbo_mscp_check": [str(mscp_check.pk)]})
+        self.assertEqual(metadata["objects"], {"turbo_mscp_check": [str(mscp_check.pk)],
+                                               "compliance_check": [str(mscp_check.compliance_check.pk)]})
 
     def test_create_mscp_check_baseline_post(self):
         self.login("turbo.add_mscpcheck", "turbo.view_mscpcheck")

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -1,9 +1,9 @@
-from django.db import connection, transaction
+from django.db import connection
 from django.http import Http404
 from django.urls import reverse
 from django.utils import timezone
 from django_filters import rest_framework as filters
-from rest_framework import generics, status
+from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
@@ -11,9 +11,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from accounts.api_authentication import APITokenAuthentication
 from zentral.core.events.base import EventRequest
-from zentral.utils.drf import (DefaultDjangoModelPermissions, DjangoPermissionRequired,
-                               ListCreateAPIViewWithAudit, RetrieveUpdateDestroyAPIViewWithAudit)
-from .events import JMESPathCheckCreated, JMESPathCheckDeleted, JMESPathCheckUpdated
+from zentral.utils.drf import (DjangoPermissionRequired, ListCreateAPIViewWithAudit,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
 from .forms import AndroidAppSearchForm, DebPackageSearchForm, IOSAppSearchForm, MacOSAppSearchForm, ProgramsSearchForm
 from .models import (CurrentMachineSnapshot,
                      JMESPathCheck,
@@ -415,39 +414,21 @@ class JMESPathCheckFilter(filters.FilterSet):
     name = filters.CharFilter(field_name="compliance_check__name")
 
 
-class JMESPathCheckList(generics.ListCreateAPIView):
+class JMESPathCheckList(ListCreateAPIViewWithAudit):
     """
     List, search by name or create JMESPath compliance checks.
     """
     queryset = JMESPathCheck.objects.select_related("compliance_check").all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = JMESPathCheckSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = JMESPathCheckFilter
 
-    def perform_create(self, serializer):
-        serializer.save()
-        event = JMESPathCheckCreated.build_from_request_and_object(self.request, serializer.instance)
-        transaction.on_commit(lambda: event.post())
 
-
-class JMESPathCheckDetail(generics.RetrieveUpdateDestroyAPIView):
+class JMESPathCheckDetail(RetrieveUpdateDestroyAPIViewWithAudit):
     """
     Retrieve, update or delete a JMESPath compliance check.
     """
     queryset = JMESPathCheck.objects.select_related("compliance_check").all()
-    permission_classes = [DefaultDjangoModelPermissions]
     serializer_class = JMESPathCheckSerializer
-
-    def perform_update(self, serializer):
-        serializer.save()
-        event = JMESPathCheckUpdated.build_from_request_and_object(self.request, serializer.instance)
-        transaction.on_commit(lambda: event.post())
-
-    def perform_destroy(self, instance):
-        event = JMESPathCheckDeleted.build_from_request_and_object(self.request, instance)
-        instance.compliance_check.delete()
-        transaction.on_commit(lambda: event.post())
 
 
 class MetaBusinessUnitList(ListCreateAPIViewWithAudit):

--- a/zentral/contrib/inventory/events/__init__.py
+++ b/zentral/contrib/inventory/events/__init__.py
@@ -132,48 +132,6 @@ def post_enrollment_secret_verification_success(request, model):
 # compliance checks
 
 
-class JMESPathCheckBaseEvent(BaseEvent):
-    namespace = 'compliance_check'
-    tags = ['compliance_check', 'inventory_jmespath_check']
-
-    @classmethod
-    def build_from_request_and_object(cls, request, jmespath_check):
-        payload = jmespath_check.compliance_check.serialize_for_event()
-        payload["inventory_jmespath_check"] = jmespath_check.serialize_for_event()
-        return cls(EventMetadata(request=EventRequest.build_from_request(request)), payload)
-
-    def get_linked_objects_keys(self):
-        keys = {}
-        pk = self.payload.get("pk")
-        if pk:
-            keys["compliance_check"] = [(pk,)]
-        jmespath_check_pk = self.payload.get("inventory_jmespath_check", {}).get("pk")
-        if jmespath_check_pk:
-            keys["inventory_jmespath_check"] = [(jmespath_check_pk,)]
-        return keys
-
-
-class JMESPathCheckCreated(JMESPathCheckBaseEvent):
-    event_type = 'inventory_jmespath_check_created'
-
-
-register_event_type(JMESPathCheckCreated)
-
-
-class JMESPathCheckUpdated(JMESPathCheckBaseEvent):
-    event_type = 'inventory_jmespath_check_updated'
-
-
-register_event_type(JMESPathCheckUpdated)
-
-
-class JMESPathCheckDeleted(JMESPathCheckBaseEvent):
-    event_type = 'inventory_jmespath_check_deleted'
-
-
-register_event_type(JMESPathCheckDeleted)
-
-
 class JMESPathCheckStatusUpdated(BaseEvent):
     event_type = 'inventory_jmespath_check_status_updated'
     namespace = 'compliance_check'

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -1621,6 +1621,9 @@ class File(AbstractMTObject):
 
 
 class JMESPathCheck(models.Model):
+    # the verbose name gives jmes_path_check, and the events page asks for inventory_jmespath_check
+    linked_objects_key = "inventory_jmespath_check"
+
     compliance_check = models.OneToOneField(
         "compliance_checks.ComplianceCheck",
         on_delete=models.CASCADE,
@@ -1642,6 +1645,9 @@ class JMESPathCheck(models.Model):
 
     def get_absolute_url(self):
         return reverse("inventory:compliance_check", args=(self.pk,))
+
+    def linked_objects_keys_for_event(self):
+        return {"compliance_check": [(self.compliance_check_id,)]}
 
     def get_platforms_display(self):
         return ", ".join(sorted(PLATFORM_CHOICES_DICT.get(p) for p in self.platforms))

--- a/zentral/contrib/inventory/models.py
+++ b/zentral/contrib/inventory/models.py
@@ -1649,6 +1649,11 @@ class JMESPathCheck(models.Model):
     def linked_objects_keys_for_event(self):
         return {"compliance_check": [(self.compliance_check_id,)]}
 
+    def delete(self, *args, **kwargs):
+        # the compliance check cascades back to this object, so the views only have to delete it
+        self.compliance_check.delete()
+        return super().delete(*args, **kwargs)
+
     def get_platforms_display(self):
         return ", ".join(sorted(PLATFORM_CHOICES_DICT.get(p) for p in self.platforms))
 

--- a/zentral/contrib/inventory/views.py
+++ b/zentral/contrib/inventory/views.py
@@ -7,16 +7,16 @@ from urllib.parse import urlencode
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import transaction
 from django.db.models import F
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
-from django.views.generic import DeleteView, DetailView, FormView, ListView, TemplateView, View
+from django.views.generic import DetailView, FormView, ListView, TemplateView, View
 
 from pbac.engine import engine
+from zentral.core.events.base import AuditEvent
 from zentral.conf import settings
 from zentral.core.compliance_checks import compliance_check_class_from_model
 from zentral.core.compliance_checks.forms import ComplianceCheckForm
@@ -34,10 +34,10 @@ from zentral.utils.views import (
     UpdateViewWithAudit,
     UserPaginationListView,
     UserPaginationMixin,
+    post_audit_event,
 )
 
 from .compliance_checks import InventoryJMESPathCheck
-from .events import JMESPathCheckCreated, JMESPathCheckDeleted, JMESPathCheckUpdated
 from .forms import (
     AndroidAppSearchForm,
     CreateTagForm,
@@ -968,8 +968,7 @@ class CreateComplianceCheckView(PermissionRequiredMixin, TemplateView):
         jmespath_check.compliance_check = compliance_check
         jmespath_check.save()
         jmespath_check_form.save_m2m()
-        event = JMESPathCheckCreated.build_from_request_and_object(self.request, jmespath_check)
-        transaction.on_commit(lambda: event.post())
+        post_audit_event(self.request, jmespath_check, AuditEvent.Action.CREATED)
         return redirect(jmespath_check)
 
     def post(self, request, *args, **kwargs):
@@ -1018,6 +1017,9 @@ class UpdateComplianceCheckView(PermissionRequiredMixin, TemplateView):
             pk=kwargs["pk"]
         )
         self.compliance_check = self.object.compliance_check
+        # a ModelForm writes the posted data onto its instance while it validates, so the previous
+        # value has to be read before the forms exist
+        self.prev_value = self.object.serialize_for_event()
         return super().dispatch(request, *args, **kwargs)
 
     def get_forms(self):
@@ -1064,8 +1066,8 @@ class UpdateComplianceCheckView(PermissionRequiredMixin, TemplateView):
         jmespath_check_form.save_m2m()
         if compliance_check_form.has_changed() or jmespath_check_form.has_changed():
             jmespath_check.refresh_from_db()  # get version number
-            event = JMESPathCheckUpdated.build_from_request_and_object(self.request, jmespath_check)
-            transaction.on_commit(lambda: event.post())
+            post_audit_event(self.request, jmespath_check, AuditEvent.Action.UPDATED,
+                             prev_value=self.prev_value)
         return redirect(jmespath_check)
 
     def post(self, request, *args, **kwargs):
@@ -1076,7 +1078,7 @@ class UpdateComplianceCheckView(PermissionRequiredMixin, TemplateView):
             return self.forms_invalid(compliance_check_form, jmespath_check_form)
 
 
-class DeleteComplianceCheckView(PermissionRequiredMixin, DeleteView):
+class DeleteComplianceCheckView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "inventory.delete_jmespathcheck"
     template_name = "inventory/compliancecheck_confirm_delete.html"
     model = JMESPathCheck
@@ -1086,13 +1088,14 @@ class DeleteComplianceCheckView(PermissionRequiredMixin, DeleteView):
         ctx["compliance_check"] = self.object.compliance_check
         return ctx
 
+    def get_success_url(self):
+        return reverse("inventory:compliance_checks")
+
     def form_valid(self, form):
         name = self.object.compliance_check.name
-        event = JMESPathCheckDeleted.build_from_request_and_object(self.request, self.object)
-        self.object.compliance_check.delete()
+        response = super().form_valid(form)
         messages.info(self.request, f'Compliance check "{name}" deleted')
-        transaction.on_commit(lambda: event.post())
-        return redirect("inventory:compliance_checks")
+        return response
 
 
 class ComplianceCheckEventsMixin:

--- a/zentral/contrib/munki/models.py
+++ b/zentral/contrib/munki/models.py
@@ -242,6 +242,9 @@ class ScriptCheck(models.Model):
     def get_absolute_url(self):
         return reverse("munki:script_check", args=(self.pk,))
 
+    def linked_objects_keys_for_event(self):
+        return {"compliance_check": [(self.compliance_check_id,)]}
+
     def serialize_for_event(self):
         d = {
             "pk": self.pk,

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -162,6 +162,13 @@ class Query(models.Model):
             self.compliance_check.delete()
         return super().delete(*args, **kwargs)
 
+    def linked_objects_keys_for_event(self):
+        keys = {}
+        # a query is a compliance check only when the user asks for one
+        if self.compliance_check_id:
+            keys["compliance_check"] = [(self.compliance_check_id,)]
+        return keys
+
     def compliance_check_enabled(self):
         return True if self.compliance_check else False
 

--- a/zentral/contrib/turbo/models.py
+++ b/zentral/contrib/turbo/models.py
@@ -321,9 +321,12 @@ class Script(models.Model):
         return d
 
     def linked_objects_keys_for_event(self):
-        keys = {"turbo_script": [(self.pk,)]}
+        keys = {}
         if self.tag_id:
             keys["tag"] = [(self.tag_id,)]
+        # a script is a compliance check only when the user asks for one
+        if self.compliance_check_id:
+            keys["compliance_check"] = [(self.compliance_check_id,)]
         return keys
 
     def delete(self, *args, **kwargs):
@@ -387,6 +390,9 @@ class MSCPCheck(models.Model):
 
     def get_absolute_url(self):
         return reverse("turbo:mscp_check", args=(self.pk,))
+
+    def linked_objects_keys_for_event(self):
+        return {"compliance_check": [(self.compliance_check_id,)]}
 
     @property
     def version(self):

--- a/zentral/core/compliance_checks/models.py
+++ b/zentral/core/compliance_checks/models.py
@@ -10,6 +10,10 @@ logger = logging.getLogger('zentral.core.compliance_checks.models')
 
 
 class ComplianceCheck(models.Model):
+    # the verbose name gives compliance_checks_compliance_check, which reads badly and does not
+    # match the key the events of the checks already use
+    linked_objects_key = "compliance_check"
+
     model = models.CharField(max_length=256, editable=False)
     name = models.TextField()
     description = models.TextField(blank=True)


### PR DESCRIPTION
The inventory JMESPath compliance check had three event types of its own, where every other object of the console and of the API publishes a `zentral_audit` event. The Munki script checks and the Turbo MSCP checks, which are compliance checks too, already publish `zentral_audit` events.

Two commits.

### 1. The audit events of the compliance checks reach the check

An audit event of a Munki script check, a Turbo MSCP check, an Osquery query or a Turbo script that is a compliance check, or an inventory JMESPath check was linked to the check itself and not to its compliance check. A query for the events of a compliance check found only a part of them. The five models declare it in `linked_objects_keys_for_event()` now.

The Osquery query and the Turbo script declare it only when they have one, because they are compliance checks only when the user asks for it.

These are the five models that have a compliance check and views that publish an audit event. `MachineStatus` has one too, and it is the result of a check on a machine and not a check, so it keeps no link.

The test of the creation of a compliance check query published no event assertion, so the link of the Osquery query has a new one.

Two object keys were also corrected, and one of them was a real defect:

| model | key before | key now |
|---|---|---|
| `ComplianceCheck` | `compliance_checks_compliance_check` | `compliance_check` |
| `JMESPathCheck` | `jmes_path_check` | `inventory_jmespath_check` |

The events page of a JMESPath check asks for `inventory_jmespath_check`. Without this correction, the audit events of the check would go to a key that no page reads, and the page would show nothing, with no error.

**A behaviour that was called deliberate is reversed.** The Turbo test of a script with a tag and a compliance check said the audit event links the tag and "deliberately NOT the compliance check". That comment came with the Turbo test suite in `dd2e569f`, it gives no reason, and no other compliance check makes that difference. The five checks behave the same way now.

**A link that did the same work two times is removed.** The Turbo script also declared a link to itself. `AuditEvent.build()` adds the link to the object of the event when `linked_objects_keys_for_event()` gives no link to it, and the key that it computes for the model is `turbo_script` — the key that the line wrote. The Turbo tests that compare the full `objects` dictionary of the event show that the result is the same.

Nine other models declare a link to themselves in the same way, and they are not a part of this change: `mdm.DEPDevice`, `monolith.PkgInfoName`, `monolith.PkgInfo`, `monolith.SubManifestPkgInfo`, `osquery.ConfigurationPack`, `osquery.Enrollment`, `turbo.Enrollment`, `turbo.RecurringJob` and `turbo.OneTimeJob`. `mdm.DeviceCommand` also declares one, but that one is necessary: it links itself by uuid and not by pk, which is the reason why `build()` lets a model keep control of its own key.

### 2. The JMESPath check views publish audit events

The six views — three of the console, three of the API — publish `zentral_audit` events, and the three event types are removed.

The two views of the console drive two forms each, so they call `post_audit_event()`, like the Osquery enrollment views. On the update, the previous value is read in `dispatch()`: a `ModelForm` writes the posted data onto its instance while it validates, so a value read in `forms_valid()` is the new one. The update still publishes an event only when a form changed.

The delete of the API deleted the compliance check and let the cascade remove the JMESPath check. `JMESPathCheck.delete()` does that now, like `ScriptCheck.delete()` in Munki, so the views only delete the object and the shared bases publish the event.

### Tests

The events of the console views had no test at all. The three tests of the console check the audit event now:

- the create and the delete check that the event still reaches the compliance check,
- the delete checks that the compliance check goes with the JMESPath check,
- the update checks that the previous value is not the new one, which is the only way to find the `ModelForm` trap.

The full test suite, as CI does it: **8028 tests, OK**. All the added lines in `zentral/` have test coverage: 45 added lines, and 0 lines without coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

