### PR TITLE
Expire the probe caches after 300s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@ The notifier sets a connect timeout, a socket timeout and a health check interva
 
 The event store cache expires after 300 seconds now. A notifier notification was the only thing that made an instance load it again, so an instance that did not get one kept the store configuration it read when it started, and sent events to a store an operator had already changed. The Cedar policies cache had this protection, the store cache did not.
 
+The probe caches expire after 300 seconds now. A notifier notification was the only thing that made an instance load them again, so an instance that did not get one matched events against the probes it read when it started. Some probe views are built from another view. Such a view follows the version of the view it is built from, and not an age of its own, so 300 seconds is the delay for all of them.
+
 Fixed the `zentral_audit` events of the Santa enrollments and the Santa enrolled machines, which were not linked to the object they report. A model that declares the parents of an object replaced the link to the object itself, and the events of that object did not reach its page. A model keeps control of its own key when it declares one, because the MDM commands are linked by UUID and not by primary key.
 
 Fixed the version of an Osquery query in the events published when a user changed the query from the web console. The version was a database expression, and not a number.

--- a/tests/core_probes/test_probes_conf.py
+++ b/tests/core_probes/test_probes_conf.py
@@ -1,6 +1,10 @@
+from unittest.mock import patch
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils.crypto import get_random_string
-from zentral.core.probes.conf import all_probes, all_probes_dict
+from zentral.core.events.base import BaseEvent, EventMetadata
+from zentral.core.probes.conf import all_probes, all_probes_dict, ProbeList, ProbesDict, ProbeView
 from zentral.core.probes.models import ProbeSource
 from zentral.core.probes.probe import Probe
 
@@ -26,3 +30,195 @@ class ProbesConfTestCase(TestCase):
         self.assertEqual(all_probes_dict[self.probe.pk], self.probe)
         with self.assertRaises(KeyError):
             all_probes_dict[self.inactive_probe.pk]
+
+    # _start_sync
+
+    def test_start_sync_registers_the_callback_once(self):
+        probes = ProbeList(with_sync=True)
+        with patch("zentral.core.probes.conf.notifier") as notifier:
+            probes._start_sync()
+            probes._start_sync()
+            notifier.add_callback.assert_called_once()
+        self.assertTrue(probes._sync_started)
+
+    def test_no_sync_registers_nothing(self):
+        probes = ProbeList(with_sync=False)
+        with patch("zentral.core.probes.conf.notifier") as notifier:
+            probes._start_sync()
+            notifier.add_callback.assert_not_called()
+        self.assertFalse(probes._sync_started)
+
+    # ProbesDict
+
+    def test_probes_dict_default_item_func_keys_on_the_name(self):
+        probes_dict = ProbesDict(ProbeList())
+        self.assertEqual(probes_dict[self.probe_source.name], self.probe)
+
+    def test_probes_dict_non_unique_key(self):
+        probes_dict = ProbesDict(ProbeList(), item_func=lambda p: [("shared", p)], unique_key=False)
+        self.assertEqual(probes_dict["shared"], [self.probe])
+
+    def test_probes_dict_keys(self):
+        probes_dict = ProbesDict(ProbeList(), item_func=lambda p: [(p.pk, p)])
+        self.assertEqual(list(probes_dict.keys()), [self.probe.pk])
+
+    def test_probes_dict_get(self):
+        probes_dict = ProbesDict(ProbeList(), item_func=lambda p: [(p.pk, p)])
+        self.assertEqual(probes_dict.get(self.probe.pk), self.probe)
+        self.assertIsNone(probes_dict.get(self.inactive_probe.pk))
+
+    def test_probes_dict_len(self):
+        probes_dict = ProbesDict(ProbeList(), item_func=lambda p: [(p.pk, p)])
+        self.assertEqual(len(probes_dict), 1)
+
+    # ProbeList children
+
+    def test_filter(self):
+        probes = ProbeList()
+        matching = probes.filter(lambda p: p.pk == self.probe.pk)
+        self.assertEqual(list(matching), [self.probe])
+        none_matching = probes.filter(lambda p: False)
+        self.assertEqual(list(none_matching), [])
+
+    def test_dict(self):
+        probes = ProbeList()
+        probes_dict = probes.dict(item_func=lambda p: [(p.pk, p)])
+        self.assertEqual(probes_dict[self.probe.pk], self.probe)
+
+    def test_event_filtered(self):
+        probes = ProbeList()
+        event = BaseEvent(EventMetadata(), {})
+        # the probe has an empty body, so it matches every event
+        self.assertEqual(list(probes.event_filtered(event)), [self.probe])
+
+    def test_clear_cascades_to_the_children(self):
+        probes = ProbeList()
+        child = probes.filter(lambda p: True)
+        list(child)
+        self.assertIsNotNone(child._probes)
+        probes.clear()
+        self.assertIsNone(child._probes)
+        self.assertIsNone(child._last_load_ts)
+
+    # max age fallback
+
+    def test_cache_is_fresh_after_load(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        list(all_probes)
+        self.assertTrue(all_probes._is_fresh(None))
+
+    def test_cache_expires(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        list(all_probes)
+        all_probes._last_load_ts -= all_probes.max_age_seconds + 1
+        self.assertFalse(all_probes._is_fresh(None))
+
+    def test_clear_resets_the_load_timestamp(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        list(all_probes)
+        all_probes.clear()
+        self.assertIsNone(all_probes._last_load_ts)
+        self.assertIsNone(all_probes_dict._last_load_ts)
+
+    def test_child_follows_parent_expiry_when_staggered(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        self.assertEqual(all_probes_dict[self.probe.pk], self.probe)
+        # the child reloads on its own while the parent is still fresh
+        all_probes_dict.clear()
+        self.assertEqual(all_probes_dict[self.probe.pk], self.probe)
+        probe_source = ProbeSource.objects.create(name=get_random_string(12),
+                                                  status=ProbeSource.ACTIVE,
+                                                  body={})
+        # only the parent is expired, the child's own timer is still fresh
+        all_probes._last_load_ts -= all_probes.max_age_seconds + 1
+        self.assertEqual(all_probes_dict[probe_source.pk], Probe(probe_source))
+
+    def test_child_has_no_age_of_its_own(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        self.assertEqual(all_probes_dict[self.probe.pk], self.probe)
+        probe_source = ProbeSource.objects.create(name=get_random_string(12),
+                                                  status=ProbeSource.ACTIVE,
+                                                  body={})
+        # only the child is backdated: it follows the parent, which is still fresh,
+        # so the new probe stays invisible and the bound is one max age, not two
+        all_probes_dict._last_load_ts -= all_probes_dict.max_age_seconds + 1
+        with self.assertRaises(KeyError):
+            all_probes_dict[probe_source.pk]
+
+    # snapshot
+
+    def test_snapshot_pairs_the_generation_with_the_probes(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        generation, probes = all_probes.snapshot()
+        self.assertEqual(probes, [self.probe])
+        # nothing changed, so the same version and the same probes come back
+        self.assertEqual(all_probes.snapshot(), (generation, probes))
+
+    def test_snapshot_applies_the_max_age(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        generation, _ = all_probes.snapshot()
+        probe_source = ProbeSource.objects.create(name=get_random_string(12),
+                                                  status=ProbeSource.ACTIVE,
+                                                  body={})
+        all_probes._last_load_ts -= all_probes.max_age_seconds + 1
+        new_generation, probes = all_probes.snapshot()
+        self.assertGreater(new_generation, generation)
+        self.assertIn(Probe(probe_source), probes)
+
+    def test_generation_increases_on_every_build(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        first, _ = all_probes.snapshot()
+        all_probes.clear()
+        second, _ = all_probes.snapshot()
+        # clear() does not reset the number, so a version is never reused
+        self.assertGreater(second, first)
+
+    def test_build_is_not_implemented_on_the_base_view(self):
+        with self.assertRaises(NotImplementedError):
+            ProbeView()._build([])
+
+    def test_a_derived_view_follows_its_immediate_parent(self):
+        root = ProbeList()
+        child = root.filter(lambda p: True)
+        grandchild = child.filter(lambda p: True)
+        self.assertEqual(list(grandchild), [self.probe])
+        # rebuild the middle view only: its version moves, the root's does not,
+        # and the view below follows the middle one
+        child.clear()
+        self.assertEqual(list(grandchild), [self.probe])
+        self.assertEqual(grandchild._parent_generation, child._generation)
+        self.assertNotEqual(grandchild._parent_generation, root._generation)
+
+    # database access
+
+    def test_a_fresh_cache_makes_no_query(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        event = BaseEvent(EventMetadata(), {})
+        # warm every view on the hot path
+        list(all_probes)
+        all_probes_dict[self.probe.pk]
+        list(all_probes.event_filtered(event))
+        with self.assertNumQueries(0):
+            for _ in range(10):
+                list(all_probes)
+                all_probes_dict[self.probe.pk]
+                list(all_probes.event_filtered(event))
+
+    def test_an_expired_cache_queries_again(self):
+        all_probes.clear()
+        self.addCleanup(all_probes.clear)
+        list(all_probes)
+        all_probes._last_load_ts -= all_probes.max_age_seconds + 1
+        # the count depends on the number of probes, only that it goes back matters
+        with CaptureQueriesContext(connection) as queries:
+            list(all_probes)
+        self.assertGreater(len(queries), 0)

--- a/zentral/core/probes/conf.py
+++ b/zentral/core/probes/conf.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+import time
 import weakref
 from base.notifier import notifier
 from .models import ProbeSource
@@ -11,9 +12,17 @@ logger = logging.getLogger("zentral.core.probes.conf")
 
 
 class ProbeView(object):
+    # Fallback for missed notifier notifications. Only a root uses it: a derived view
+    # has no age of its own, it follows the generation of the view it is built from,
+    # so the whole tree stays inside one max age whatever its depth.
+    max_age_seconds = 300
+
     def __init__(self, parent=None, with_sync=False):
         self.parent = parent
         self._probes = None
+        self._generation = 0
+        self._parent_generation = None
+        self._last_load_ts = None
         self._lock = threading.Lock()
         self.with_sync = with_sync
         self._sync_started = False
@@ -21,13 +30,75 @@ class ProbeView(object):
     def clear(self, *args, **kwargs):
         with self._lock:
             self._probes = None
+            self._parent_generation = None
+            self._last_load_ts = None
 
-    def iter_parent_probes(self):
+    def snapshot(self):
+        """Version number of the probes this view serves, and the probes.
+
+        The two come from the same critical section, so a caller can never pair a
+        version with probes from a different build. The number increases on every
+        build and at no other time, and clear() does not reset it, so the same
+        number twice always means the same probes.
+
+        The view builds before it answers. The probes are therefore the ones a
+        reader gets now, and asking for them is what makes a view apply its own
+        max age.
+        """
+        with self._lock:
+            self._load()
+            return self._generation, self._probes
+
+    def _build_from(self):
+        """The probes _build() gets, and the version number to record with them.
+
+        The number is always the parent's own, never the root's: a view deeper in
+        the tree follows the one directly above it, and each of them follows the
+        one above in turn. A root has no parent and follows no version, it reads
+        the database.
+
+        A derived view takes a snapshot of its parent: one call, so the version it
+        records always belongs to the probes it builds from.
+
+        This holds our lock and takes the parent's. Child to parent is the safe
+        order: clear() goes the other way, and cascades to the children after it
+        has released its own lock.
+        """
         if self.parent is None:
-            for ps in ProbeSource.objects.active():
-                yield Probe(ps)
-        else:
-            yield from self.parent
+            return None, self._iter_db_probes()
+        return self.parent.snapshot()
+
+    def _iter_db_probes(self):
+        # a generator function, not a generator expression: an expression evaluates
+        # its outermost iterable when it is created, so the query would run here even
+        # when _load() finds the cache fresh straight after and drops the rows
+        for ps in ProbeSource.objects.active():
+            yield Probe(ps)
+
+    def _is_fresh(self, parent_generation):
+        if self._probes is None:
+            return False
+        if self.parent is not None:
+            return self._parent_generation == parent_generation
+        return (
+            self._last_load_ts is not None
+            and time.monotonic() - self._last_load_ts <= self.max_age_seconds
+        )
+
+    def _load(self):
+        self._start_sync()
+        parent_generation, probes = self._build_from()
+        if self._is_fresh(parent_generation):
+            return
+        # built apart and assigned in one go: a reader that holds a snapshot keeps a
+        # complete set of probes, and never sees one that is half built
+        self._probes = self._build(probes)
+        self._parent_generation = parent_generation
+        self._generation += 1
+        self._last_load_ts = time.monotonic()
+
+    def _build(self, probes):
+        raise NotImplementedError
 
     def _start_sync(self):
         if self.with_sync:
@@ -55,16 +126,15 @@ class ProbesDict(ProbeView):
             self.item_func = item_func
         self.unique_key = unique_key
 
-    def _load(self):
-        self._start_sync()
-        if self._probes is None:
-            self._probes = {}
-            for probe in self.iter_parent_probes():
-                for key, val in self.item_func(probe):
-                    if self.unique_key:
-                        self._probes[key] = val
-                    else:
-                        self._probes.setdefault(key, []).append(val)
+    def _build(self, probes):
+        built = {}
+        for probe in probes:
+            for key, val in self.item_func(probe):
+                if self.unique_key:
+                    built[key] = val
+                else:
+                    built.setdefault(key, []).append(val)
+        return built
 
     def __getitem__(self, key):
         with self._lock:
@@ -91,20 +161,20 @@ class ProbeList(ProbeView):
     def clear(self, *args, **kwargs):
         with self._lock:
             self._probes = None
+            self._parent_generation = None
+            self._last_load_ts = None
             children = list(self._children)
-        # cascade outside our lock: a reader holds a child's lock while iterating
-        # its parent (child -> parent), so taking a child's lock while holding
-        # ours would invert that order and can deadlock.
+        # cascade outside our lock: a reader holds a child's lock while it takes a
+        # snapshot of its parent (child -> parent), so taking a child's lock while
+        # holding ours would invert that order and can deadlock.
         for child in children:
             child.clear()
 
-    def _load(self):
-        self._start_sync()
-        if self._probes is None:
-            self._probes = []
-            for probe in self.iter_parent_probes():
-                if self.filter_func is None or self.filter_func(probe):
-                    self._probes.append(probe)
+    def _build(self, probes):
+        return [
+            probe for probe in probes
+            if self.filter_func is None or self.filter_func(probe)
+        ]
 
     def filter(self, filter_func):
         child = self.__class__(self, filter_func)


### PR DESCRIPTION
Follow-up to zentralopensource/zentral#1658, which gave the event store cache a fallback for a notifier notification that never arrives. This does the same for the probe caches, where the problem has one more dimension.

## Problem

The probe views form a tree. `all_probes` reads the database; `all_probes_dict`, and every view that `filter()` and `dict()` return, are built from another view. Only the root registers the `probes.change` callback, and a notification that never arrives leaves the whole tree with the probes it read when the instance started.

An age on each view is not enough. @Labeeb2339 found the reason on the first version of this change: a child that reloads while its parent is still fresh, and whose parent then expires and reloads, keeps serving what it built from the old parent until its own age runs out. At depth one the bound is twice the max age, and more below that.

## Change

A view carries a version number that increases on every build. `clear()` does not reset it, so a version is never reused.

**Only a root has an age.** A derived view has none. It takes a snapshot of the view it is built from, records the version, and builds again when that version no longer matches. The bound is one max age for the whole tree, whatever its depth.

```python
def snapshot(self):
    with self._lock:
        self._load()
        return self._generation, self._probes
```

The version and the probes come from the same critical section, so a view can never pair a version with the probes of another build, and asking for them is what makes the parent apply its own age before it answers.

`_build_from()` gives `_build()` the probes and the version to record with them: the parent's snapshot, or the database for a root. The version is always the parent's own and never the root's, because each view follows the one directly above it, and that one follows the one above in turn.

`_build()` returns the container and `_load()` assigns it in one operation, instead of assigning an empty one and filling it, so a reader that holds a snapshot always has a complete set of probes.

`_load()` is on the base view now. The sub-classes only say how to shape the probes they are given, which removes the two copies of the load logic.

## The probes a root reads are behind a generator function

`_load()` asks for the probes before it tests the age, because a derived view has to take the snapshot first: that call is what applies the parent's age. A root therefore has to give its probes without reading the database, or a fresh cache would query on every access and save nothing.

A generator function does that; a generator expression does not. CPython evaluates the outermost iterable of an expression and calls `iter()` on it when the expression is created, and `QuerySet.__iter__` runs the `SELECT`. `_iter_db_probes()` is a function for that reason, and it says so, because the two forms look interchangeable.

`test_a_fresh_cache_makes_no_query` holds this. With a generator expression it fails with 50 queries against 0 expected.

## Locks

A child holds its own lock and takes its parent's. `clear()` goes in the other direction and cascades to the children after it has released its own lock, so the two orders never meet. This is the rule the comment on `ProbeList.clear()` already gave; the comment now names the snapshot instead of the iteration it replaces.

## Tests

`zentral/core/probes/conf.py` goes to **100%**, not only the changed lines.

The tree:
- `test_child_follows_parent_expiry_when_staggered` moves the parent alone, with the child fresh. This is the case from the review, and it fails without this change.
- `test_child_has_no_age_of_its_own` moves the child alone and expects no change, which the design before this one could not give.
- `test_a_derived_view_follows_its_immediate_parent` builds a tree two deep and rebuilds the view in the middle: the view below follows it, and the root does not move.

The database:
- `test_a_fresh_cache_makes_no_query` counts the queries of ten passes over `all_probes`, `all_probes_dict` and `event_filtered()`, and expects none.
- `test_an_expired_cache_queries_again` expects the queries to come back after the age.

The snapshot: the pair stays together, `snapshot()` applies the max age, and a version survives `clear()`.

The views: `ProbesDict` with its default `item_func` and with `unique_key` false, `keys()`, `get()`, `__len__`, `filter()`, `dict()`, `event_filtered()`, the `clear()` cascade, and `_start_sync` with and without sync.

`tests.core_probes` 159 tests. With `core_events`, `core_incidents`, `core_stores`, `core_queues`, `santa`, `osquery`, `munki` and `server_base`: 2440 tests pass.