### PR TITLE
Remove the redundant self keys of the linked objects

### DIFF
--- a/tests/core_events/test_audit_event_objects.py
+++ b/tests/core_events/test_audit_event_objects.py
@@ -1,4 +1,7 @@
-from django.test import TestCase
+import inspect
+import re
+from django.apps import apps
+from django.test import SimpleTestCase, TestCase
 from zentral.core.events.base import AuditEvent, linked_objects_key
 
 
@@ -64,3 +67,34 @@ class AuditEventObjectsTestCase(TestCase):
 
     def test_a_renamed_key_is_used_for_the_object(self):
         self.assertEqual(self._objects(RenamedKeyInstance(4)), {"accounts_oidc_api_token_issuer": [(4,)]})
+
+
+# a model writes its own key with its own pk in one of these two spellings
+OWN_PK = r"(\[\(self\.pk,\)\]|\(\(self\.pk,\),\))"
+
+
+class RedundantSelfKeysTestCase(SimpleTestCase):
+    """AuditEvent.build() links the object of the event on its own.
+
+    A model that writes its own key with its own pk in linked_objects_keys_for_event() does the
+    same work a second time. A model that writes its own key with something else keeps control of
+    it — the MDM device commands link themselves by uuid — so only the pk spelling is a defect.
+    """
+
+    def iter_hooks(self):
+        for model in apps.get_models():
+            hook = getattr(model, "linked_objects_keys_for_event", None)
+            if hook is not None:
+                yield model, hook
+
+    def test_the_traversal_finds_the_hooks(self):
+        """A guard that stops traversing passes for the wrong reason."""
+        self.assertGreater(len(list(self.iter_hooks())), 10)
+
+    def test_no_model_writes_its_own_key_with_its_own_pk(self):
+        offenders = []
+        for model, hook in self.iter_hooks():
+            own_key = linked_objects_key(model)
+            if re.search(rf'"{re.escape(own_key)}":\s*{OWN_PK}', inspect.getsource(hook)):
+                offenders.append(f"{model._meta.label} {own_key}")
+        self.assertEqual(sorted(offenders), [])

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -2247,8 +2247,7 @@ class DEPDevice(models.Model):
         return MetaMachine(self.serial_number).get_urlsafe_serial_number()
 
     def linked_objects_keys_for_event(self):
-        keys = {"mdm_dep_device": [(self.pk,)],
-                "mdm_dep_virtual_server": [(self.virtual_server.pk,)]}
+        keys = {"mdm_dep_virtual_server": [(self.virtual_server.pk,)]}
         if self.enrollment:
             keys["mdm_dep_enrollment"] = [(self.enrollment.pk,)]
         return keys

--- a/zentral/contrib/monolith/models.py
+++ b/zentral/contrib/monolith/models.py
@@ -312,7 +312,7 @@ class PkgInfoName(models.Model):
 
     # TODO: reevaluate for backward compatibility
     def linked_objects_keys_for_event(self):
-        return {"monolith_pkg_info_name": ((self.pk,),), "munki_pkginfo_name": ((self.name,),)}
+        return {"munki_pkginfo_name": ((self.name,),)}
 
 
 class PkgInfoManager(models.Manager):
@@ -577,7 +577,6 @@ class PkgInfo(models.Model):
     def linked_objects_keys_for_event(self):
         return {"munki_pkginfo_name": ((self.name.name,),),
                 "munki_pkginfo": ((self.name.name, self.version),),
-                "monolith_pkg_info": [(self.pk,)],
                 "monolith_pkg_info_name": [(self.name.pk,)],
                 "monolith_repository": [(self.repository.pk,)]}
 
@@ -876,8 +875,7 @@ class SubManifestPkgInfo(models.Model):
         return d
 
     def linked_objects_keys_for_event(self):
-        return {"monolith_sub_manifest_pkg_info": [(self.pk,)],
-                "monolith_sub_manifest": [(self.sub_manifest.pk,)],
+        return {"monolith_sub_manifest": [(self.sub_manifest.pk,)],
                 "monolith_pkg_info_name": [(self.pkg_info_name.pk,)]}
 
 

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -591,8 +591,7 @@ class ConfigurationPack(models.Model):
         }
 
     def linked_objects_keys_for_event(self):
-        return {"osquery_configuration_pack": ((self.pk,),),
-                "osquery_configuration": ((self.configuration_id,),),
+        return {"osquery_configuration": ((self.configuration_id,),),
                 "osquery_pack": ((self.pack_id,),)}
 
 
@@ -614,8 +613,7 @@ class Enrollment(BaseEnrollment):
         return enrollment_dict
 
     def linked_objects_keys_for_event(self):
-        return {"osquery_enrollment": ((self.pk,),),
-                "osquery_configuration": ((self.configuration_id,),)}
+        return {"osquery_configuration": ((self.configuration_id,),)}
 
     def get_absolute_url(self):
         return "{}#enrollment_{}".format(reverse("osquery:configuration", args=(self.configuration.pk,)), self.pk)

--- a/zentral/contrib/turbo/models.py
+++ b/zentral/contrib/turbo/models.py
@@ -139,11 +139,8 @@ class Enrollment(BaseEnrollment):
         return enrollment_dict
 
     def linked_objects_keys_for_event(self):
-        # link both the enrollment and its configuration, so enrollment audit events surface under the config too
-        return {
-            "turbo_enrollment": [(self.pk,)],
-            "turbo_configuration": [(self.configuration_id,)],
-        }
+        # the events of an enrollment are also on the page of its configuration
+        return {"turbo_configuration": [(self.configuration_id,)]}
 
     def can_be_updated(self):
         return Enrollment.objects.can_be_updated().filter(pk=self.pk).exists()
@@ -572,10 +569,7 @@ class RecurringJob(JobScope):
         return d
 
     def linked_objects_keys_for_event(self):
-        keys = {
-            "turbo_recurring_job": [(self.pk,)],
-            "turbo_configuration": [(self.configuration_id,)],
-        }
+        keys = {"turbo_configuration": [(self.configuration_id,)]}
         keys.update(self.job.definition_linked_objects_keys())
         return keys
 
@@ -622,10 +616,7 @@ class OneTimeJob(JobScope):
         return d
 
     def linked_objects_keys_for_event(self):
-        keys = {
-            "turbo_one_time_job": [(self.pk,)],
-            "turbo_configuration": [(self.configuration_id,)],
-        }
+        keys = {"turbo_configuration": [(self.configuration_id,)]}
         keys.update(self.job.definition_linked_objects_keys())
         return keys
 


### PR DESCRIPTION
## What this does

`AuditEvent.build()` links the object of the event when `linked_objects_keys_for_event()` gives no link to it. Nine models wrote their own key with their own pk, which is the value that `build()` computes, so the line did the same work a second time.

| module | models |
|---|---|
| mdm | `DEPDevice` |
| monolith | `PkgInfoName`, `PkgInfo`, `SubManifestPkgInfo` |
| osquery | `ConfigurationPack`, `Enrollment` |
| turbo | `Enrollment`, `RecurringJob`, `OneTimeJob` |

Each model keeps the links to its parents. Only the link to itself goes away.

## One model keeps its self key

`mdm.DeviceCommand` also writes its own key, and it keeps it: it links itself by uuid and not by pk. That is the reason why `build()` lets a model keep control of its own key, and the comment in `zentral/core/events/base.py` gives it as the example.

## Why the events do not change

`linked_objects_keys_for_event()` has two callers only: `AuditEvent.build()`, which supplies the missing self key, and `DeviceCommand`, which calls `super()` on its own parent. No serializer and no view reads the hook, so there is no other path where the removed line did work.

The tests of the four modules compare the full `objects` dictionary of the event, so they show the result directly. `tests/turbo/test_api_recurring_jobs.py` compares the set of the keys and finds `turbo_recurring_job` in it, and `tests/munki/test_api_views.py` compares the whole dictionary. They pass with no change.

There is no changelog entry, because a user sees no difference.

## The new test

`tests/core_events/test_audit_event_objects.py` walks the models and finds a model that writes its own key with its own pk.

The test reads the source of the hook, because the hook needs an instance to run. It finds the two spellings that the code uses, `[(self.pk,)]` and `((self.pk,),)`, and not every possible one — it is a guard and not a proof. `mdm.DeviceCommand` needs no exception in it, because the rule is the pk spelling and that model writes `str(self.uuid)`.

A second test makes sure that the traversal finds the hooks. A guard that stops traversing passes for the wrong reason.

To show that the guard works, I put one self key back and ran it: it failed with `['osquery.Enrollment osquery_enrollment'] != []`.

## Tests

- full suite: 8030 tests, OK (8028 before, plus the two new ones)
- patch coverage: 8 added executable lines in `zentral/`, 0 uncovered
