### PR TITLE
Publish audit events from the munki and santa console enrollment views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The Monolith API publishes the same `zentral_audit` events as the web console no
 
 The Munki API publishes the same `zentral_audit` events as the web console now, for the enrollments.
 
+The Munki web console publishes a `zentral_audit` event when a user creates an enrollment, deletes an enrollment, or increases the version of an enrollment. These three changes had no record.
+
+The audit events of a Munki enrollment are also on the page of its configuration now, like the Osquery, Santa and Turbo enrollments. The Munki enrollment gave no link to its configuration, so its events were only on the enrollment.
+
 
 #### Osquery
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ The Osquery API publishes the same `zentral_audit` events as the web console now
 
 The Santa API publishes the same `zentral_audit` events as the web console now, for the enrollments.
 
+The Santa web console publishes a `zentral_audit` event when a user creates an enrollment. This change had no record.
+
 A clean sync — `CLEAN` or `CLEAN_ALL` — can be queued for an enrolled machine from its machine page or from the API, and cancelled before its next preflight. The new `Santa::Action::"forceCleanSync"` PBAC action gives the permission, and accepts a meta business unit and a sync type.
 
 New `/api/santa/enrolled_machines/` endpoint.

--- a/tests/munki/test_setup_views.py
+++ b/tests/munki/test_setup_views.py
@@ -14,7 +14,8 @@ from zentral.contrib.munki.models import Enrollment
 from zentral.core.events.base import AuditEvent
 from zentral.core.stores.conf import stores
 from zentral.utils.provisioning import provision
-from .utils import force_configuration, force_enrollment, force_script_check, make_enrolled_machine
+from .utils import (assert_audit_event, assert_no_enrollment_secret, force_configuration,
+                    force_enrollment, force_script_check, make_enrolled_machine)
 
 
 class MunkiSetupViewsTestCase(TestCase, LoginCase):
@@ -374,18 +375,29 @@ class MunkiSetupViewsTestCase(TestCase, LoginCase):
         self.assertFormError(response.context["enrollment_form"], "configuration",
                              "Select a valid choice. That choice is not one of the available choices.")
 
-    def test_create_enrollment_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_enrollment_post(self, post_event):
         configuration = force_configuration()
         self.login("munki.add_enrollment", "munki.view_configuration", "munki.view_enrollment")
-        response = self.client.post(reverse("munki:create_enrollment", args=(configuration.pk,)),
-                                    {"configuration": configuration.pk,
-                                     "secret-meta_business_unit": self.mbu.pk}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("munki:create_enrollment", args=(configuration.pk,)),
+                                        {"configuration": configuration.pk,
+                                         "secret-meta_business_unit": self.mbu.pk}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "munki/configuration_detail.html")
         enrollment = response.context["enrollments"][0][0]
         self.assertEqual(enrollment.configuration, configuration)
         self.assertEqual(enrollment.secret.meta_business_unit, self.mbu)
         self.assertContains(response, enrollment.secret.meta_business_unit.name)
+        self.assertEqual(len(callbacks), 1)
+        payload, metadata = assert_audit_event(self, post_event, "created", enrollment)
+        self.assertEqual(metadata["objects"],
+                         {"munki_enrollment": [str(enrollment.pk)],
+                          "munki_configuration": [str(configuration.pk)]})
+        self.assertEqual(payload["object"]["new_value"]["version"], 1)
+        self.assertEqual(payload["object"]["new_value"]["configuration"],
+                         {"pk": configuration.pk, "name": configuration.name})
+        assert_no_enrollment_secret(self, payload, enrollment)
 
     # bump enrollment version
 
@@ -408,17 +420,28 @@ class MunkiSetupViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "munki/enrollment_confirm_version_bump.html")
 
-    def test_bump_enrollment_version_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_bump_enrollment_version_post(self, post_event):
         enrollment = force_enrollment(meta_business_unit=self.mbu)
         version = enrollment.version
+        prev_value = enrollment.serialize_for_event()
         self.login("munki.change_enrollment", "munki.view_configuration")
-        response = self.client.post(reverse("munki:bump_enrollment_version",
-                                            args=(enrollment.configuration.pk, enrollment.pk)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("munki:bump_enrollment_version",
+                                                args=(enrollment.configuration.pk, enrollment.pk)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "munki/configuration_detail.html")
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.version, version + 1)
+        self.assertEqual(len(callbacks), 1)
+        payload, metadata = assert_audit_event(self, post_event, "updated", enrollment, prev_value=prev_value)
+        self.assertEqual(metadata["objects"],
+                         {"munki_enrollment": [str(enrollment.pk)],
+                          "munki_configuration": [str(enrollment.configuration.pk)]})
+        self.assertEqual(payload["object"]["prev_value"]["version"], version)
+        self.assertEqual(payload["object"]["new_value"]["version"], version + 1)
+        assert_no_enrollment_secret(self, payload, enrollment)
 
     # delete enrollment
 
@@ -441,17 +464,27 @@ class MunkiSetupViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "munki/enrollment_confirm_delete.html")
 
-    def test_delete_enrollment_post(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_delete_enrollment_post(self, post_event):
         enrollment = force_enrollment(meta_business_unit=self.mbu)
+        prev_value = enrollment.serialize_for_event()
         self.login("munki.delete_enrollment", "munki.view_configuration")
-        response = self.client.post(reverse("munki:delete_enrollment",
-                                            args=(enrollment.configuration.pk, enrollment.pk)),
-                                    follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("munki:delete_enrollment",
+                                                args=(enrollment.configuration.pk, enrollment.pk)),
+                                        follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "munki/configuration_detail.html")
         ctx_configuration = response.context["configuration"]
         self.assertEqual(ctx_configuration, enrollment.configuration)
         self.assertEqual(ctx_configuration.enrollment_set.filter(pk=enrollment.pk).count(), 0)
+        self.assertEqual(len(callbacks), 1)
+        payload, metadata = assert_audit_event(self, post_event, "deleted", enrollment, prev_value=prev_value)
+        self.assertEqual(metadata["objects"],
+                         {"munki_enrollment": [str(enrollment.pk)],
+                          "munki_configuration": [str(enrollment.configuration.pk)]})
+        self.assertNotIn("new_value", payload["object"])
+        assert_no_enrollment_secret(self, payload, enrollment)
 
     def test_delete_enrollment_distributor_404(self):
         enrollment = force_enrollment(meta_business_unit=self.mbu)

--- a/tests/munki/utils.py
+++ b/tests/munki/utils.py
@@ -1,3 +1,4 @@
+import json
 from django.utils.crypto import get_random_string
 
 from zentral.core.events.base import AuditEvent
@@ -104,3 +105,12 @@ def assert_audit_event(test_case, post_event, action, instance, prev_value=None,
     metadata = event.metadata.serialize()
     test_case.assertEqual(sorted(metadata["tags"]), ["munki", "zentral"])
     return event.payload, metadata
+
+
+def assert_no_enrollment_secret(test_case, payload, enrollment):
+    """EnrollmentSecret.serialize_for_event() leaves the secret out on purpose.
+
+    The secret is the credential that enrolls a machine, so a regression there puts a live
+    credential in every event store.
+    """
+    test_case.assertNotIn(enrollment.secret.secret, json.dumps(payload))

--- a/tests/santa/test_setup_views.py
+++ b/tests/santa/test_setup_views.py
@@ -21,6 +21,8 @@ from zentral.utils.provisioning import provision
 from zentral.utils.time import naive_utcnow
 
 from .utils import (
+    assert_audit_event,
+    assert_no_enrollment_secret,
     force_configuration,
     force_realm,
     force_realm_group,
@@ -630,13 +632,15 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
         # no view enrollment perm!
         self.assertNotIn("enrollments", response.context)
 
-    def test_post_create_enrollment_view(self):
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_post_create_enrollment_view(self, post_event):
         configuration = force_configuration()
         self.mbu.create_enrollment_business_unit()
         self.login("santa.add_enrollment", "santa.view_enrollment", "santa.view_configuration")
-        response = self.client.post(reverse("santa:create_enrollment", args=(configuration.pk,)),
-                                    {"secret-meta_business_unit": self.mbu.pk,
-                                     "configuration": configuration.pk}, follow=True)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("santa:create_enrollment", args=(configuration.pk,)),
+                                        {"secret-meta_business_unit": self.mbu.pk,
+                                         "configuration": configuration.pk}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "santa/configuration_detail.html")
         self.assertEqual(response.context["object"], configuration)
@@ -646,6 +650,15 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, enrollment.secret.meta_business_unit.name)
         self.assertContains(response, reverse("santa_api:enrollment_plist", args=(enrollment.pk,)))
         self.assertContains(response, reverse("santa_api:enrollment_configuration_profile", args=(enrollment.pk,)))
+        self.assertEqual(len(callbacks), 1)
+        payload, metadata = assert_audit_event(self, post_event, "created", enrollment)
+        self.assertEqual(metadata["objects"],
+                         {"santa_enrollment": [str(enrollment.pk)],
+                          "santa_configuration": [str(configuration.pk)]})
+        self.assertEqual(payload["object"]["new_value"]["version"], 1)
+        self.assertEqual(payload["object"]["new_value"]["configuration"],
+                         {"pk": configuration.pk, "name": configuration.name})
+        assert_no_enrollment_secret(self, payload, enrollment)
 
     def test_enrollment_plist_permission_denied(self):
         _, enrollment = self._force_enrollment()

--- a/tests/santa/utils.py
+++ b/tests/santa/utils.py
@@ -565,3 +565,12 @@ def assert_audit_event(test_case, post_event, action, instance, prev_value=None,
     metadata = event.metadata.serialize()
     test_case.assertEqual(sorted(metadata["tags"]), ["santa", "zentral"])
     return event.payload, metadata
+
+
+def assert_no_enrollment_secret(test_case, payload, enrollment):
+    """EnrollmentSecret.serialize_for_event() leaves the secret out on purpose.
+
+    The secret is the credential that enrolls a machine, so a regression there puts a live
+    credential in every event store.
+    """
+    test_case.assertNotIn(enrollment.secret.secret, json.dumps(payload))

--- a/zentral/contrib/munki/models.py
+++ b/zentral/contrib/munki/models.py
@@ -130,6 +130,10 @@ class Enrollment(BaseEnrollment):
         enrollment_dict["configuration"] = self.configuration.serialize_for_event(keys_only=True)
         return enrollment_dict
 
+    def linked_objects_keys_for_event(self):
+        # the events of an enrollment are also on the page of its configuration
+        return {"munki_configuration": ((self.configuration_id,),)}
+
 
 class EnrolledMachine(models.Model):
     enrollment = models.ForeignKey(Enrollment, on_delete=models.CASCADE)

--- a/zentral/contrib/munki/views.py
+++ b/zentral/contrib/munki/views.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.db.models import F, Count
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
-from django.views.generic import DeleteView, DetailView, ListView, TemplateView, View
+from django.views.generic import DetailView, ListView, TemplateView, View
 from zentral.contrib.inventory.forms import EnrollmentSecretForm
 from zentral.contrib.inventory.models import MetaMachine
 from zentral.core.compliance_checks.forms import ComplianceCheckForm
@@ -16,7 +16,8 @@ from zentral.core.stores.conf import stores
 from zentral.core.stores.views import EventsView, FetchEventsView, EventsStoreRedirectView
 from zentral.utils.terraform import build_config_response
 from zentral.utils.text import encode_args
-from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
+from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, post_audit_event,
+                                 UpdateViewWithAudit, UserPaginationListView)
 from .compliance_checks import MunkiScriptCheck
 from .forms import ConfigurationForm, EnrollmentForm, ScriptCheckForm, ScriptCheckSearchForm
 from .models import Configuration, Enrollment, MunkiState, PrincipalUserDetectionSource, ScriptCheck
@@ -194,6 +195,7 @@ class CreateEnrollmentView(PermissionRequiredMixin, TemplateView):
         enrollment.secret = secret
         enrollment.configuration = self.configuration
         enrollment.save()
+        post_audit_event(self.request, enrollment, AuditEvent.Action.CREATED)
         return redirect(enrollment)
 
     def post(self, request, *args, **kwargs):
@@ -204,7 +206,7 @@ class CreateEnrollmentView(PermissionRequiredMixin, TemplateView):
             return self.forms_invalid(secret_form, enrollment_form)
 
 
-class DeleteEnrollmentView(PermissionRequiredMixin, DeleteView):
+class DeleteEnrollmentView(PermissionRequiredMixin, DeleteViewWithAudit):
     permission_required = "munki.delete_enrollment"
 
     def get_queryset(self):
@@ -243,7 +245,9 @@ class EnrollmentBumpVersionView(PermissionRequiredMixin, TemplateView):
         return ctx
 
     def post(self, request, *args, **kwargs):
+        prev_value = self.enrollment.serialize_for_event()
         self.enrollment.save()  # will bump the version
+        post_audit_event(request, self.enrollment, AuditEvent.Action.UPDATED, prev_value=prev_value)
         return redirect(self.enrollment)
 
 

--- a/zentral/contrib/santa/views/setup.py
+++ b/zentral/contrib/santa/views/setup.py
@@ -18,11 +18,13 @@ from zentral.contrib.santa.forms import (BinarySearchForm,
                                          RuleForm, RuleSearchForm, UpdateRuleForm)
 from zentral.contrib.santa.models import Configuration, Enrollment, Rule, Target, VotingGroup
 from zentral.contrib.santa.terraform import iter_resources
+from zentral.core.events.base import AuditEvent
 from zentral.core.stores.conf import stores
 from zentral.core.stores.views import EventsView, FetchEventsView, EventsStoreRedirectView
 from zentral.utils.terraform import build_config_response
 from zentral.utils.text import encode_args
-from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
+from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, post_audit_event,
+                                 UpdateViewWithAudit, UserPaginationListView)
 
 
 logger = logging.getLogger('zentral.contrib.santa.views.setup')
@@ -238,6 +240,7 @@ class CreateEnrollmentView(PermissionRequiredMixin, TemplateView):
         if self.configuration:
             enrollment.configuration = self.configuration
         enrollment.save()
+        post_audit_event(self.request, enrollment, AuditEvent.Action.CREATED)
         return HttpResponseRedirect(enrollment.get_absolute_url())
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
## What this does

The web console publishes a `zentral_audit` event for the enrollment changes that had no record. Munki and santa were the last two modules without them.

| module | view | before | now |
|---|---|---|---|
| munki | create enrollment | no event | `created` |
| munki | delete enrollment | no event | `deleted` |
| munki | bump enrollment version | no event | `updated` |
| santa | create enrollment | no event | `created` |

The other modules already do this: the six MDM enrollment views (DEP, OTA and user, create and update), osquery and turbo.

## How

The create views and the munki bump version view drive two forms, so they are plain `TemplateView`s and not the audited `CreateView`. They use `post_audit_event()`, like the osquery and MDM equivalents. The munki delete view moves from `DeleteView` to `DeleteViewWithAudit`.

The bump version view serializes the enrollment before the save, to give the `prev_value`.

## Why the API entries in the changelog were not the full story

#1648 gave the audit events to the munki and santa enrollment API endpoints. The changelog said that the API publishes "the same events as the web console". For the create, the delete and the version bump, the console published nothing, so there was nothing to be the same as. This change makes the sentence true.

## The munki enrollment gave no linked objects

`munki.Enrollment` declared no `linked_objects_keys_for_event()` at all, so its audit events were only on the page of the enrollment. The osquery, santa and turbo enrollments each give their configuration, so the events of an enrollment are on the page of the configuration too. The munki enrollment gives it now, with the key `munki_configuration` that the configuration events page reads.

It gives no link to itself. `AuditEvent.build()` adds the link to the object of the event when `linked_objects_keys_for_event()` gives no link to it, and the key that it computes, `munki_enrollment`, is correct. The osquery and turbo enrollments still write their own key, which does the same work two times; they are not a part of this change.

## Tests

The four tests that already exercised these views now assert the event: the action, the model, the pk, the payload and the tags.

Each test also asserts that the enrollment secret does not appear in the payload. `EnrollmentSecret.serialize_for_event()` leaves the secret out on purpose, because the secret is the credential that enrolls a machine: a regression there puts a live credential in each event store. The MDM enrollment audit tests make the same check.

- full suite: 8028 tests, OK (the count does not change, because the four tests already existed)
- the four tests compare the full `objects` dictionary of the event, and not only the payload
- `tests.munki` and `tests.santa`: 1111 tests, OK
- patch coverage: 11 added executable lines in `zentral/`, 0 uncovered
