### PR TITLE
Verify the store of a worker on an interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ The event store cache expires after 300 seconds now. A notifier notification was
 
 The probe caches expire after 300 seconds now. A notifier notification was the only thing that made an instance load them again, so an instance that did not get one matched events against the probes it read when it started. Some probe views are built from another view. Such a view follows the version of the view it is built from, and not an age of its own, so 300 seconds is the delay for all of them.
 
+A store worker verifies the configuration of its store every 300 seconds now. Before, only a notifier notification made the worker apply a change, and the notifier does not guarantee delivery. A worker that did not receive the notification kept the event filters and the credentials from its start, and an operator had to restart it. The worker now stops when it finds a change to its store, and starts again with the configuration in the database.
+
 Fixed the `zentral_audit` events of the Santa enrollments and the Santa enrolled machines, which were not linked to the object they report. A model that declares the parents of an object replaced the link to the object itself, and the events of that object did not reach its page. A model keeps control of its own key when it declares one, because the MDM commands are linked by UUID and not by primary key.
 
 Fixed the version of an Osquery query in the events published when a user changed the query from the web console. The version was a database expression, and not a number.

--- a/tests/core_queues/test_aws_sns_sqs.py
+++ b/tests/core_queues/test_aws_sns_sqs.py
@@ -844,3 +844,48 @@ class AWSSNSSQSQueuesTestCase(TestCase):
             thread.start.assert_called_once()
             thread.join.assert_called_once()
         self.assertTrue(consumer.stop_event.is_set())
+
+    # store worker config
+
+    def _build_store_worker(self):
+        with patch("zentral.core.queues.backends.aws_sns_sqs.EventQueues.get_queue") as get_queue:
+            get_queue.return_value = (True, "store-worker-http", "https://www.example.com/fomo")
+            store = self.build_store(name=get_random_string(12), provisioned=True)
+            return store, self.get_queues().get_store_worker(store)
+
+    def test_stop_receiving_for_store_update(self):
+        store, w = self._build_store_worker()
+        self.assertFalse(w.stop_receiving_event.is_set())
+        with self.assertLogs("zentral.core.queues.backends.aws_sns_sqs", level="WARNING") as cm:
+            w.stop_receiving_for_store_update()
+        self.assertTrue(w.stop_receiving_event.is_set())
+        self.assertIn(f"store worker {store.name} - stop receiving events, the store has been updated",
+                      "\n".join(cm.output))
+
+    def test_stop_receiving_for_store_update_is_idempotent(self):
+        _, w = self._build_store_worker()
+        with self.assertLogs("zentral.core.queues.backends.aws_sns_sqs", level="WARNING") as cm:
+            w.stop_receiving_for_store_update()
+            w.stop_receiving_for_store_update()
+        # both ways of learning can find the same change, the second one is a no-op
+        self.assertEqual(len(cm.output), 1)
+        self.assertTrue(w.stop_receiving_event.is_set())
+
+    def test_store_worker_run_watches_the_store_config(self):
+        store, w = self._build_store_worker()
+        with patch("zentral.core.queues.backends.aws_sns_sqs.StoreWorkerConfigWatcher") as watcher, \
+             patch.object(BaseConsumer, "run") as consumer_run:
+            w.run()
+        watcher.assert_called_once_with(store, w.stop_receiving_for_store_update)
+        # the with block is what keeps it: the notifier holds its callback weakly
+        watcher.return_value.__enter__.assert_called_once()
+        watcher.return_value.__exit__.assert_called_once()
+        consumer_run.assert_called_once()
+
+    def test_store_worker_run_leaves_the_watcher_on_an_error(self):
+        _, w = self._build_store_worker()
+        with patch("zentral.core.queues.backends.aws_sns_sqs.StoreWorkerConfigWatcher") as watcher, \
+             patch.object(BaseConsumer, "run", side_effect=Exception("boom")):
+            with self.assertRaises(Exception):
+                w.run()
+        watcher.return_value.__exit__.assert_called_once()

--- a/tests/core_stores/test_sync.py
+++ b/tests/core_stores/test_sync.py
@@ -1,0 +1,196 @@
+from datetime import timedelta
+from unittest.mock import Mock, patch
+from django.test import TestCase
+from zentral.core.stores.models import Store
+from zentral.core.stores.sync import signal_store_change, StoreWorkerConfigWatcher
+from .utils import force_store
+
+
+class TestSignalStoreChange(TestCase):
+    def test_signal_store_change(self):
+        store = force_store()
+        with patch("zentral.core.stores.sync.notifier") as notifier:
+            signal_store_change(store)
+        notifier.send_notification.assert_called_once_with("stores.store", str(store.pk))
+
+
+class TestStoreWorkerConfigWatcher(TestCase):
+    maxDiff = None
+
+    def test_an_unchanged_store_is_not_a_change(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        self.assertFalse(watcher.store_changed())
+
+    def test_a_saved_store_is_a_change(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        store.instance.save()  # auto_now moves updated_at
+        self.assertTrue(watcher.store_changed())
+
+    def test_a_deleted_store_is_a_change(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        Store.objects.filter(pk=store.pk).delete()
+        # the notification cannot tell a deletion apart, so this has to agree
+        self.assertTrue(watcher.store_changed())
+
+    def test_a_database_error_is_not_a_change(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        with patch("zentral.core.stores.models.Store.objects") as objects:
+            objects.filter.side_effect = Exception("boom")
+            with self.assertLogs("zentral.core.stores.sync", level="ERROR") as cm:
+                self.assertFalse(watcher.store_changed())
+                self.assertFalse(watcher.store_changed())
+        # not a reason to stop the worker, but the count shows how long it lasts
+        self.assertEqual(watcher.failures, 2)
+        self.assertIn(f"store worker {store.name} - could not read the store, 2 consecutive failure(s)",
+                      "\n".join(cm.output))
+
+    def test_a_read_that_works_resets_the_failures(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        watcher.failures = 7
+        self.assertFalse(watcher.store_changed())
+        self.assertEqual(watcher.failures, 0)
+
+    def test_one_read_uses_one_query(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        with self.assertNumQueries(1):
+            watcher.store_changed()
+
+    # the notification
+
+    def test_notification_for_this_store(self):
+        store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        with self.assertLogs("zentral.core.stores.sync", level="WARNING") as cm:
+            watcher.handle_notification(str(store.pk))
+        stop.assert_called_once_with()
+        self.assertIn(f"store worker {store.name} - store changed, found by notification", "\n".join(cm.output))
+
+    def test_notification_for_another_store(self):
+        store = force_store()
+        other_store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        watcher.handle_notification(str(other_store.pk))
+        stop.assert_not_called()
+
+    def test_notification_error(self):
+        store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        with self.assertLogs("zentral.core.stores.sync", level="ERROR") as cm:
+            watcher.handle_notification()  # no argument
+        stop.assert_not_called()
+        self.assertIn(f"store worker {store.name} - could not process the store update notification",
+                      "\n".join(cm.output))
+
+    def test_start_registers_the_notifier_callback(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        with patch("zentral.core.stores.sync.notifier") as notifier, \
+             patch("zentral.core.stores.sync.threading.Thread"):
+            watcher.start()
+        notifier.add_callback.assert_called_once()
+        self.assertEqual(notifier.add_callback.call_args.args[0], "stores.store")
+
+    def test_context_manager_starts_and_stops(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        with patch.object(watcher, "start") as start, patch.object(watcher, "stop") as stop:
+            with watcher as entered:
+                self.assertIs(entered, watcher)
+                start.assert_called_once_with()
+                stop.assert_not_called()
+            stop.assert_called_once_with()
+
+    # the loop
+
+    def test_the_loop_stops_the_worker_on_an_update(self):
+        store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        watcher.interval_seconds = 0
+        with patch("zentral.core.stores.sync.connection") as connection:
+            with patch.object(watcher, "store_changed", side_effect=[False, True]):
+                with self.assertLogs("zentral.core.stores.sync", level="WARNING") as cm:
+                    watcher._run()
+        stop.assert_called_once_with()
+        self.assertIn(f"store worker {store.name} - store changed, found by interval", "\n".join(cm.output))
+        # the connection is released after every read, not held between them
+        self.assertEqual(connection.close.call_count, 2)
+
+    def test_a_failed_iteration_releases_the_connection_and_keeps_the_loop(self):
+        store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        watcher.interval_seconds = 0
+        calls = []
+
+        def boom():
+            calls.append(1)
+            if len(calls) == 2:
+                # a second iteration is what proves the first one did not kill the thread
+                watcher.stop()
+            raise Exception("boom")
+
+        with patch("zentral.core.stores.sync.connection") as connection:
+            with patch.object(watcher, "store_changed", side_effect=boom):
+                with self.assertLogs("zentral.core.stores.sync", level="ERROR") as cm:
+                    watcher._run()
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(connection.close.call_count, 2)
+        stop.assert_not_called()
+        self.assertIn(f"store worker {store.name} - the store verification failed", "\n".join(cm.output))
+
+    def test_a_stop_that_raises_leaves_the_interval_armed(self):
+        store = force_store()
+        stop = Mock(side_effect=[Exception("boom"), None])
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        watcher.interval_seconds = 0
+        with patch("zentral.core.stores.sync.connection"):
+            with patch.object(watcher, "store_changed", return_value=True):
+                with self.assertLogs("zentral.core.stores.sync", level="WARNING"):
+                    watcher._run()
+        # the first stop raised, so the flag stayed clear and the next interval tried it again
+        self.assertEqual(stop.call_count, 2)
+        self.assertTrue(watcher._stopped.is_set())
+
+    def test_a_change_ends_the_loop(self):
+        store = force_store()
+        watcher = StoreWorkerConfigWatcher(store, Mock())
+        # a notification stops the thread too, it has nothing left to watch
+        watcher.handle_notification(str(store.pk))
+        watcher.interval_seconds = 0
+        with patch.object(watcher, "store_changed") as store_changed:
+            watcher._run()
+        store_changed.assert_not_called()
+
+    def test_the_loop_leaves_when_it_is_stopped(self):
+        store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        watcher.interval_seconds = 0
+        watcher.stop()
+        watcher._run()
+        stop.assert_not_called()
+
+    def test_start_runs_the_loop_in_a_thread(self):
+        store = force_store()
+        stop = Mock()
+        watcher = StoreWorkerConfigWatcher(store, stop)
+        watcher.interval_seconds = 0
+        store.instance.updated_at -= timedelta(seconds=1)
+        watcher.updated_at = store.instance.updated_at
+        with patch("zentral.core.stores.sync.notifier"), \
+             patch("zentral.core.stores.sync.threading.Thread") as thread:
+            watcher.start()
+        thread.assert_called_once()
+        self.assertTrue(thread.call_args.kwargs["daemon"])
+        self.assertEqual(thread.call_args.kwargs["target"], watcher._run)
+        thread.return_value.start.assert_called_once()

--- a/zentral/core/queues/backends/aws_sns_sqs/__init__.py
+++ b/zentral/core/queues/backends/aws_sns_sqs/__init__.py
@@ -4,11 +4,9 @@ import queue
 import signal
 import threading
 import time
-import weakref
 from importlib import import_module
 
 import boto3
-from base.notifier import notifier
 from botocore.config import Config
 from django.utils.functional import cached_property
 
@@ -17,6 +15,7 @@ from zentral.conf.config import ConfigDict
 from zentral.core.queues.backends.base import BaseEventQueues
 from zentral.core.queues.compression import compress_raw_event_if_needed
 from zentral.core.queues.preprocessing import iter_preprocessed_events
+from zentral.core.stores.sync import StoreWorkerConfigWatcher
 from zentral.utils.signals import setup_signal_handler
 from zentral.utils.time import naive_utcnow
 
@@ -59,6 +58,9 @@ class WorkerMixin:
 
     def log_info(self, msg, *args):
         self.log(msg, logging.INFO, *args)
+
+    def log_warning(self, msg, *args):
+        self.log(msg, logging.WARNING, *args)
 
     def log_error(self, msg, *args):
         self.log(msg, logging.ERROR, *args)
@@ -174,20 +176,16 @@ class ProcessWorker(WorkerMixin, Consumer):
 
 
 class StoreWorkerMixin(WorkerMixin):
-    def store_notification_handler(self, *args, **kwargs):
-        try:
-            if str(args[0]) == str(self.event_store.pk):
-                if not self.stop_receiving_event.is_set():
-                    logger.warning("Stop receiving events because the store has been updated.")
-                    self.stop_receiving_event.set()
-        except Exception:
-            logger.exception("Could not process store update notification.")
+    def stop_receiving_for_store_update(self):
+        if not self.stop_receiving_event.is_set():
+            self.log_warning("stop receiving events, the store has been updated")
+            self.stop_receiving_event.set()
 
     def run(self, *args, **kwargs):
         self.log_info("run")
         super().setup_metrics_exporter(*args, **kwargs)
-        notifier.add_callback("stores.store", weakref.WeakMethod(self.store_notification_handler))
-        super().run(*args, **kwargs)
+        with StoreWorkerConfigWatcher(self.event_store, self.stop_receiving_for_store_update):
+            super().run(*args, **kwargs)
 
     def skip_event(self, receipt_handle, event_d):
         event_type = event_d['_zentral']['type']

--- a/zentral/core/stores/sync.py
+++ b/zentral/core/stores/sync.py
@@ -1,5 +1,97 @@
+import logging
+import threading
+import weakref
+from django.db import connection
 from base.notifier import notifier
+
+
+logger = logging.getLogger("zentral.core.stores.sync")
 
 
 def signal_store_change(store):
     notifier.send_notification("stores.store", str(store.pk))
+
+
+class StoreWorkerConfigWatcher:
+    """Stop a store worker when its store is updated or deleted.
+
+    A worker builds its backend one time and cannot exchange it while it runs, so
+    stopping is how it takes a change: the process leaves, and whatever supervises
+    it starts a new one on the configuration in the database.
+
+    The "stores.store" notification says so in a second and can be lost. Reading
+    updated_at every interval_seconds always works and only every interval_seconds.
+    Both call stop_worker, which therefore has to be idempotent.
+    """
+
+    interval_seconds = 300
+
+    def __init__(self, store, stop_worker):
+        self.store_pk = store.pk
+        self.store_name = store.name
+        self.updated_at = store.updated_at
+        self.failures = 0
+        self._stop_worker = stop_worker
+        self._stopped = threading.Event()
+
+    def start(self):
+        # the notifier keeps the callback weakly: the with block is what holds us
+        notifier.add_callback("stores.store", weakref.WeakMethod(self.handle_notification))
+        # daemon: it sleeps interval_seconds at a time, stop() is the way out
+        threading.Thread(target=self._run, name="store config watcher thread", daemon=True).start()
+
+    def stop(self):
+        self._stopped.set()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.stop()
+
+    def handle_notification(self, *args, **kwargs):
+        try:
+            if str(args[0]) == str(self.store_pk):
+                self._stop_for_change("notification")
+        except Exception:
+            logger.exception("store worker %s - could not process the store update notification", self.store_name)
+
+    def _run(self):
+        while not self._stopped.wait(self.interval_seconds):
+            try:
+                try:
+                    changed = self.store_changed()
+                finally:
+                    connection.close()  # a long sleep follows, do not hold it
+                if changed:
+                    self._stop_for_change("interval")
+            except Exception:
+                # this half is the one that always arrives: a dead thread would take it away
+                logger.exception("store worker %s - the store verification failed", self.store_name)
+
+    def _stop_for_change(self, source):
+        logger.warning("store worker %s - store changed, found by %s", self.store_name, source)
+        # stop before the flag: a stop that raises has to leave the interval armed to try it again
+        self._stop_worker()
+        self._stopped.set()  # nothing left to watch
+
+    def store_changed(self):
+        from .models import Store  # avoid a circular import
+        try:
+            updated_at = (
+                Store.objects.filter(pk=self.store_pk)
+                .values_list("updated_at", flat=True)
+                .first()
+            )
+        except Exception:
+            # a worker does not need the database, keep it and count the failures
+            self.failures += 1
+            logger.exception("store worker %s - could not read the store, %s consecutive failure(s)",
+                             self.store_name, self.failures)
+            return False
+        self.failures = 0
+        if updated_at is None:
+            # deleted: the notification stops the worker for this too, so agree
+            return True
+        return updated_at > self.updated_at


### PR DESCRIPTION
## Problem

A store worker builds its backend one time. The backend holds the event filters, the endpoint, the credentials and the batch size. The worker cannot replace the backend while it runs. To apply a change, the worker stops. The process then starts again and reads the configuration from the database.

Only the `stores.store` notification stopped the worker. The notification is one message, and delivery is not guaranteed. A worker that did not receive the notification kept the configuration from its start, and gave no sign of the problem:

- **Event filters.** `skip_event()` calls `self.event_store.is_serialized_event_included()`. Old filters keep or drop events by the old rules. There is no error and no log message.
- **Backend kwargs.** The endpoint, the credentials and the index. A changed credential makes every write fail. It can also keep the writes to an endpoint that nobody monitors.
- **The class of the worker.** `get_store_worker()` reads `batch_size` and `concurrency` when it builds the worker. A store that changes from 1 to 100 keeps a `SimpleStoreWorker`.

A cache can use a maximum age, because it reads its configuration again. A worker cannot, because it holds a live client.

## Change

`StoreWorkerConfigWatcher` holds the two ways to find a change to the store. Both call the same `stop_worker` function:

- the notification, when it arrives
- a read of `updated_at` every 300 seconds, which always arrives

The worker asks for one thing, and does not keep a fast path and a slow path in agreement. The log message tells which of the two found the change, so an operator can see that the notifier does not work.

### A deletion also stops the worker

The notification holds only a primary key. It cannot tell a deletion from an update, and it stops the worker for both. A row that is no longer in the database is therefore also a change. If it were not, the result would depend on the delivery of a message, and a deleted store would continue to receive events.

### A read that fails does not stop the worker

A store worker does not need the database. It reads its events from the queue, and writes them to the backend. A stop after a failed read would restart a good worker for an unrelated failure. The watcher counts the failures instead, so the log shows the difference between one failure and a fallback that is down for hours. Only this half is degraded then. The notification continues to work, and the two halves fail in different places.

### Three parts that are easy to break

- **The `with` block holds the watcher.** The notifier keeps a weak reference to the callback, so the watcher must stay in memory for as long as the worker runs. The `with` block gives it that lifetime, and the worker needs no attribute and no `try`/`finally`.
- **The stop comes before the flag.** `_stop_for_change()` calls `stop_worker` first, and sets its own flag after. If the stop fails, the interval stays active and makes the next attempt. The opposite order stops the interval first, and nothing tries again.
- **The interval thread catches all its errors.** A thread that stops leaves the worker with the notification alone, which is the failure this pull request removes.

Two more results: the queue backend no longer imports the notifier, and `WorkerMixin` has a `log_warning` method with the other three.

## Not in this pull request

**The other two queue backends.** The notification handler was in the AWS SNS and SQS backend only. A store worker on Google Pub/Sub or on kombu applies no configuration change, with or without a notification. That is a missing function, not an unreliable one, and the three backends stop a worker in three different ways. The watcher takes the stop as an argument for that reason. Each backend is then a small change, but it belongs in its own pull request.

**A store that is added or removed.** `get_workers()` reads the list of stores when the process starts. A store that is added after that has no worker until the workers start again. No notification can change this.

## Tests

`zentral/core/stores/sync.py` is at **100%**: a store that does not change, a store that changes, a store that is deleted, a read that fails and the count that it keeps, the number of queries of one read, the notification for this store, for a different store and without an argument, `start()` for what it registers and what it runs, the context manager, and the loop for a change, for an iteration that fails, for a stop that raises and for a stop.

On the worker: the stop, the second stop that does nothing, and `run()`, which builds the watcher and uses it as a context manager, also when the consumer raises.

`zentral/core/queues/backends/aws_sns_sqs/__init__.py` is at **85%**. The other gaps are in the run loops of the other workers, in `process_event` and in the graceful stop.

The full test suite passes.
