### PR TITLE
Restrict the task result endpoints to the user of the task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,12 @@ The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `
 
 `zentral_santa_enrolled_machines_total` and `zentral_santa_enrolled_machines_sync_total` are replaced by `zentral_santa_enrolled_machines_bucket` and `zentral_santa_enrolled_machines_sync_bucket`, which have an `le` label. The `le="+Inf"` bucket gives the value of the two removed gauges: in a dashboard or an alert, change the metric name and select that bucket. A query that sums the buckets counts each machine seven times.
 
+#### 🧨 Privilege escalation hardening — task results
+
+A task belongs to the user or the service account that launched it, and `/api/task_result/<task_id>/` and `/api/task_result/<task_id>/download/` answer only for that principal. A superuser reads all of them, as before. Until now the two endpoints only asked for a valid session or API token: any authenticated principal that had a task ID could read the state of that task and download its file, and an export carries everything the principal that launched it was allowed to see. The state endpoint gives the `UNKNOWN` status for the task of a different principal, like it does for a task that does not exist, and the download endpoint gives a `404`. The task list and the task pages of the web console already applied this rule.
+
+A task that a device launched, and a task that Zentral launched before version 2025.11, has no user, so only a superuser can read those. The exports are temporary: launch the export again to get a file that you can download.
+
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ The task that pushes an updated DEP profile to Apple Business Manager belongs to
 
 A retried task does not write an error to the logs about its user record anymore. Celery publishes a retry with the same task ID, Zentral tried to write the record a second time, and the unique constraint refused it. The task that assigns the default enrollment of a DEP virtual server retries when Apple throttles it.
 
+The task list of the web console reads the user of each task together with the tasks now. It made one more query for each row of the page, and a superuser sees the tasks of all the users.
+
 The notifier sets a connect timeout, a socket timeout and a health check interval on its Redis client now. Without the timeouts the socket stays in blocking mode: a Redis server that stops answering and does not close the connection, a managed Redis during a failover for example, blocked a notification for ever in the middle of a web request. The health check interval covers the listener thread, which reads only, and which stayed silent for ever on the same connection because a read that times out there does not give an error. The listener sends a periodic PING now, and the write that fails is what makes the notifier reconnect. Zentral applies configuration changes on the probes, the event stores and the Monolith repositories again after this failure, and not only after a restart.
 
 The event store cache expires after 300 seconds now. A notifier notification was the only thing that made an instance load it again, so an instance that did not get one kept the store configuration it read when it started, and sent events to a store an operator had already changed. The Cedar policies cache had this protection, the store cache did not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `
 ### Bug fixes
 
 
+A retried task does not write an error to the logs about its user record anymore. Celery publishes a retry with the same task ID, Zentral tried to write the record a second time, and the unique constraint refused it. The task that assigns the default enrollment of a DEP virtual server retries when Apple throttles it.
+
 The notifier sets a connect timeout, a socket timeout and a health check interval on its Redis client now. Without the timeouts the socket stays in blocking mode: a Redis server that stops answering and does not close the connection, a managed Redis during a failover for example, blocked a notification for ever in the middle of a web request. The health check interval covers the listener thread, which reads only, and which stayed silent for ever on the same connection because a read that times out there does not give an error. The listener sends a periodic PING now, and the write that fails is what makes the notifier reconnect. Zentral applies configuration changes on the probes, the event stores and the Monolith repositories again after this failure, and not only after a restart.
 
 The event store cache expires after 300 seconds now. A notifier notification was the only thing that made an instance load it again, so an instance that did not get one kept the store configuration it read when it started, and sent events to a store an operator had already changed. The Cedar policies cache had this protection, the store cache did not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `
 ### Bug fixes
 
 
+The task that pushes an updated DEP profile to Apple Business Manager belongs to the user who saved the enrollment now. It was the only task that a user launched with no record of the user, so it was not in the task list of that user, and only a superuser saw its result.
+
 A retried task does not write an error to the logs about its user record anymore. Celery publishes a retry with the same task ID, Zentral tried to write the record a second time, and the unique constraint refused it. The task that assigns the default enrollment of a DEP virtual server retries when Apple throttles it.
 
 The notifier sets a connect timeout, a socket timeout and a health check interval on its Redis client now. Without the timeouts the socket stays in blocking mode: a Redis server that stops answering and does not close the connection, a managed Redis during a failover for example, blocked a notification for ever in the middle of a web request. The health check interval covers the listener thread, which reads only, and which stayed silent for ever on the same connection because a read that times out there does not give an error. The listener sends a periodic PING now, and the write that fails is what makes the notifier reconnect. Zentral applies configuration changes on the probes, the event stores and the Monolith repositories again after this failure, and not only after a restart.

--- a/docs/apps/core.md
+++ b/docs/apps/core.md
@@ -115,6 +115,8 @@ Issuers can also be managed over the API, at `/api/accounts/token_issuers/oidc/`
 
 Use this endpoint to get the status of a task. If the task generates a file, a `download_url` attribute will be included. The `download_url` will redirect to the exported file (for example, a signed S3 URL if Zentral is configured with a S3 bucket). A process should wait for a task if `unready` is true.
 
+A task belongs to the user or the service account that launched it. Only that principal can read its status, and a superuser can read the status of all the tasks. The endpoint gives the `UNKNOWN` status for the task of a different principal, like it does for a task that does not exist. A task that a device launched, and a task that Zentral launched before version 2025.11, has no user: only a superuser can read it.
+
 Example:
 
 ```
@@ -146,6 +148,8 @@ Result:
 * PBAC action: none
 
 Use this endpoint to download the result of a task. A process waiting for a task result should only hit this endpoint when the URL is present in a task response (see [above](#apitask_resultuuidtask_id)).
+
+Only the principal that launched the task, or a superuser, can download the file. The endpoint gives a `404` to the others.
 
 Example:
 

--- a/server/accounts/models.py
+++ b/server/accounts/models.py
@@ -382,6 +382,15 @@ class UserTask(models.Model):
     task_result = models.OneToOneField(TaskResult, on_delete=models.CASCADE)
 
 
+def task_results_for_user(user):
+    # a task result can carry an export of everything its user was allowed to see, so it stays
+    # theirs. Superusers read them all, service accounts never do, like ZentralBackend.has_perm.
+    queryset = TaskResult.objects.all()
+    if user.is_service_account or not user.is_superuser:
+        queryset = queryset.filter(usertask__user=user)
+    return queryset
+
+
 class PolicyManager(models.Manager):
     def not_provisioned(self):
         return self.filter(provisioning_uid__isnull=True)

--- a/server/accounts/views/tasks.py
+++ b/server/accounts/views/tasks.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("zentral.accounts.views.tasks")
 class TaskViewMixin:
     def get_queryset(self):
         return (task_results_for_user(self.request.user)
-                .select_related('usertask')
+                .select_related('usertask__user')
                 .order_by('-date_created'))
 
 

--- a/server/accounts/views/tasks.py
+++ b/server/accounts/views/tasks.py
@@ -3,8 +3,8 @@ import logging
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView
-from django_celery_results.models import TaskResult
 
+from accounts.models import task_results_for_user
 from zentral.utils.views import UserPaginationListView
 
 logger = logging.getLogger("zentral.accounts.views.tasks")
@@ -12,10 +12,9 @@ logger = logging.getLogger("zentral.accounts.views.tasks")
 
 class TaskViewMixin:
     def get_queryset(self):
-        queryset = TaskResult.objects.select_related('usertask').all()
-        if not self.request.user.is_superuser:
-            queryset = queryset.filter(usertask__user=self.request.user)
-        return queryset.order_by('-date_created')
+        return (task_results_for_user(self.request.user)
+                .select_related('usertask')
+                .order_by('-date_created'))
 
 
 class TasksView(LoginRequiredMixin, TaskViewMixin, UserPaginationListView):

--- a/server/base/api_views.py
+++ b/server/base/api_views.py
@@ -11,19 +11,25 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from accounts.api_authentication import APITokenAuthentication
+from accounts.models import task_results_for_user
 from zentral.utils.storage import file_storage_has_signed_urls
 
 
 logger = logging.getLogger("server.base.api_views")
 
 
-class TaskResultView(APIView):
+class BaseTaskResultView(APIView):
     authentication_classes = [APITokenAuthentication, SessionAuthentication]
 
+    def get_task_results(self):
+        return task_results_for_user(self.request.user)
+
+
+class TaskResultView(BaseTaskResultView):
     def get(self, request, *args, **kwargs):
         task_id = str(kwargs["task_id"])
         try:
-            task_result = TaskResult.objects.get(task_id=task_id)
+            task_result = self.get_task_results().get(task_id=task_id)
         except TaskResult.DoesNotExist:
             response = {"id": task_id,
                         "status": "UNKNOWN",
@@ -46,15 +52,13 @@ class TaskResultView(APIView):
         return Response(response)
 
 
-class TaskResultFileDownloadView(APIView):
-    authentication_classes = [APITokenAuthentication, SessionAuthentication]
-
+class TaskResultFileDownloadView(BaseTaskResultView):
     @cached_property
     def _redirect_to_files(self):
         return file_storage_has_signed_urls()
 
     def get(self, request, *args, **kwargs):
-        task_result = get_object_or_404(TaskResult, task_id=str(kwargs["task_id"]), status="SUCCESS")
+        task_result = get_object_or_404(self.get_task_results(), task_id=str(kwargs["task_id"]), status="SUCCESS")
         try:
             result = json.loads(task_result.result)
         except (TypeError, ValueError):

--- a/server/server/celery.py
+++ b/server/server/celery.py
@@ -66,25 +66,28 @@ def create_task_result_on_publish(sender=None, headers=None, body=None, **kwargs
 
     except Exception:
         logger.exception("Could not store pending task %s result", headers["id"])
-    else:
-        if 'task_user' in task_kwargs:
-            try:
-                task_user_pk = task_kwargs['task_user']
 
-                # TODO: better circular import
-                from accounts.models import User, UserTask
-                from django_celery_results.models import TaskResult
+    task_user_pk = task_kwargs.get('task_user')
+    if task_user_pk is not None:
+        # TODO: better circular import
+        from accounts.models import User, UserTask
+        from django_celery_results.models import TaskResult
 
-                UserTask.objects.create(
-                    user=User.objects.get(id=task_user_pk),
-                    task_result=TaskResult.objects.get(task_id=headers["id"])
-                )
-            except Exception:
-                logger.exception(
-                    "UserTask could not be created. Is the user %s or task %s result missing?",
-                    task_user_pk,
-                    headers["id"]
-                )
+        try:
+            user = User.objects.get(pk=task_user_pk)
+        except User.DoesNotExist:
+            # the cascade took the ownership row away with the user. Nobody is left to attribute
+            # the task to, and nobody is left to keep it from either.
+            logger.error("Task %s user %s does not exist", headers["id"], task_user_pk)
+        else:
+            # the task result endpoints key on this row, so a task published without it could not
+            # be read by the user who asked for it. This signal runs before the message is
+            # published: an error here fails the launch and leaves nothing queued.
+            # A retry publishes the same task ID again, hence the get_or_create.
+            UserTask.objects.get_or_create(
+                task_result=TaskResult.objects.get(task_id=headers["id"]),
+                defaults={"user": user},
+            )
 
 
 before_task_publish.connect(create_task_result_on_publish, dispatch_uid='create_task_result_on_publish')

--- a/tests/mdm/test_setup_dep_enrollment.py
+++ b/tests/mdm/test_setup_dep_enrollment.py
@@ -523,7 +523,9 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
         self.assertEqual(enrollment.realm, realm)
         self.assertEqual(enrollment.macos_min_version, "13.3.1")
         self.assertEqual(enrollment.skip_setup_items, ["AppleID"])
-        define_dep_profile_task.apply_async.assert_called_once_with((enrollment.pk,))
+        define_dep_profile_task.apply_async.assert_called_once_with(
+            (enrollment.pk,), {"task_user": self.user.pk}
+        )
 
     @patch("zentral.contrib.mdm.views.dep_enrollments.define_dep_profile_task")
     def test_update_dep_enrollment_post_remove_admin(self, define_dep_profile_task):
@@ -550,7 +552,9 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "mdm/depenrollment_detail.html")
         # the DEP profile push and the audit event
         self.assertEqual(len(callbacks), 2)
-        define_dep_profile_task.apply_async.assert_called_once_with((enrollment.pk,))
+        define_dep_profile_task.apply_async.assert_called_once_with(
+            (enrollment.pk,), {"task_user": self.user.pk}
+        )
         enrollment.refresh_from_db()
         self.assertIsNone(enrollment.admin_full_name)
         self.assertIsNone(enrollment.admin_short_name)
@@ -583,7 +587,9 @@ class MDMDEPEnrollmentSetupViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "mdm/depenrollment_detail.html")
         # the DEP profile push and the audit event
         self.assertEqual(len(callbacks), 2)
-        define_dep_profile_task.apply_async.assert_called_once_with((enrollment.pk,))
+        define_dep_profile_task.apply_async.assert_called_once_with(
+            (enrollment.pk,), {"task_user": self.user.pk}
+        )
         enrollment.refresh_from_db()
         self.assertEqual(enrollment.admin_full_name, "yolo2")
         self.assertEqual(enrollment.admin_short_name, "fomo2")

--- a/tests/server_base/test_api_views.py
+++ b/tests/server_base/test_api_views.py
@@ -24,6 +24,13 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
             is_service_account=True
         )
         cls.user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        cls.other_user = User.objects.create_user(
+            get_random_string(12), "{}@zentral.io".format(get_random_string(12)), get_random_string(12)
+        )
+        cls.superuser = User.objects.create_user(
+            get_random_string(12), "{}@zentral.io".format(get_random_string(12)), get_random_string(12),
+            is_superuser=True
+        )
         cls.group = Group.objects.create(name=get_random_string(12))
         cls.service_account.groups.set([cls.group])
         cls.user.groups.set([cls.group])
@@ -65,7 +72,7 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.json(), {"id": task_id, "status": "UNKNOWN", "unready": True})
 
     def test_task_result(self):
-        tr, result, _ = force_task_result()
+        tr, result, _ = force_task_result(user=self.service_account)
         response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -79,7 +86,7 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         )
 
     def test_task_result_bad_json(self):
-        tr, _, _ = force_task_result(bad_json=True)
+        tr, _, _ = force_task_result(bad_json=True, user=self.service_account)
         response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -91,7 +98,7 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         )
 
     def test_task_result_login(self):
-        tr, result, _ = force_task_result()
+        tr, result, _ = force_task_result(user=self.user)
         self.login()
         response = self.get(reverse("base_api:task_result", args=(tr.task_id,)), include_token=False)
         self.assertEqual(response.status_code, 200)
@@ -104,6 +111,55 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
              "result": result,
              "download_url": f"/api/task_result/{tr.task_id}/download/"}
         )
+
+    def test_task_result_other_user_unknown(self):
+        tr, _, _ = force_task_result(user=self.other_user)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": tr.task_id, "status": "UNKNOWN", "unready": True})
+
+    def test_task_result_other_user_unknown_login(self):
+        tr, _, _ = force_task_result(user=self.other_user)
+        self.login()
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)), include_token=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": tr.task_id, "status": "UNKNOWN", "unready": True})
+
+    def test_task_result_without_user_unknown(self):
+        tr, _, _ = force_task_result()
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": tr.task_id, "status": "UNKNOWN", "unready": True})
+
+    def test_task_result_superuser(self):
+        tr, result, _ = force_task_result(user=self.other_user)
+        self.client.force_login(self.superuser)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)), include_token=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"id": tr.task_id,
+             "name": "zentral.contrib.santa.tasks.export_targets",
+             "status": "SUCCESS",
+             "unready": False,
+             "result": result,
+             "download_url": f"/api/task_result/{tr.task_id}/download/"}
+        )
+
+    def test_task_result_without_user_superuser(self):
+        tr, result, _ = force_task_result()
+        self.client.force_login(self.superuser)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)), include_token=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "SUCCESS")
+
+    def test_task_result_superuser_service_account_unknown(self):
+        # a service account is never a superuser, but the flag is only forced on save
+        User.objects.filter(pk=self.service_account.pk).update(is_superuser=True)
+        tr, _, _ = force_task_result(user=self.other_user)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": tr.task_id, "status": "UNKNOWN", "unready": True})
 
     # task result file download
 
@@ -123,22 +179,22 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_result_file_download_bad_json(self):
-        tr, _, _ = force_task_result(bad_json=True)
+        tr, _, _ = force_task_result(bad_json=True, user=self.service_account)
         response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
         self.assertEqual(response.status_code, 404)
 
     def test_result_no_filepath(self):
-        tr, _, _ = force_task_result(result={})
+        tr, _, _ = force_task_result(result={}, user=self.service_account)
         response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
         self.assertEqual(response.status_code, 404)
 
     def test_result_file_download_not_exists(self):
-        tr, result, _ = force_task_result()
+        tr, result, _ = force_task_result(user=self.service_account)
         response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
         self.assertEqual(response.status_code, 404)
 
     def test_result_file_download_direct(self):
-        tr, result, filepath = force_task_result()
+        tr, result, filepath = force_task_result(user=self.service_account)
         with default_storage.open(filepath, "wb") as f:
             f.write(b"yolo")
         response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
@@ -147,10 +203,43 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.headers["Content-Disposition"], result["headers"]["Content-Disposition"])
         self.assertEqual(b"".join(response.streaming_content), b"yolo")
 
+    def test_result_file_download_other_user_404(self):
+        tr, _, filepath = force_task_result(user=self.other_user)
+        with default_storage.open(filepath, "wb") as f:
+            f.write(b"yolo")
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_file_download_other_user_404_login(self):
+        tr, _, filepath = force_task_result(user=self.other_user)
+        with default_storage.open(filepath, "wb") as f:
+            f.write(b"yolo")
+        self.login()
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)),
+                            include_token=False)
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_file_download_without_user_404(self):
+        tr, _, filepath = force_task_result()
+        with default_storage.open(filepath, "wb") as f:
+            f.write(b"yolo")
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_file_download_superuser(self):
+        tr, result, filepath = force_task_result(user=self.other_user)
+        with default_storage.open(filepath, "wb") as f:
+            f.write(b"yolo")
+        self.client.force_login(self.superuser)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)),
+                            include_token=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(b"".join(response.streaming_content), b"yolo")
+
     @patch("base.api_views.file_storage_has_signed_urls")
     def test_result_file_download_redirect_login(self, file_storage_has_signed_urls):
         file_storage_has_signed_urls.return_value = True
-        tr, result, filepath = force_task_result()
+        tr, result, filepath = force_task_result(user=self.user)
         self.login()
         response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)),
                             include_token=False)

--- a/tests/server_base/test_celery.py
+++ b/tests/server_base/test_celery.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from server.celery import create_task_result_on_publish
 from django_celery_results.models import TaskResult
-from accounts.models import User
+from accounts.models import User, UserTask
 from django.utils.crypto import get_random_string
 
 
@@ -45,7 +45,7 @@ class TestZentralCelery(TestCase):
         db_result_backend.store_result.assert_called_once()
 
     @patch("server.celery.logger.error")
-    def test_create_task_result_on_publish_could_not_find_user_or_task(self, logger_error):
+    def test_create_task_result_on_publish_could_not_find_user(self, logger_error):
         self.assertIsNone(create_task_result_on_publish(
             sender="zentral.contrib.mdm.tasks.sync_dep_virtual_server_devices_task",
             headers={
@@ -55,11 +55,24 @@ class TestZentralCelery(TestCase):
             body=([], {'task_user': 0}, dict())
         ))
         logger_error.assert_called_once_with(
-            'UserTask could not be created. Is the user %s or task %s result missing?',
-            0,
+            'Task %s user %s does not exist',
             '0b56443a-597f-4492-818e-6e2a4ad45a91',
-            exc_info=True,
+            0,
         )
+        self.assertEqual(UserTask.objects.count(), 0)
+
+    @patch("server.celery.db_result_backend")
+    def test_create_task_result_on_publish_could_not_find_task_result(self, db_result_backend):
+        user = User.objects.create_user(get_random_string(12), "godzilla@zentral.io", get_random_string(12))
+        with self.assertRaises(TaskResult.DoesNotExist):
+            create_task_result_on_publish(
+                sender="zentral.contrib.mdm.tasks.sync_dep_virtual_server_devices_task",
+                headers={
+                    'task': 'zentral.contrib.mdm.tasks.sync_dep_virtual_server_devices_task',
+                    'id': '0b56443a-597f-4492-818e-6e2a4ad45a91'
+                },
+                body=([], {'task_user': user.id}, dict())
+            )
 
     def test_create_task_result_on_publish_and_find_usertask(self):
         user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
@@ -74,3 +87,21 @@ class TestZentralCelery(TestCase):
         ))
         task = TaskResult.objects.get(task_id=header_id)
         self.assertEqual(task.usertask.user.id, user.id)
+
+    def test_create_task_result_on_publish_twice_keeps_the_first_usertask(self):
+        user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        other_user = User.objects.create_user(get_random_string(12), "mothra@zentral.io", get_random_string(12))
+        header_id = '0b56443a-597f-4492-818e-6e2a4ad45a91'
+        for task_user in (user, other_user):
+            # a retried task is published a second time, with the same task ID
+            self.assertIsNone(create_task_result_on_publish(
+                sender="zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task",
+                headers={
+                    'task': 'zentral.contrib.mdm.tasks.assign_dep_virtual_server_default_enrollment_task',
+                    'id': header_id
+                },
+                body=([], {'task_user': task_user.id}, dict())
+            ))
+        self.assertEqual(UserTask.objects.count(), 1)
+        task = TaskResult.objects.get(task_id=header_id)
+        self.assertEqual(task.usertask.user, user)

--- a/tests/server_base/utils.py
+++ b/tests/server_base/utils.py
@@ -5,10 +5,11 @@ from datetime import timedelta
 from django.utils.crypto import get_random_string
 from django_celery_results.models import TaskResult
 
+from accounts.models import UserTask
 from zentral.utils.time import naive_utcnow
 
 
-def force_task_result(bad_json=False, result=None):
+def force_task_result(bad_json=False, result=None, user=None):
     if result is None:
         result = {
             "filepath": f"exports/santa_targets_export_{get_random_string(12)}.xlsx",
@@ -35,5 +36,7 @@ def force_task_result(bad_json=False, result=None):
         date_done=naive_utcnow() - timedelta(days=1),
         meta='{"children": []}'
     )
+    if user is not None:
+        UserTask.objects.create(user=user, task_result=tr)
     filepath = result.pop("filepath", None)
     return tr, result, filepath

--- a/zentral/contrib/mdm/tasks.py
+++ b/zentral/contrib/mdm/tasks.py
@@ -161,7 +161,8 @@ def assign_dep_virtual_server_default_enrollment_task(self, dep_virtual_server_p
 
 
 @shared_task
-def define_dep_profile_task(dep_enrollment_pk):
+def define_dep_profile_task(dep_enrollment_pk, **kwargs):
+    # kwargs absorbs task_user, added by the view for the UserTask created in the celery signal
     dep_enrollment = DEPEnrollment.objects.select_related("virtual_server").get(pk=dep_enrollment_pk)
     return define_dep_profile(dep_enrollment)
 

--- a/zentral/contrib/mdm/views/dep_enrollments.py
+++ b/zentral/contrib/mdm/views/dep_enrollments.py
@@ -148,7 +148,11 @@ class UpdateDEPEnrollmentView(PermissionRequiredMixin, TemplateView):
             enrollment_secret_form.save_m2m()
             if serialize_dep_profile(dep_enrollment) != prev_dep_profile:
                 logger.info("Push updated DEP profile %s to ABM", dep_enrollment.pk)
-                transaction.on_commit(lambda: define_dep_profile_task.apply_async((dep_enrollment.pk,)))
+                transaction.on_commit(
+                    lambda: define_dep_profile_task.apply_async(
+                        (dep_enrollment.pk,), {"task_user": request.user.id}
+                    )
+                )
             else:
                 logger.info("DEP profile %s unchanged", dep_enrollment.pk)
             post_audit_event(request, dep_enrollment, AuditEvent.Action.UPDATED, prev_value=prev_value)


### PR DESCRIPTION
## Problem

`/api/task_result/<uuid:task_id>/` and `/api/task_result/<uuid:task_id>/download/` set `authentication_classes` but no `permission_classes`, so the project default `IsAuthenticated` was the whole check. Neither view filtered on a user. Any authenticated principal that had a task ID could read the state of any task, and download any exported file, whatever the model permissions that gated the export in the first place. The endpoint is shared by every export in Zentral: inventory, MDM, Monolith, Osquery, Santa, Intune and Workspace ONE.

The link to make the check with exists. `accounts.UserTask` joins a user to a `TaskResult`, and the console task list and task pages already use it. It was written but never read for authorization on the API.

## Part 1 — the tasks with no user

There are 22 launch sites. `apply_async` is the only entry point: there is no `.delay()`, no `chain`, `group`, `chord` or `signature`, and no Celery beat schedule, so no periodic tasks. 19 of the 22 pass `task_user`. The other three:

| Site | Kind | Decision |
|---|---|---|
| `mdm/views/dep_enrollments.py` `define_dep_profile_task` | user-initiated | **Fixed.** It passes `task_user` now, and the task takes `**kwargs` like the others. Nothing polls it — the view redirects — so it only ever appeared in the task list, and it did not appear there. |
| `osquery/public_views.py` `build_file_carving_session_archive` | device-initiated | **Correct as is.** An Osquery agent finishes a carve upload and there is no user. The task writes to `FileCarvingSession.archive` and returns no `filepath`, so it never reaches the download endpoint. |
| `mdm/tasks.py` `assign_dep_virtual_server_default_enrollment_task` | chained | **Correct as is.** It inherits the user of the synchronization that scheduled it. Its only parent is an API view that always passes one. |

Two of the 26 tasks had no `**kwargs`. `define_dep_profile_task` needed it; `build_file_carving_session_archive` does not, because it is never given a user.

A task with no user is superuser-only from here on. Nothing in the console or the API polls one, so no flow breaks: every `.task` link in the templates points at an API view that passes `task_user`.

## Part 2 — the enforcement

Both views read through `task_results_for_user()`, which scopes to the `UserTask` row. A superuser sees every task, and a service account never does, the rule of `ZentralBackend.has_perm`. `User.save()` already forces `is_superuser = False` on a service account; the check does not depend on that.

A task that is hidden is a task that does not exist. The state endpoint answers `UNKNOWN`/`unready`, which is what it already answered for an unknown ID, and the download endpoint gives a `404`. Neither confirms that the ID exists. The console views now share the queryset, so the two surfaces cannot drift apart.

## The edge cases

**Best-effort ownership.** `create_task_result_on_publish` logged any failure and published the task anyway. That silence becomes an unexplainable `404` once the endpoints check ownership, so the write fails the launch now. This is safe: `before_task_publish` runs before `producer.publish`, and Django signals do not swallow exceptions, so the message never reaches the broker. Inside a request that is a clean rollback under `ATOMIC_REQUESTS`.

A missing user is the exception, and is still only logged. The cascade already removed the ownership row with the user, so there is nobody left to attribute the task to and nobody to keep it from — and failing there would kill a DEP assignment mid-retry for no gain.

**Retries.** `self.retry()` republishes the same task ID, so `UserTask.objects.create` hit the `OneToOne` constraint and logged an error on every retry of the DEP default enrollment assignment. It is a `get_or_create` now, which also keeps the first user.

**`ATOMIC_REQUESTS` orphans.** The `UserTask` row is written inside the request transaction while the broker publish is not transactional, so a view that raised after `apply_async` would leave a queued task with no ownership row. No launcher can: 20 of them return a `Response` or a `redirect` immediately, and the two remaining ones publish from `transaction.on_commit`, after the commit.

**Old task results.** A task from before v2025.11 has no `UserTask` at all, so only a superuser can read it. Exports are temporary — launching the export again gives a new file. Noted as a backward incompatibility.

**Service accounts** launch and download as the same principal, so they keep working. Covered by a test.

## Testing

Full suite: 8220 tests, green. 100% patch coverage, verified by intersecting `coverage json` `missing_lines` with the `git diff -U0` hunks.

Unrelated: `tests/monolith/test_rebuild_manifest_enrollment_packages_cmd.py::test_rebuild_with_a_storage_without_a_local_path` is order-dependent and failed in one full run. It asserts on a filename captured before the rebuild, so it breaks whenever the media storage has to rename the file. Deleting the stale files under `/var/zentral/monolith` makes it pass. It is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
