### PR TITLE
santa: reject the compiler policy on an incompatible target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@ The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `
 
 `zentral_santa_enrolled_machines_total` and `zentral_santa_enrolled_machines_sync_total` are replaced by `zentral_santa_enrolled_machines_bucket` and `zentral_santa_enrolled_machines_sync_bucket`, which have an `le` label. The `le="+Inf"` bucket gives the value of the two removed gauges: in a dashboard or an alert, change the metric name and select that bucket. A query that sums the buckets counts each machine seven times.
 
+#### 🧨 Santa compiler rules on team ID and certificate targets
+
+A rule with the `ALLOWLIST_COMPILER` policy is rejected on a target that is not a cdhash, a binary or a signing ID, in the web console, the rule API and the ruleset API. The Santa client only accepts the compiler state on those three rule types. On a team ID or a certificate it drops the rule when it evaluates it, so the rule synchronized cleanly and then left its target with no rule at all, which blocks the target in lockdown mode. The rules already in the database keep their policy, but Zentral rejects each of them at the next write: a ruleset that you post again, a `PUT` on the rule API, a Terraform configuration that you apply again, and a change to any other attribute of the rule in the web console.
+
 #### 🧨 Privilege escalation hardening — task results
 
 A task belongs to the user or the service account that launched it, and `/api/task_result/<task_id>/` and `/api/task_result/<task_id>/download/` answer only for that principal. A superuser reads all of them, as before. Until now the two endpoints only asked for a valid session or API token: any authenticated principal that had a task ID could read the state of that task and download its file, and an export carries everything the principal that launched it was allowed to see. The state endpoint gives the `UNKNOWN` status for the task of a different principal, like it does for a task that does not exist, and the download endpoint gives a `404`. The task list and the task pages of the web console already applied this rule.

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -118,7 +118,7 @@ The payload is an array of [NotificationSettingItem](https://developer.apple.com
 
 ### Definitions
 
-Zentral Santa rule combine a *target* and a *policy*. The target can be of type `Binary`, `Bundle`, `Certificate` or `Team ID`. A target is uniquely identified by its type, and its identifier (sha256 hexdigest for `Binary`, `Bundle` and `Certificate` targets). The policy can be one of `Allowlist`, `Blocklist`, `Silent blocklist` and `Allowlist compiler`.
+A Zentral Santa rule combines a *target* and a *policy*. The target can be of type `cdhash`, `Binary`, `Signing ID`, `Certificate` or `Team ID`. A target is uniquely identified by its type, and its identifier: a sha256 hexdigest for `Binary` and `Certificate`, a 40 character hexdigest for `cdhash`, `TEAMID:SIGNINGID` for `Signing ID`, and the 10 character team ID for `Team ID`. `Bundle` is a sixth type that only exists in Zentral, see below. The policy can be one of `Allowlist`, `Allowlist compiler`, `Blocklist`, `Silent blocklist` and `CEL`.
 
 To avoid conflicts, there is at most **one rule per target** for each configuration.
 
@@ -127,6 +127,10 @@ To avoid conflicts, there is at most **one rule per target** for each configurat
 **Bundle** targets are only available when Zentral managed to get the full bundle information from Santa. This happens only when Santa blocks a binary that is part of a bundle, and when `Enable bundles` is set to true in the Zentral Santa configuration. Rules on a bundle target only exist in Zentral. There are expanded to a list of binary rules when sent to the Santa agent – this is the reason why we need the bundle information.
 
 **Allowlist compiler** rules will only generate local transitive rules when `Enable transitive rules` is set to true in the Zentral Santa configuration. A transitive Allowlist rule will be created locally for each file written by the targets of those Santa rules.
+
+This policy is only available for `cdhash`, `Binary` and `Signing ID` targets. The Santa agent does not accept the compiler policy on a `Certificate` or a `Team ID` rule. It drops such a rule when it evaluates it, and the target keeps no rule at all, which blocks it in lockdown mode. Zentral rejects these rules.
+
+**CEL** rules carry an expression that the Santa agent evaluates for each execution of the target. Zentral stores the expression and sends it to the agent with the rule. See the [Santa documentation](https://northpole.dev/features/binary-authorization.html#cel) for the syntax of the expression and for the values that it can return.
 
 ### Quick start
 

--- a/docs/apps/santa.md
+++ b/docs/apps/santa.md
@@ -759,9 +759,9 @@ The rulesets can be posted in JSON or YAML format. See *Examples* below, and the
 
 |Attribute|Mandatory|Value|
 |---|---|---|
-|`rule_type`|✓|Either `BINARY`, `CERTIFICATE`, `BUNDLE`, or `TEAMID`|
-|`identifier`|✓|The `BINARY`, `CERTIFICATE`, `BUNDLE` sha256 hex digest,<br>or the `TEAMID` of the signing certificate|
-|`policy`|✓|Either `ALLOWLIST`, `ALLOWLIST_COMPILER`, `BLOCKLIST`,<br>or `SILENT_BLOCKLIST`|
+|`rule_type`|✓|Either `CDHASH`, `BINARY`, `SIGNINGID`, `CERTIFICATE`,<br>or `TEAMID`|
+|`identifier`|✓|The `BINARY` or `CERTIFICATE` sha256 hex digest,<br>the `CDHASH` hex digest,<br>the `SIGNINGID` as `TEAMID:BUNDLEID` (or `platform:BUNDLEID`),<br>or the `TEAMID` of the signing certificate|
+|`policy`|✓|Either `ALLOWLIST`, `ALLOWLIST_COMPILER`, `BLOCKLIST`,<br>or `SILENT_BLOCKLIST`.<br>`ALLOWLIST_COMPILER` is only valid for the `SIGNINGID`, `BINARY`<br>and `CDHASH` rule types|
 |`custom_msg`||Optional message to show when the application is blocked.<br>Only valid for a `BLOCKLIST` policy|
 |`description`||Optional description to add context to a rule.<br>Only displayed in the Zentral GUI.|
 |`serial_numbers`||A list of machine serial numbers.<br>If set, **only** those machines will receive the rule|

--- a/tests/santa/test_api_views.py
+++ b/tests/santa/test_api_views.py
@@ -888,6 +888,48 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
             {"rules": {"0": {"non_field_errors": ["Conflict between tags and excluded_tags"]}}}
         )
 
+    def test_ruleset_update_compiler_policy_rule_type_error(self):
+        self.set_permissions("santa.add_ruleset", "santa.change_ruleset",
+                             "santa.add_rule", "santa.change_rule", "santa.delete_rule")
+        url = reverse("santa_api:ruleset_update")
+        for rule_type, identifier in ((Target.Type.TEAM_ID, new_team_id()),
+                                      (Target.Type.CERTIFICATE, new_sha256())):
+            with self.subTest(rule_type):
+                data = {
+                    "name": get_random_string(12),
+                    "rules": [
+                        {"rule_type": rule_type,
+                         "identifier": identifier,
+                         "policy": "ALLOWLIST_COMPILER"},
+                    ]
+                }
+                response = self.post(url, data)
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.json(), {"rules": {"0": {"policy": [Target.Type.compiler_policy_error()]}}})
+        self.assertEqual(Rule.objects.count(), 0)
+
+    def test_ruleset_update_compiler_policy_rules(self):
+        self.set_permissions("santa.add_ruleset", "santa.change_ruleset",
+                             "santa.add_rule", "santa.change_rule", "santa.delete_rule")
+        url = reverse("santa_api:ruleset_update")
+        for rule_type, identifier in ((Target.Type.CDHASH, new_cdhash()),
+                                      (Target.Type.BINARY, new_sha256()),
+                                      (Target.Type.SIGNING_ID, new_signing_id_identifier())):
+            with self.subTest(rule_type):
+                data = {
+                    "name": get_random_string(12),
+                    "rules": [
+                        {"rule_type": rule_type,
+                         "identifier": identifier,
+                         "policy": "ALLOWLIST_COMPILER"},
+                    ]
+                }
+                response = self.post(url, data)
+                self.assertEqual(response.status_code, 200)
+                rule = self.configuration.rule_set.select_related("target").get(target__identifier=identifier)
+                self.assertEqual(rule.target.type, rule_type)
+                self.assertEqual(rule.policy, Rule.Policy.ALLOWLIST_COMPILER)
+
     def test_ruleset_update_rule_unusual_signingid(self):
         self.set_permissions("santa.add_ruleset", "santa.change_ruleset",
                              "santa.add_rule", "santa.change_rule", "santa.delete_rule")
@@ -1242,6 +1284,40 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                          {'target_type': ['"BUNDLE" is not a valid choice.']})
         self.assertEqual(Rule.objects.count(), 0)
 
+    def test_create_rule_compiler_policy_target_type_error(self):
+        self.set_permissions("santa.add_rule")
+        for target_type, target_identifier in ((Target.Type.TEAM_ID, new_team_id()),
+                                               (Target.Type.CERTIFICATE, new_sha256())):
+            with self.subTest(target_type):
+                data = {
+                    "configuration": self.configuration.pk,
+                    "policy": Rule.Policy.ALLOWLIST_COMPILER,
+                    "target_type": target_type,
+                    "target_identifier": target_identifier
+                }
+                response = self.post(reverse("santa_api:rules"), data)
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertEqual(response.json(), {"policy": [Target.Type.compiler_policy_error()]})
+        self.assertEqual(Rule.objects.count(), 0)
+
+    def test_create_rule_compiler_policy(self):
+        self.set_permissions("santa.add_rule")
+        for target_type, target_identifier in ((Target.Type.CDHASH, new_cdhash()),
+                                               (Target.Type.BINARY, new_sha256()),
+                                               (Target.Type.SIGNING_ID, new_signing_id_identifier())):
+            with self.subTest(target_type):
+                data = {
+                    "configuration": self.configuration.pk,
+                    "policy": Rule.Policy.ALLOWLIST_COMPILER,
+                    "target_type": target_type,
+                    "target_identifier": target_identifier
+                }
+                response = self.post(reverse("santa_api:rules"), data)
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                rule = Rule.objects.select_related("target").get(pk=response.json()["id"])
+                self.assertEqual(rule.target.type, target_type)
+                self.assertEqual(rule.policy, Rule.Policy.ALLOWLIST_COMPILER)
+
     def test_create_rule_policy_custom_msg_error(self):
         self.set_permissions("santa.add_rule")
         data = {
@@ -1560,6 +1636,24 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         rule.refresh_from_db()
         self.assertEqual(rule.description, "Description Text Updated")
         self.assertEqual(rule.version, 1)
+
+    def test_update_rule_compiler_policy_target_type_error(self):
+        self.set_permissions("santa.change_rule")
+        for target_type, target_identifier in ((Target.Type.TEAM_ID, new_team_id()),
+                                               (Target.Type.CERTIFICATE, new_sha256())):
+            with self.subTest(target_type):
+                rule = self.force_rule(target_type=target_type, target_identifier=target_identifier)
+                data = {
+                    "configuration": rule.configuration.pk,
+                    "policy": Rule.Policy.ALLOWLIST_COMPILER,
+                    "target_type": rule.target.type,
+                    "target_identifier": rule.target.identifier
+                }
+                response = self.put(reverse("santa_api:rule", args=(rule.pk,)), data)
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertEqual(response.json(), {"policy": [Target.Type.compiler_policy_error()]})
+                rule.refresh_from_db()
+                self.assertEqual(rule.policy, Rule.Policy.ALLOWLIST)
 
     def test_update_rule_change_tags(self):
         tags = [t.id for t in self.force_tags(3)]

--- a/tests/santa/test_models.py
+++ b/tests/santa/test_models.py
@@ -1,6 +1,7 @@
 import datetime
+from django.core.exceptions import ValidationError
 from django.test import TestCase
-from zentral.contrib.santa.models import EnrolledMachine, Target
+from zentral.contrib.santa.models import EnrolledMachine, Rule, Target
 from tests.zentral_test_utils.assertions.serialization_assertions import SerializeForEventAssertions
 from .utils import (add_file_to_test_class, force_ballot, force_configuration, force_enrolled_machine,
                     force_realm_user, force_target, force_target_state, force_voting_group)
@@ -142,3 +143,51 @@ class SantaSerializationTestCase(TestCase, SerializeForEventAssertions):
         self.assertIsNone(serialized["last_preflight_at"])
         # the sync session is an implementation detail of the sync protocol
         self.assertNotIn("sync_session", serialized)
+
+
+class SantaRuleModelTestCase(TestCase):
+    maxDiff = None
+
+    # compiler policy target types
+
+    def test_compatible_with_compiler_policy(self):
+        # the order is the one the error message enumerates
+        self.assertEqual([member.value for member in Target.Type if member.compatible_with_compiler_policy],
+                         ["SIGNINGID", "BINARY", "CDHASH"])
+
+    def test_compiler_policy_error(self):
+        self.assertEqual(Target.Type.compiler_policy_error(),
+                         "Only available for SIGNINGID, BINARY, CDHASH targets")
+
+    # clean
+
+    def _clean_rule(self, target_type, policy):
+        rule = Rule(configuration=force_configuration(),
+                    target=force_target(target_type),
+                    policy=policy)
+        # the ruleset FK is nullable but not blank, and no rule form offers it
+        rule.full_clean(exclude=["ruleset"])
+
+    def test_clean_compiler_policy_incompatible_target_type(self):
+        for target_type in (Target.Type.TEAM_ID, Target.Type.CERTIFICATE):
+            with self.subTest(target_type):
+                with self.assertRaises(ValidationError) as cm:
+                    self._clean_rule(target_type, Rule.Policy.ALLOWLIST_COMPILER)
+                self.assertEqual(cm.exception.message_dict, {"policy": [Target.Type.compiler_policy_error()]})
+
+    def test_clean_compiler_policy_compatible_target_type(self):
+        for target_type in (Target.Type.CDHASH, Target.Type.BINARY, Target.Type.SIGNING_ID):
+            with self.subTest(target_type):
+                self._clean_rule(target_type, Rule.Policy.ALLOWLIST_COMPILER)
+
+    def test_clean_other_policy_any_target_type(self):
+        for target_type in (Target.Type.TEAM_ID, Target.Type.CERTIFICATE):
+            with self.subTest(target_type):
+                self._clean_rule(target_type, Rule.Policy.ALLOWLIST)
+
+    def test_clean_incomplete_rule(self):
+        for target, policy in ((None, Rule.Policy.ALLOWLIST_COMPILER),
+                               (force_target(Target.Type.TEAM_ID), None),
+                               (force_target(Target.Type.TEAM_ID), 42)):
+            with self.subTest(policy=policy, target=target):
+                Rule(configuration=force_configuration(), target=target, policy=policy).clean()

--- a/tests/santa/test_serializers.py
+++ b/tests/santa/test_serializers.py
@@ -4,7 +4,7 @@ from django.utils.crypto import get_random_string
 
 from zentral.conf import settings
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit
-from zentral.contrib.santa.models import Configuration, Enrollment
+from zentral.contrib.santa.models import Configuration, Enrollment, Target
 from zentral.contrib.santa.serializers import EnrollmentSerializer, RuleUpdateSerializer
 
 
@@ -102,6 +102,29 @@ class SantaSerializersTestCase(TestCase):
         sha256_errors = s.errors.get("sha256", [])
         self.assertEqual(len(sha256_errors), 1)
         self.assertEqual(str(sha256_errors[0]), "This field cannot be used in a TEAMID rule")
+
+    def test_rule_compiler_policy_incompatible_rule_type(self):
+        for rule_type, identifier in (("TEAMID", "43AQ936H96"),
+                                      ("CERTIFICATE", get_random_string(64, "0123456789abcdef"))):
+            with self.subTest(rule_type):
+                data = {"rule_type": rule_type,
+                        "identifier": identifier,
+                        "policy": "ALLOWLIST_COMPILER"}
+                serializer = RuleUpdateSerializer(data=data)
+                self.assertFalse(serializer.is_valid())
+                ed = serializer.errors["policy"][0]
+                self.assertEqual(str(ed), Target.Type.compiler_policy_error())
+
+    def test_rule_compiler_policy(self):
+        for rule_type, identifier in (("CDHASH", get_random_string(40, "0123456789abcdef")),
+                                      ("BINARY", get_random_string(64, "0123456789abcdef")),
+                                      ("SIGNINGID", "43AQ936H96:org.mozilla.firefoxdeveloperedition")):
+            with self.subTest(rule_type):
+                data = {"rule_type": rule_type,
+                        "identifier": identifier,
+                        "policy": "ALLOWLIST_COMPILER"}
+                serializer = RuleUpdateSerializer(data=data)
+                self.assertTrue(serializer.is_valid())
 
     def test_rule_custom_msg_allowlist(self):
         data = {"rule_type": "BINARY",

--- a/tests/santa/test_setup_views.py
+++ b/tests/santa/test_setup_views.py
@@ -1215,6 +1215,55 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "santa/rule_form.html")
         self.assertFormError(response.context["form"], "custom_url", "Cannot be set for this rule policy")
 
+    def test_create_configuration_rule_missing_policy(self):
+        self.login("santa.add_rule", "santa.view_rule")
+        configuration = force_configuration()
+        response = self.client.post(reverse("santa:create_configuration_rule", args=(configuration.pk,)),
+                                    {"target_type": Target.Type.BINARY,
+                                     "target_identifier": new_sha256()},
+                                    follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "santa/rule_form.html")
+        self.assertFormError(response.context["form"], "policy", "This field is required.")
+
+    def test_create_configuration_compiler_policy_target_type_error(self):
+        self.login("santa.add_rule", "santa.view_rule")
+        configuration = force_configuration()
+        for target_type, target_identifier in ((Target.Type.TEAM_ID, new_team_id()),
+                                               (Target.Type.CERTIFICATE, new_sha256())):
+            with self.subTest(target_type):
+                response = self.client.post(
+                    reverse("santa:create_configuration_rule", args=(configuration.pk,)),
+                    {"target_type": target_type,
+                     "target_identifier": target_identifier,
+                     "policy": Rule.Policy.ALLOWLIST_COMPILER},
+                    follow=True,
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "santa/rule_form.html")
+                self.assertFormError(response.context["form"], "policy", Target.Type.compiler_policy_error())
+        self.assertEqual(configuration.rule_set.count(), 0)
+
+    def test_create_configuration_compiler_policy_rules(self):
+        self.login("santa.add_rule", "santa.view_rule")
+        configuration = force_configuration()
+        for target_type, target_identifier in ((Target.Type.CDHASH, new_cdhash()),
+                                               (Target.Type.BINARY, new_sha256()),
+                                               (Target.Type.SIGNING_ID, new_signing_id_identifier())):
+            with self.subTest(target_type):
+                response = self.client.post(
+                    reverse("santa:create_configuration_rule", args=(configuration.pk,)),
+                    {"target_type": target_type,
+                     "target_identifier": target_identifier,
+                     "policy": Rule.Policy.ALLOWLIST_COMPILER},
+                    follow=True,
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "santa/configuration_rules.html")
+                rule = configuration.rule_set.select_related("target").get(target__identifier=target_identifier)
+                self.assertEqual(rule.target.type, target_type)
+                self.assertEqual(rule.policy, Rule.Policy.ALLOWLIST_COMPILER)
+
     def test_create_configuration_cel_expr_not_on_cel_rule_error(self):
         self.login("santa.add_configuration", "santa.view_configuration")
         configuration = force_configuration()
@@ -1709,6 +1758,37 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "santa/rule_form.html")
         self.assertFormError(response.context["form"], "cel_expr", "Can only be set on CEL rules")
+
+    def test_update_configuration_rule_compiler_policy_target_type_error(self):
+        self.login("santa.change_rule")
+        for target_type in (Target.Type.TEAM_ID, Target.Type.CERTIFICATE):
+            with self.subTest(target_type):
+                rule = force_rule(target_type=target_type)
+                response = self.client.post(
+                    reverse("santa:update_configuration_rule", args=(rule.configuration.pk, rule.pk)),
+                    {"policy": Rule.Policy.ALLOWLIST_COMPILER},
+                    follow=True,
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "santa/rule_form.html")
+                self.assertFormError(response.context["form"], "policy", Target.Type.compiler_policy_error())
+                rule.refresh_from_db()
+                self.assertEqual(rule.policy, Rule.Policy.BLOCKLIST)
+
+    def test_update_configuration_rule_to_compiler_policy(self):
+        self.login("santa.change_rule", "santa.view_rule")
+        for target_type in (Target.Type.CDHASH, Target.Type.BINARY, Target.Type.SIGNING_ID):
+            with self.subTest(target_type):
+                rule = force_rule(target_type=target_type)
+                response = self.client.post(
+                    reverse("santa:update_configuration_rule", args=(rule.configuration.pk, rule.pk)),
+                    {"policy": Rule.Policy.ALLOWLIST_COMPILER},
+                    follow=True,
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, "santa/configuration_rules.html")
+                rule.refresh_from_db()
+                self.assertEqual(rule.policy, Rule.Policy.ALLOWLIST_COMPILER)
 
     def test_update_configuration_rule_to_cel_rule(self):
         self.login("santa.view_configuration",

--- a/zentral/contrib/santa/forms.py
+++ b/zentral/contrib/santa/forms.py
@@ -397,12 +397,17 @@ class RuleForm(RuleFormMixin, forms.Form):
                 self.add_error(error_field, f"Invalid {target_type} identifier")
 
         # policy
+        policy = None
         try:
             policy = int(cleaned_data.get("policy"))
         except (TypeError, ValueError):
             pass
 
         if policy:
+            # compiler policy only on the target types the client accepts it on
+            if target_type and not Rule.Policy(policy).compatible_with_target_type(target_type):
+                self.add_error("policy", Target.Type.compiler_policy_error())
+
             # custom message/url only on blocklist or CEL rules
             if not Rule.Policy(policy).compatible_with_custom_msg_and_url:
                 error_field = None

--- a/zentral/contrib/santa/models.py
+++ b/zentral/contrib/santa/models.py
@@ -3,6 +3,7 @@ import uuid
 from collections import namedtuple
 
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError
 from django.core.validators import (
     MaxValueValidator,
     MinLengthValidator,
@@ -295,6 +296,17 @@ class Target(models.Model):
         @classmethod
         def rule_choices(cls):
             return [(member.value, member.label) for member in cls if member.is_native]
+
+        @property
+        def compatible_with_compiler_policy(self):
+            # the client only accepts the compiler state on these rule types
+            return self.value in (self.SIGNING_ID, self.BINARY, self.CDHASH)
+
+        @classmethod
+        def compiler_policy_error(cls):
+            return "Only available for {} targets".format(
+                ", ".join(member.value for member in cls if member.compatible_with_compiler_policy)
+            )
 
         @property
         def url_name(self):
@@ -1192,6 +1204,14 @@ class Rule(models.Model):
         def compatible_with_custom_msg_and_url(self):
             return self.value in (self.BLOCKLIST, self.CEL)
 
+        def compatible_with_target_type(self, target_type):
+            # only answers for the policy itself: a CEL expression can return ALLOWLIST_COMPILER
+            # too, and the client resolves the CEL state before the (type, state) lookup, so a CEL
+            # rule reaches the same invalid combination. The expression is opaque to the server.
+            if self.value != self.ALLOWLIST_COMPILER:
+                return True
+            return Target.Type(target_type).compatible_with_compiler_policy
+
         @property
         def sync_only(self):
             # the REMOVE policy is only used for the sync protocol
@@ -1226,6 +1246,12 @@ class Rule(models.Model):
 
     class Meta:
         unique_together = (("configuration", "target"),)
+
+    def clean(self):
+        # clean() also runs when the field validation failed, so the policy can be missing or unknown here
+        if self.target_id and self.policy in self.Policy.values:
+            if not self.Policy(self.policy).compatible_with_target_type(self.target.type):
+                raise ValidationError({"policy": Target.Type.compiler_policy_error()})
 
     def is_blocking_rule(self):
         return self.policy in (self.Policy.BLOCKLIST, self.Policy.SILENT_BLOCKLIST)

--- a/zentral/contrib/santa/serializers.py
+++ b/zentral/contrib/santa/serializers.py
@@ -139,6 +139,8 @@ class RuleSerializer(serializers.ModelSerializer):
 
         # policy
         policy = Rule.Policy(data.get("policy"))
+        if not policy.compatible_with_target_type(target_type):
+            raise serializers.ValidationError({"policy": Target.Type.compiler_policy_error()})
         if not policy.compatible_with_custom_msg_and_url:
             errors = {}
             for field in ["custom_msg", "custom_url"]:
@@ -289,6 +291,9 @@ class RuleUpdateSerializer(serializers.Serializer):
             if not identifier:
                 raise serializers.ValidationError({"identifier": f"Invalid {rule_type} identifier"})
             data["identifier"] = identifier
+        # compiler policy only on the rule types the client accepts it on
+        if not data["policy"].compatible_with_target_type(rule_type):
+            raise serializers.ValidationError({"policy": Target.Type.compiler_policy_error()})
         # custom message only with blocklist / CEL rule
         if not data["policy"].compatible_with_custom_msg_and_url:
             if data.get("custom_msg"):


### PR DESCRIPTION
## Problem

`Rule.Policy.ALLOWLIST_COMPILER` was accepted on any target type. Nothing tied the policy to a compatible target: not the model, not the forms, not the serializers.

The Santa client only accepts the compiler state on three rule types. `SNTPolicyProcessor.mm` looks the `(type, state)` pair up in a decision map, and that map has an entry for the compiler state only under `SNTRuleTypeCDHash`, `SNTRuleTypeBinary` and `SNTRuleTypeSigningID`:

```objc
{{SNTRuleTypeCDHash, SNTRuleStateAllowCompiler}, SNTEventStateAllowCompilerCDHash},
{{SNTRuleTypeBinary, SNTRuleStateAllowCompiler}, SNTEventStateAllowCompilerBinary},
{{SNTRuleTypeSigningID, SNTRuleStateAllowCompiler}, SNTEventStateAllowCompilerSigningID},
```

There is no such pair for `SNTRuleTypeTeamID` or `SNTRuleTypeCertificate`. The lookup misses, and the client logs an invalid type/state combination and returns `NO` — it treats the rule as if it were not found.

So a compiler rule on a team ID or a certificate target passed validation, synchronized cleanly, and then did nothing on the client. The failure is silent, and worse than a rejection: the target ends up with no rule at all, so it is blocked in lockdown mode. The `NSException` in the `SNTRuleStateAllowCompiler` branch further down is not what a server can trigger — the map lookup already returned before it, and the three cases it handles are the three valid ones.

## The rule

`Target.Type` carries it, the way it already carries `is_native`, and the message enumerates the members the way `rule_choices()` already does:

```python
@property
def compatible_with_compiler_policy(self):
    # the client only accepts the compiler state on these rule types
    return self.value in (self.SIGNING_ID, self.BINARY, self.CDHASH)

@classmethod
def compiler_policy_error(cls):
    return "Only available for {} targets".format(
        ", ".join(member.value for member in cls if member.compatible_with_compiler_policy)
    )
```

`Rule.Policy` holds the other half — that only the compiler policy constrains the target type at all:

```python
def compatible_with_target_type(self, target_type):
    # only answers for the policy itself: a CEL expression can return ALLOWLIST_COMPILER
    # too, and the client resolves the CEL state before the (type, state) lookup, so a CEL
    # rule reaches the same invalid combination. The expression is opaque to the server.
    if self.value != self.ALLOWLIST_COMPILER:
        return True
    return Target.Type(target_type).compatible_with_compiler_policy
```

The message runs off the same predicate the check does, so it cannot name a set that is not enforced. It enumerates in declaration order and renders as `Only available for SIGNINGID, BINARY, CDHASH targets`.

## Where it is checked

| Entry point | Where |
|---|---|
| Model | `Rule.clean()` |
| Create form | `RuleForm.clean()` |
| Update form | `Rule.clean()`, through `ModelForm._post_clean` |
| Rule API, create and update | `RuleSerializer.validate()` |
| Ruleset API | `RuleUpdateSerializer.validate()` |

All five report `Target.Type.compiler_policy_error()` on the `policy` field.

`RuleForm` is a plain `forms.Form` and never touches model validation, so it needs the explicit check. `UpdateRuleForm` is a `ModelForm`, so `Rule.clean()` already reaches it and maps onto its `policy` field — a second check there would report the error twice, and `assertFormError` compares the error list exactly, so the test proves one arrives and only one.

**A check constraint is not an option.** `policy` is a column of `santa_rule` and the type is a column of `santa_target`; a Postgres `CHECK` cannot span the two tables. `clean()` is the model-level mechanism available.

Voting rules cannot produce one: the upsert in `utils.py` only ever writes policy `1` or `2`.

## Drive-by fix

`RuleForm.clean()` read `policy` on a path where it was never bound:

```python
try:
    policy = int(cleaned_data.get("policy"))
except (TypeError, ValueError):
    pass

if policy:  # UnboundLocalError
```

A rule form submitted without a policy makes `int(None)` raise, so `cleaned_data` has no `policy`, so the `except` runs and `if policy:` raised `UnboundLocalError` — a 500 instead of "This field is required." on the field. It is one line above the check this PR adds, so it is fixed here, with `test_create_configuration_rule_missing_policy` to hold it. Confirmed by removing the fix and watching the test fail on the `UnboundLocalError`.

## Tests

Each entry point asserts that the two incompatible types are rejected. All of them except the rule `PUT` also assert that the three compatible types are accepted. The `PUT` shares `RuleSerializer.validate()` with the `POST`, and the `POST` covers the accept path.

- `test_models.py` — `Rule.clean()`, and an incomplete rule, since `clean()` also runs after the field validation failed and the policy can be missing or unknown there
- `test_setup_views.py` — the create and update rule views
- `test_api_views.py` — rule `POST` and `PUT`, and `ruleset_update`
- `test_serializers.py` — `RuleUpdateSerializer`, next to its other validation tests

They assert against `Target.Type.compiler_policy_error()` rather than a copy of the string. `test_compiler_policy_error` pins what it renders to and `test_compatible_with_compiler_policy` pins the members and their order, so a broken format string or a silently widened set still fails.

Full suite: 8281 tests, OK. `flake8` and `ruff` clean on the changed files. `mkdocs build --strict` passes. 100% coverage on the edited lines.

## Docs

The `policy` row of the ruleset API rule attributes gets the constraint. The `rule_type` and `identifier` rows of the same table were stale, from before the cdhash and signing ID types: they listed `BUNDLE`, which the serializer rejects (there is a test for it), and omitted `CDHASH` and `SIGNINGID`. Corrected, so the table does not contradict the new note.

A second commit corrects the *Definitions* section, one screen above the table. It listed four target types and four policies, from before the cdhash, the signing ID and the CEL rules, and gave the sha256 hexdigest as the identifier of all the targets. It is the first description of a rule that a reader meets. The **Allowlist compiler** paragraph carries the constraint now, and a short paragraph describes the CEL policy, which the page did not document at all.

## Existing rows

This is validation, so the rows already in a database keep their policy, and there is no data migration. Nothing writes them again though. A ruleset that carries such a rule gives a 400 on the next post, and so does a `PUT` on the rule API. `santa/terraform.py` exports the policy through `get_translated_policy()`, so a Terraform configuration that carries such a rule fails on the next apply. The update form of the web console rejects a change to any other attribute of the rule as well, because `Rule.clean()` validates the policy and the target type together.

The CHANGELOG entry is in *Backward incompatibilities* for that reason, and not in *Features*.

## Noted, not fixed

**A CEL rule reaches the same invalid combination.** `Policy.CEL` is allowed on any target type, and `cel_expr` is opaque to the server. On the client the CEL result replaces the state before the map lookup (`state = celResult.resultState`), and `ReturnValue::ALLOWLIST_COMPILER` gives `SNTRuleStateAllowCompiler` in the v1 and the v2 traits. A CEL rule on a team ID or a certificate whose expression returns `ALLOWLIST_COMPILER` therefore drops in the same way, and Santa's own documentation gives a team ID rule as an example of where to attach a CEL expression. The server cannot see this without an evaluation of the expression, so the check does not cover it. `Policy.compatible_with_target_type()` carries a comment that says so: it answers for the policy alone.

A partial `PATCH` to `/api/santa/rules/<pk>/` raises `KeyError: 'target'` on the first line of `RuleSerializer.validate()`, which reads `data["target"]` unconditionally. It predates this change and fails before any policy check. The endpoint is a `RetrieveUpdateDestroyAPIView`, so `PATCH` is routed but only ever works with a full payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


