### PR TITLE
Set the Redis socket timeouts and health check interval on the notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `
 ### Bug fixes
 
 
+The notifier sets a connect timeout and a socket timeout on its Redis client now. Without them the socket stays in blocking mode: a Redis server that stops answering and does not close the connection, a managed Redis during a failover for example, blocked a notification for ever in the middle of a web request. The client raises an error now, and the notifier reconnects.
+
 Fixed the `zentral_audit` events of the Santa enrollments and the Santa enrolled machines, which were not linked to the object they report. A model that declares the parents of an object replaced the link to the object itself, and the events of that object did not reach its page. A model keeps control of its own key when it declares one, because the MDM commands are linked by UUID and not by primary key.
 
 Fixed the version of an Osquery query in the events published when a user changed the query from the web console. The version was a database expression, and not a number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `
 ### Bug fixes
 
 
-The notifier sets a connect timeout and a socket timeout on its Redis client now. Without them the socket stays in blocking mode: a Redis server that stops answering and does not close the connection, a managed Redis during a failover for example, blocked a notification for ever in the middle of a web request. The client raises an error now, and the notifier reconnects.
+The notifier sets a connect timeout, a socket timeout and a health check interval on its Redis client now. Without the timeouts the socket stays in blocking mode: a Redis server that stops answering and does not close the connection, a managed Redis during a failover for example, blocked a notification for ever in the middle of a web request. The health check interval covers the listener thread, which reads only, and which stayed silent for ever on the same connection because a read that times out there does not give an error. The listener sends a periodic PING now, and the write that fails is what makes the notifier reconnect. Zentral applies configuration changes on the probes, the event stores and the Monolith repositories again after this failure, and not only after a restart.
 
 Fixed the `zentral_audit` events of the Santa enrollments and the Santa enrolled machines, which were not linked to the object they report. A model that declares the parents of an object replaced the link to the object itself, and the events of that object did not reach its page. A model keeps control of its own key when it declares one, because the MDM commands are linked by UUID and not by primary key.
 

--- a/server/base/notifier.py
+++ b/server/base/notifier.py
@@ -18,6 +18,9 @@ class Notifier:
     # raised for their except blocks to catch.
     _socket_connect_timeout = 3.0
     _socket_timeout = 3.0
+    # The listener only reads, and can_read() returns False instead of raising, so only
+    # this PING write finds a dead connection. Useless without _socket_timeout.
+    _health_check_interval = 30
 
     def __init__(self, config):
         self._client = None
@@ -51,6 +54,7 @@ class Notifier:
             "decode_responses": True,
             "socket_connect_timeout": self._socket_connect_timeout,
             "socket_timeout": self._socket_timeout,
+            "health_check_interval": self._health_check_interval,
         }
 
     def _get_client(self):

--- a/server/base/notifier.py
+++ b/server/base/notifier.py
@@ -13,6 +13,11 @@ logger = logging.getLogger("server.base.notifier")
 
 class Notifier:
     _reconnection_delay_range = (1.0, 3.0)
+    # Unset, redis-py blocks for ever on a server that stops answering without closing
+    # the connection: send_notification() and subscribe() deadlock, and nothing is
+    # raised for their except blocks to catch.
+    _socket_connect_timeout = 3.0
+    _socket_timeout = 3.0
 
     def __init__(self, config):
         self._client = None
@@ -44,6 +49,8 @@ class Notifier:
             "username": config.get("username"),
             "password": config.get("password"),
             "decode_responses": True,
+            "socket_connect_timeout": self._socket_connect_timeout,
+            "socket_timeout": self._socket_timeout,
         }
 
     def _get_client(self):

--- a/tests/server_base/test_notifier.py
+++ b/tests/server_base/test_notifier.py
@@ -34,3 +34,7 @@ class TestNotifierKwargs(SimpleTestCase):
         notifier = Notifier(None)
         self.assertEqual(notifier._kwargs["socket_connect_timeout"], 3.0)
         self.assertEqual(notifier._kwargs["socket_timeout"], 3.0)
+
+    def test_health_check_interval(self):
+        notifier = Notifier(None)
+        self.assertEqual(notifier._kwargs["health_check_interval"], 30)

--- a/tests/server_base/test_notifier.py
+++ b/tests/server_base/test_notifier.py
@@ -1,5 +1,8 @@
+import gc
+import weakref
+from unittest.mock import call, patch, Mock
 from django.test import SimpleTestCase
-from base.notifier import Notifier
+from base.notifier import build_notifier, Notifier
 
 
 class TestNotifierKwargs(SimpleTestCase):
@@ -38,3 +41,211 @@ class TestNotifierKwargs(SimpleTestCase):
     def test_health_check_interval(self):
         notifier = Notifier(None)
         self.assertEqual(notifier._kwargs["health_check_interval"], 30)
+
+
+class CallbackHolder:
+    def __init__(self):
+        self.calls = []
+
+    def callback(self, data):
+        self.calls.append(data)
+
+
+class TestNotifier(SimpleTestCase):
+    maxDiff = None
+
+    def build_notifier(self):
+        notifier = Notifier(None)
+        patcher = patch("base.notifier.redis")
+        redis = patcher.start()
+        self.addCleanup(patcher.stop)
+        return notifier, redis
+
+    # _get_client / _get_pubsub
+
+    def test_get_client_is_built_once(self):
+        notifier, redis = self.build_notifier()
+        self.assertIs(notifier._get_client(), notifier._get_client())
+        redis.Redis.assert_called_once_with(**notifier._kwargs)
+
+    def test_get_pubsub_is_built_once(self):
+        notifier, redis = self.build_notifier()
+        self.assertIs(notifier._get_pubsub(), notifier._get_pubsub())
+        redis.Redis.return_value.pubsub.assert_called_once_with(ignore_subscribe_messages=True)
+
+    # _subscribe
+
+    def test_subscribe_starts_the_thread_once(self):
+        notifier, redis = self.build_notifier()
+        pubsub = redis.Redis.return_value.pubsub.return_value
+        notifier._subscribe("yolo")
+        pubsub.subscribe.assert_called_once_with(yolo=notifier._message_handler)
+        self.assertIs(notifier._thread, pubsub.run_in_thread.return_value)
+        notifier._subscribe("fomo")
+        pubsub.run_in_thread.assert_called_once()
+        self.assertEqual(pubsub.subscribe.call_args_list[-1], call(fomo=notifier._message_handler))
+
+    # _message_handler
+
+    def test_message_handler_unknown_channel(self):
+        notifier, _ = self.build_notifier()
+        with self.assertLogs("server.base.notifier", level="ERROR") as cm:
+            notifier._message_handler({"channel": "yolo", "data": "fomo"})
+        self.assertIn("ERROR:server.base.notifier:Unknown channel: yolo", cm.output)
+
+    def test_message_handler_plain_callback(self):
+        notifier, _ = self.build_notifier()
+        holder = CallbackHolder()
+        notifier._callbacks["yolo"] = [holder.callback]
+        notifier._message_handler({"channel": "yolo", "data": "fomo"})
+        self.assertEqual(holder.calls, ["fomo"])
+
+    def test_message_handler_live_weakref_callback(self):
+        notifier, _ = self.build_notifier()
+        holder = CallbackHolder()
+        notifier._callbacks["yolo"] = [weakref.WeakMethod(holder.callback)]
+        notifier._message_handler({"channel": "yolo", "data": "fomo"})
+        self.assertEqual(holder.calls, ["fomo"])
+        self.assertEqual(len(notifier._callbacks["yolo"]), 1)
+
+    def test_message_handler_removes_dead_weakref_callback(self):
+        notifier, _ = self.build_notifier()
+        holder = CallbackHolder()
+        notifier._callbacks["yolo"] = [weakref.WeakMethod(holder.callback)]
+        del holder
+        gc.collect()
+        notifier._message_handler({"channel": "yolo", "data": "fomo"})
+        self.assertEqual(notifier._callbacks["yolo"], [])
+
+    # _schedule_reconnect
+
+    def test_schedule_reconnect_starts_a_timer(self):
+        notifier, _ = self.build_notifier()
+        with patch("base.notifier.threading.Timer") as timer:
+            notifier._schedule_reconnect()
+            timer.assert_called_once()
+            timer.return_value.start.assert_called_once()
+        self.assertIs(notifier._reconnect_timer, timer.return_value)
+
+    def test_schedule_reconnect_keeps_the_current_timer(self):
+        notifier, _ = self.build_notifier()
+        current_timer = Mock()
+        notifier._reconnect_timer = current_timer
+        with patch("base.notifier.threading.Timer") as timer:
+            notifier._schedule_reconnect()
+            timer.assert_not_called()
+        self.assertIs(notifier._reconnect_timer, current_timer)
+
+    def test_schedule_reconnect_forced_replaces_the_current_timer(self):
+        notifier, _ = self.build_notifier()
+        notifier._reconnect_timer = Mock()
+        with patch("base.notifier.threading.Timer") as timer:
+            notifier._schedule_reconnect(force=True)
+            timer.assert_called_once()
+        self.assertIs(notifier._reconnect_timer, timer.return_value)
+
+    # _reconnect
+
+    def test_reconnect(self):
+        notifier, redis = self.build_notifier()
+        notifier._callbacks["yolo"] = [Mock()]
+        pubsub = redis.Redis.return_value.pubsub.return_value
+        notifier._pubsub = pubsub
+        notifier._reconnect_timer = Mock()
+        with self.assertLogs("server.base.notifier", level="INFO") as cm:
+            notifier._reconnect()
+        pubsub.close.assert_called_once()
+        pubsub.subscribe.assert_called_once_with(yolo=notifier._message_handler)
+        self.assertIsNone(notifier._reconnect_timer)
+        self.assertIn("INFO:server.base.notifier:Reconnected", cm.output)
+
+    def test_reconnect_without_pubsub(self):
+        notifier, redis = self.build_notifier()
+        notifier._reconnect()
+        redis.Redis.return_value.pubsub.return_value.close.assert_not_called()
+
+    def test_reconnect_error_is_rescheduled(self):
+        notifier, redis = self.build_notifier()
+        notifier._callbacks["yolo"] = [Mock()]
+        pubsub = redis.Redis.return_value.pubsub.return_value
+        notifier._pubsub = pubsub
+        pubsub.subscribe.side_effect = Exception("boom")
+        with patch("base.notifier.threading.Timer") as timer:
+            with self.assertLogs("server.base.notifier", level="ERROR") as cm:
+                notifier._reconnect()
+            timer.assert_called_once()
+        self.assertIn("ERROR:server.base.notifier:Could not reconnect: boom", cm.output)
+
+    # _exception_handler
+
+    def test_exception_handler_stops_the_thread(self):
+        notifier, _ = self.build_notifier()
+        thread = Mock()
+        notifier._thread = thread
+        with patch("base.notifier.threading.Timer"):
+            with self.assertLogs("server.base.notifier", level="ERROR") as cm:
+                notifier._exception_handler(Exception("boom"), Mock(), thread)
+        thread.stop.assert_called_once()
+        thread.join.assert_called_once_with(timeout=1.0)
+        self.assertIsNone(notifier._thread)
+        self.assertIn("ERROR:server.base.notifier:Exception: boom", cm.output)
+
+    def test_exception_handler_thread_cannot_be_joined(self):
+        notifier, _ = self.build_notifier()
+        thread = Mock()
+        thread.join.side_effect = RuntimeError
+        notifier._thread = thread
+        with patch("base.notifier.threading.Timer"):
+            with self.assertLogs("server.base.notifier", level="ERROR") as cm:
+                notifier._exception_handler(Exception("boom"), Mock(), thread)
+        self.assertIn("ERROR:server.base.notifier:Cannot join stopping thread", cm.output)
+        self.assertIsNone(notifier._thread)
+
+    def test_exception_handler_without_thread(self):
+        notifier, _ = self.build_notifier()
+        with patch("base.notifier.threading.Timer") as timer:
+            with self.assertLogs("server.base.notifier", level="ERROR"):
+                notifier._exception_handler(Exception("boom"), Mock(), Mock())
+            timer.assert_called_once()
+
+    # add_callback
+
+    def test_add_callback_subscribes_the_first_time_only(self):
+        notifier, redis = self.build_notifier()
+        pubsub = redis.Redis.return_value.pubsub.return_value
+        notifier.add_callback("yolo", Mock())
+        pubsub.subscribe.assert_called_once_with(yolo=notifier._message_handler)
+        notifier.add_callback("yolo", Mock())
+        pubsub.subscribe.assert_called_once()
+        self.assertEqual(len(notifier._callbacks["yolo"]), 2)
+
+    def test_add_callback_subscribe_error_is_rescheduled(self):
+        notifier, redis = self.build_notifier()
+        pubsub = redis.Redis.return_value.pubsub.return_value
+        pubsub.subscribe.side_effect = Exception("boom")
+        with patch("base.notifier.threading.Timer") as timer:
+            with self.assertLogs("server.base.notifier", level="ERROR") as cm:
+                notifier.add_callback("yolo", Mock())
+            timer.assert_called_once()
+        self.assertIn("ERROR:server.base.notifier:Could not subscribe to channel yolo: boom", cm.output)
+        # the callback is kept, the reconnection subscribes again
+        self.assertEqual(len(notifier._callbacks["yolo"]), 1)
+
+    # send_notification
+
+    def test_send_notification(self):
+        notifier, redis = self.build_notifier()
+        notifier.send_notification("yolo", "fomo")
+        redis.Redis.return_value.publish.assert_called_once_with("yolo", "fomo")
+
+    def test_send_notification_error_is_logged(self):
+        notifier, redis = self.build_notifier()
+        redis.Redis.return_value.publish.side_effect = Exception("boom")
+        with self.assertLogs("server.base.notifier", level="ERROR") as cm:
+            notifier.send_notification("yolo")
+        self.assertIn("Could not send notification on channel yolo", "\n".join(cm.output))
+
+    # build_notifier
+
+    def test_build_notifier(self):
+        self.assertIsInstance(build_notifier(), Notifier)

--- a/tests/server_base/test_notifier.py
+++ b/tests/server_base/test_notifier.py
@@ -1,0 +1,36 @@
+from django.test import SimpleTestCase
+from base.notifier import Notifier
+
+
+class TestNotifierKwargs(SimpleTestCase):
+    maxDiff = None
+
+    def test_default_url(self):
+        notifier = Notifier(None)
+        self.assertEqual(notifier._kwargs["host"], "redis")
+        self.assertEqual(notifier._kwargs["port"], 6379)
+        self.assertEqual(notifier._kwargs["db"], 15)
+        self.assertFalse(notifier._kwargs["ssl"])
+
+    def test_url_without_path(self):
+        notifier = Notifier({"url": "redis://redis:6379"})
+        self.assertEqual(notifier._kwargs["db"], 0)
+
+    def test_bad_path(self):
+        with self.assertRaises(ValueError) as cm:
+            Notifier({"url": "redis://redis:6379/yolo"})
+        self.assertEqual(cm.exception.args[0], "Could not parse path")
+
+    def test_tls_scheme(self):
+        notifier = Notifier({"url": "rediss://redis:6379/15"})
+        self.assertTrue(notifier._kwargs["ssl"])
+
+    def test_credentials(self):
+        notifier = Notifier({"url": "redis://redis:6379/15", "username": "un", "password": "pwd"})
+        self.assertEqual(notifier._kwargs["username"], "un")
+        self.assertEqual(notifier._kwargs["password"], "pwd")
+
+    def test_socket_timeouts(self):
+        notifier = Notifier(None)
+        self.assertEqual(notifier._kwargs["socket_connect_timeout"], 3.0)
+        self.assertEqual(notifier._kwargs["socket_timeout"], 3.0)


### PR DESCRIPTION
`Notifier` builds its Redis client with no `socket_timeout`, no `socket_connect_timeout` and no `health_check_interval`. redis-py leaves all three unset by default. The result is that a Redis server which stops answering but does not close the connection breaks the notifier in two different ways, and it recovers from neither. A managed Redis during a failover does exactly this.

Two commits, one for each half. They are in the same pull request because each one is incomplete alone, and because the second is unsafe without the first.

## 1. The socket timeouts

With no timeout redis-py calls `sock.settimeout(None)` and the socket is in blocking mode. The caller then waits for ever:

- `send_notification()` publishes from a web request. The request thread blocks until the web worker timeout.
- `subscribe()` blocks in `_reconnect()`, so the notifier cannot recover.

The `try`/`except` blocks around both never fire, because no exception is raised.

`socket_connect_timeout` and `socket_timeout` are 3 seconds now. The client raises `TimeoutError`, redis-py closes the connection, and the existing exception handling reconnects.

`socket_timeout` applies immediately after `connect()`, so it also covers the TLS handshake and the AUTH and SELECT commands, not only the command. The handshake is the floor, some tens of milliseconds in one region, so 3 seconds keeps a wide margin. There is no multiplication: the default is `Retry(NoBackoff(), 0)`, which does not retry.

## 2. The health check interval

The timeouts cover the paths that wait for a response. They do nothing for the listener thread, which only reads. `PubSub.get_message()` calls `can_read(raise_on_timeout=False)`, which returns `False` on a timeout and does not raise. A dead connection therefore leaves the listener reading nothing for ever: no exception, no log, no reconnect. The notifier silently stops delivering notifications.

Only a write finds a dead TCP connection. `health_check_interval` makes `PubSub.check_health()` send a `PING` once for each `get_message()` iteration, and the write that fails after the kernel stops the retransmissions is what raises and starts the reconnection.

30 seconds gives one PING for each listener iteration: `check_health()` runs one time for each `get_message()`, and `_subscribe()` gives that a 60 second `sleep_time`. A lower value cannot make the detection faster.

## Why one pull request

`health_check_interval` alone would be worse than nothing: the read of the PING response would block for ever without `socket_timeout`. And the timeouts alone leave the listener, which is the main function of the notifier, unprotected. The two are a pair.

That second failure is the more serious one, because the fallbacks are not equal. `PoliciesCache` has `max_age_seconds = 300`, and its comment gives the reason: "Fallback for missed notifier notifications". `MonolithConf` has an equivalent, `reload_interval`, of one hour. `zentral/core/probes/conf.py` and `zentral/core/stores/conf.py` had none, so a silently dead listener kept the probes and the event store configuration stale on that instance until an operator restarted the process. zentralopensource/zentral#1658 gives those two the same fallback.

## Tests

New `tests/server_base/test_notifier.py`, 28 tests. There were no tests on `Notifier` before, and the module was at 38%. A third commit brings `server/base/notifier.py` to **100%**: the client and pubsub singletons, `_subscribe` and its one time thread start, `_message_handler` for a plain callback, a live weakref, a dead weakref and an unknown channel, `_schedule_reconnect` for its three timer states, `_reconnect` for success, no pubsub and failure, `_exception_handler` with a thread, without one and with a join that raises, `add_callback` for the first and the later callbacks and for a subscribe error, `send_notification` for both outcomes, and `build_notifier`.
