### PR TITLE
monolith: add a pkginfo data view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Zentral adds a `default_installs` package to the `optional_installs` of the sub 
 
 The Monolith API publishes the same `zentral_audit` events as the web console now. The catalogs, the conditions, the enrollments and the manifest enrollment packages changed with no record of it.
 
+The version of a PkgInfo in the *PkgInfos* list and on a PkgInfo name page links to its data now: the pkginfo as it is stored in Zentral, the pkginfo as it is served in the catalogs, and the differences between the two. Use it to see the rewrites monolith applies, for example the `installer_item_location` it points at its own repository endpoint.
+
+The raw pkginfo carries the installation checks and the pre/postinstall scripts, so the new `Monolith::Action::"viewPkgInfoData"` PBAC action gates the page, and it is not part of the viewer action groups. It takes the PkgInfo as its resource, with its repository and its active catalogs as parents, and the repository with its meta business unit as parent, so a policy can be scoped to one PkgInfo, to a catalog, to a repository, or to the meta business unit. A `forbid` policy on a catalog takes a restricted catalog back. The action has no API endpoint, and no service account can reach it.
+
 
 #### Munki
 

--- a/docs/apps/monolith.md
+++ b/docs/apps/monolith.md
@@ -104,6 +104,45 @@ First Zentral checks the `excluded_tags`. If a machine has any one of the tags l
 
 **IMPORTANT** Make sure that the tags used in the PkgInfo exist in Zentral **before** the repository is synced.
 
+## PkgInfo data
+
+The version of a PkgInfo in the *PkgInfos* list and on a PkgInfo name page links to its data: the pkginfo as it is stored in Zentral, and the pkginfo as it is served in the catalogs, with the differences between the two – the *rewrites* monolith applies, for example the `installer_item_location` it points at its own repository endpoint, or the `catalogs` key it drops.
+
+* PBAC action: `Monolith::Action::"viewPkgInfoData"`
+
+The raw pkginfo carries the installation checks and the pre/postinstall scripts, so this action is not part of the viewer action groups, unlike the other monolith view actions: `Monolith::Action::"ViewerActions"` does not grant it, and neither does `monolith.view_pkginfo`. It has to be granted explicitly, and only to a role, not to a service account – the pkginfo data has no API endpoint.
+
+The action takes the PkgInfo as its resource, with its repository and its active catalogs as parents, and the repository with its meta business unit as parent. Nothing goes in the context. A policy can be scoped to one PkgInfo, to a catalog, to a repository, or to the meta business unit that already scopes the machines:
+
+```
+permit (
+  principal in Role::"6",
+  action == Monolith::Action::"viewPkgInfoData",
+  resource in Monolith::Repository::"3"
+);
+```
+
+`resource in Monolith::Catalog::"7"` matches the PkgInfos of that catalog, `resource in Inventory::MetaBusinessUnit::"2"` the PkgInfos of every repository of that meta business unit, and `resource == Monolith::PkgInfo::"12"` one PkgInfo.
+
+A scope on a catalog is existential: a PkgInfo of the `testing` **and** of the `production` catalog matches a policy scoped on `testing`. Take a restricted catalog back with a `forbid` policy, which wins over every `permit`:
+
+```
+permit (
+  principal in Role::"6",
+  action == Monolith::Action::"viewPkgInfoData",
+  resource in Monolith::Repository::"3"
+);
+forbid (
+  principal,
+  action == Monolith::Action::"viewPkgInfoData",
+  resource in Monolith::Catalog::"9"
+);
+```
+
+A PkgInfo promoted to the restricted catalog in the repository leaves the permission on the next sync. A new restricted catalog needs its own `forbid`.
+
+Only the active catalogs of a PkgInfo are parents of the resource, and all of them are, whatever the *PkgInfos* list is filtered on: a PkgInfo of a forbidden catalog keeps its link hidden on a list filtered on another catalog.
+
 ## HTTP API
 
 ### Requests

--- a/tests/monolith/test_pbac.py
+++ b/tests/monolith/test_pbac.py
@@ -1,0 +1,199 @@
+from django.contrib.auth.models import Group
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from accounts.models import Policy, User
+from pbac.engine import engine
+from zentral.contrib.inventory.models import MetaBusinessUnit
+from zentral.contrib.monolith.pbac import ViewPkgInfoDataRequest
+
+from .utils import force_catalog, force_pkg_info, force_repository
+
+
+class MonolithPBACTestCase(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        cls.group = Group.objects.create(name=get_random_string(12))
+        cls.user.groups.set([cls.group])
+        cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+        cls.repository = force_repository(mbu=cls.mbu)
+        cls.catalog = force_catalog(repository=cls.repository, name="testing")
+        cls.other_catalog = force_catalog(repository=cls.repository, name="production")
+        cls.pkg_info = force_pkg_info(catalog=cls.catalog)
+
+    def _build_request(self, pkg_info=None, catalogs=None, user=None):
+        pkg_info = pkg_info or self.pkg_info
+        return ViewPkgInfoDataRequest(
+            user or self.user,
+            pkg_info,
+            catalogs if catalogs is not None else pkg_info.active_catalogs(),
+        )
+
+    def _build_policy_source(self, scope="resource", forbidden_scope=None):
+        source = ("permit ("
+                  f' principal in Role::"{self.group.pk}",'
+                  ' action == Monolith::Action::"viewPkgInfoData",'
+                  f" {scope}"
+                  ");\n")
+        if forbidden_scope:
+            source += ("forbid ("
+                       " principal,"
+                       ' action == Monolith::Action::"viewPkgInfoData",'
+                       f" {forbidden_scope}"
+                       ");\n")
+        return source
+
+    def _set_policy(self, scope="resource", forbidden_scope=None):
+        Policy.objects.update_or_create(
+            name="Monolith tests",
+            defaults={"source": self._build_policy_source(scope, forbidden_scope)}
+        )
+
+    def _authorize(self, request):
+        engine.authorize_request(request)
+        return request.is_authorized
+
+    # resource
+
+    def test_view_pkg_info_data_request(self):
+        self.pkg_info.catalogs.add(self.other_catalog)
+        request = self._build_request()
+        self.assertEqual(str(request.action), 'Monolith::Action::"viewPkgInfoData"')
+        self.assertEqual(request.resource.full_type, "Monolith::PkgInfo")
+        self.assertEqual(request.resource.id, str(self.pkg_info.pk))
+        self.assertEqual(request.context, {})
+        self.assertEqual(
+            sorted(str(p) for p in request.resource.parents),
+            sorted([f'Monolith::Repository::"{self.repository.pk}"',
+                    f'Monolith::Catalog::"{self.catalog.pk}"',
+                    f'Monolith::Catalog::"{self.other_catalog.pk}"'])
+        )
+
+    def test_view_pkg_info_data_request_repository_parent_meta_business_unit(self):
+        request = self._build_request()
+        repository_resource = next(p for p in request.resource.parents if p.type == "Repository")
+        self.assertEqual([str(p) for p in repository_resource.parents],
+                         [f'Inventory::MetaBusinessUnit::"{self.mbu.pk}"'])
+
+    def test_view_pkg_info_data_request_repository_without_meta_business_unit(self):
+        pkg_info = force_pkg_info()
+        request = self._build_request(pkg_info=pkg_info)
+        repository_resource = next(p for p in request.resource.parents if p.type == "Repository")
+        self.assertEqual(repository_resource.parents, [])
+
+    def test_view_pkg_info_data_request_without_catalog(self):
+        self.pkg_info.catalogs.clear()
+        request = self._build_request()
+        self.assertEqual([str(p) for p in request.resource.parents],
+                         [f'Monolith::Repository::"{self.repository.pk}"'])
+
+    # decisions
+
+    def test_view_pkg_info_data_request_denied_by_default(self):
+        self.assertFalse(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_superuser_authorized(self):
+        superuser = User.objects.create_user(
+            get_random_string(12), "superuser@zentral.io", get_random_string(12),
+            is_superuser=True,
+        )
+        self.assertTrue(self._build_request(user=superuser).is_authorized)
+
+    def test_view_pkg_info_data_request_policy_authorized(self):
+        self._set_policy()
+        self.assertTrue(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_policy_pkg_info_authorized(self):
+        self._set_policy(scope=f'resource == Monolith::PkgInfo::"{self.pkg_info.pk}"')
+        self.assertTrue(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_policy_other_pkg_info_denied(self):
+        self._set_policy(scope=f'resource == Monolith::PkgInfo::"{self.pkg_info.pk}"')
+        other_pkg_info = force_pkg_info(catalog=self.catalog)
+        self.assertFalse(self._authorize(self._build_request(pkg_info=other_pkg_info)))
+
+    def test_view_pkg_info_data_request_policy_catalog_authorized(self):
+        self._set_policy(scope=f'resource in Monolith::Catalog::"{self.catalog.pk}"')
+        self.assertTrue(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_policy_other_catalog_denied(self):
+        self._set_policy(scope=f'resource in Monolith::Catalog::"{self.other_catalog.pk}"')
+        self.assertFalse(self._authorize(self._build_request()))
+
+    # a scope on a catalog is existential: a pkginfo of the testing and of the production
+    # catalog matches a policy scoped on testing
+
+    def test_view_pkg_info_data_request_policy_catalog_authorized_extra_catalog(self):
+        self.pkg_info.catalogs.add(self.other_catalog)
+        self._set_policy(scope=f'resource in Monolith::Catalog::"{self.catalog.pk}"')
+        self.assertTrue(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_forbidden_catalog_denied(self):
+        self.pkg_info.catalogs.add(self.other_catalog)
+        self._set_policy(scope=f'resource in Monolith::Repository::"{self.repository.pk}"',
+                         forbidden_scope=f'resource in Monolith::Catalog::"{self.other_catalog.pk}"')
+        self.assertFalse(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_forbidden_catalog_other_pkg_info_authorized(self):
+        self._set_policy(scope=f'resource in Monolith::Repository::"{self.repository.pk}"',
+                         forbidden_scope=f'resource in Monolith::Catalog::"{self.other_catalog.pk}"')
+        self.assertTrue(self._authorize(self._build_request()))
+
+    # the repository is reachable from the pkginfo, and from its catalogs
+
+    def test_view_pkg_info_data_request_policy_repository_authorized(self):
+        self._set_policy(scope=f'resource in Monolith::Repository::"{self.repository.pk}"')
+        self.assertTrue(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_policy_other_repository_denied(self):
+        self._set_policy(scope=f'resource in Monolith::Repository::"{force_repository().pk}"')
+        self.assertFalse(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_policy_meta_business_unit_authorized(self):
+        self._set_policy(scope=f'resource in Inventory::MetaBusinessUnit::"{self.mbu.pk}"')
+        self.assertTrue(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_request_policy_other_meta_business_unit_denied(self):
+        other_mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+        self._set_policy(scope=f'resource in Inventory::MetaBusinessUnit::"{other_mbu.pk}"')
+        self.assertFalse(self._authorize(self._build_request()))
+
+    def test_view_pkg_info_data_requests_batch_authorized(self):
+        other_pkg_info = force_pkg_info(catalog=self.other_catalog)
+        self._set_policy(scope=f'resource in Monolith::Catalog::"{self.catalog.pk}"')
+        requests = [self._build_request(), self._build_request(pkg_info=other_pkg_info)]
+        engine.authorize_requests(requests)
+        self.assertTrue(requests[0].is_authorized)
+        self.assertFalse(requests[1].is_authorized)
+
+    # every scope must pass the schema validation Policy.clean runs, otherwise the action
+    # would be unreachable for an operator
+
+    def test_scoped_policies_are_valid(self):
+        for scope in (f'resource == Monolith::PkgInfo::"{self.pkg_info.pk}"',
+                      f'resource in Monolith::Catalog::"{self.catalog.pk}"',
+                      f'resource in Monolith::Repository::"{self.repository.pk}"',
+                      f'resource in Inventory::MetaBusinessUnit::"{self.mbu.pk}"'):
+            with self.subTest(scope=scope):
+                policy = Policy(name=get_random_string(12), source=self._build_policy_source(scope=scope))
+                policy.full_clean()
+
+    def test_system_scoped_policy_is_invalid(self):
+        policy = Policy(name=get_random_string(12),
+                        source=self._build_policy_source(scope='resource == System::"any"'))
+        with self.assertRaises(ValidationError):
+            policy.full_clean()
+
+    def test_service_account_principal_policy_is_invalid(self):
+        source = ('permit ('
+                  ' principal == ServiceAccount::"1",'
+                  ' action == Monolith::Action::"viewPkgInfoData",'
+                  ' resource'
+                  ');\n')
+        policy = Policy(name=get_random_string(12), source=source)
+        with self.assertRaises(ValidationError):
+            policy.full_clean()

--- a/tests/monolith/test_setup_views.py
+++ b/tests/monolith/test_setup_views.py
@@ -4,7 +4,7 @@ import uuid
 from io import BytesIO
 from unittest.mock import patch
 
-from accounts.models import User
+from accounts.models import Policy, User
 from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
@@ -107,6 +107,28 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
 
     def _get_url_namespace(self):
         return "monolith"
+
+    # utils
+
+    def _set_view_pkg_info_data_policy(self, repository=None, catalog=None, forbidden_catalog=None):
+        if repository:
+            scope = f'resource in Monolith::Repository::"{repository.pk}"'
+        elif catalog:
+            scope = f'resource in Monolith::Catalog::"{catalog.pk}"'
+        else:
+            scope = "resource"
+        source = ("permit ("
+                  f' principal in Role::"{self.group.pk}",'
+                  ' action == Monolith::Action::"viewPkgInfoData",'
+                  f" {scope}"
+                  ");\n")
+        if forbidden_catalog:
+            source += ("forbid ("
+                       " principal,"
+                       ' action == Monolith::Action::"viewPkgInfoData",'
+                       f' resource in Monolith::Catalog::"{forbidden_catalog.pk}"'
+                       ");\n")
+        Policy.objects.update_or_create(name="Monolith tests", defaults={"source": source})
 
     # index
 
@@ -1380,12 +1402,26 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
         self.assertEqual(response.status_code, 403)
 
+    def test_pkg_info_data_view_pkginfo_not_enough(self):
+        pkg_info = force_pkg_info()
+        self.login("monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 403)
+
+    def test_pkg_info_data_other_repository_denied(self):
+        pkg_info = force_pkg_info()
+        self.login()
+        self._set_view_pkg_info_data_policy(repository=force_repository())
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 403)
+
     def test_pkg_info_data(self):
         pkg_info = force_pkg_info()
         pkg_info.data["unattended_install"] = True
         pkg_info.data["installer_item_location"] = "yolo/fomo-1.0.pkg"
         pkg_info.save()
-        self.login("monolith.view_pkginfo")
+        self.login()
+        self._set_view_pkg_info_data_policy()
         response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "monolith/pkginfo_data.html")
@@ -1395,12 +1431,46 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         self.assertContains(response, "yolo/fomo-1.0.pkg")
         self.assertContains(response, response.context["served_pkg_info"]["installer_item_location"])
 
+    def test_pkg_info_data_repository_scoped_policy(self):
+        pkg_info = force_pkg_info()
+        self.login()
+        self._set_view_pkg_info_data_policy(repository=pkg_info.repository)
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 200)
+
+    def test_pkg_info_data_catalog_scoped_policy(self):
+        pkg_info = force_pkg_info()
+        self.login()
+        self._set_view_pkg_info_data_policy(catalog=pkg_info.active_catalogs().first())
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 200)
+
+    def test_pkg_info_data_other_catalog_denied(self):
+        pkg_info = force_pkg_info()
+        self.login()
+        self._set_view_pkg_info_data_policy(catalog=force_catalog(repository=pkg_info.repository))
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 403)
+
+    def test_pkg_info_data_forbidden_catalog_denied(self):
+        pkg_info = force_pkg_info()
+        restricted_catalog = force_catalog(repository=pkg_info.repository)
+        pkg_info.catalogs.add(restricted_catalog)
+        self.login()
+        self._set_view_pkg_info_data_policy(repository=pkg_info.repository,
+                                            forbidden_catalog=restricted_catalog)
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 403)
+
     def test_pkg_info_data_rewrites(self):
         pkg_info = force_pkg_info()
         pkg_info.data["unattended_install"] = True
         pkg_info.data["installer_item_location"] = "yolo/fomo-1.0.pkg"
+        # a pkginfo synced from a repository carries its catalogs
+        pkg_info.data["catalogs"] = ["yolo"]
         pkg_info.save()
-        self.login("monolith.view_pkginfo")
+        self.login()
+        self._set_view_pkg_info_data_policy()
         response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
         self.assertEqual(response.status_code, 200)
         served_pkg_info = response.context["served_pkg_info"]
@@ -1417,7 +1487,8 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
 
     def test_pkg_info_data_archived(self):
         pkg_info = force_pkg_info(archived=True)
-        self.login("monolith.view_pkginfo")
+        self.login()
+        self._set_view_pkg_info_data_policy()
         response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Archived at")
@@ -1425,9 +1496,77 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
     def test_pkg_info_name_links_to_pkg_info_data(self):
         pkg_info = force_pkg_info()
         self.login("monolith.view_pkginfoname", "monolith.view_pkginfo")
+        self._set_view_pkg_info_data_policy()
         response = self.client.get(reverse("monolith:pkg_info_name", args=(pkg_info.name.pk,)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+
+    def test_pkg_info_name_no_link_to_pkg_info_data(self):
+        pkg_info = force_pkg_info()
+        self.login("monolith.view_pkginfoname", "monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_info_name", args=(pkg_info.name.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, pkg_info.version)
+        self.assertNotContains(response, reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+
+    def test_pkg_info_name_no_link_to_pkg_info_data_other_repository(self):
+        pkg_info = force_pkg_info()
+        self.login("monolith.view_pkginfoname", "monolith.view_pkginfo")
+        self._set_view_pkg_info_data_policy(repository=force_repository())
+        response = self.client.get(reverse("monolith:pkg_info_name", args=(pkg_info.name.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+
+    def test_pkg_infos_links_to_pkg_info_data(self):
+        self.login("monolith.view_pkginfo")
+        self._set_view_pkg_info_data_policy()
+        response = self.client.get(reverse("monolith:pkg_infos"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("monolith:pkg_info_data", args=(self.pkginfo_1_1.pk,)))
+
+    def test_pkg_infos_no_link_to_pkg_info_data(self):
+        self.login("monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_infos"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.pkginfo_1_1.version)
+        self.assertNotContains(response, reverse("monolith:pkg_info_data", args=(self.pkginfo_1_1.pk,)))
+
+    def test_pkg_infos_links_only_to_authorized_catalog_pkg_info_data(self):
+        other_catalog = force_catalog(repository=self.repository)
+        other_pkg_info = PkgInfo.objects.create(repository=self.repository,
+                                                name=self.pkginfo_name_1, version="2.0",
+                                                data={"name": self.pkginfo_name_1.name,
+                                                      "version": "2.0"})
+        other_pkg_info.catalogs.set([other_catalog])
+        self.login("monolith.view_pkginfo")
+        self._set_view_pkg_info_data_policy(catalog=self.catalog_1)
+        response = self.client.get(reverse("monolith:pkg_infos"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("monolith:pkg_info_data", args=(self.pkginfo_1_1.pk,)))
+        self.assertNotContains(response, reverse("monolith:pkg_info_data", args=(other_pkg_info.pk,)))
+
+    def test_pkg_infos_catalog_search_does_not_widen_the_pkg_info_data_links(self):
+        # the pkg info is in two catalogs, the search only reports the one it is filtered
+        # on, but the forbidden catalog is a parent of the resource all the same
+        restricted_catalog = force_catalog(repository=self.repository)
+        self.pkginfo_1_1.catalogs.add(restricted_catalog)
+        self.login("monolith.view_pkginfo")
+        self._set_view_pkg_info_data_policy(repository=self.repository,
+                                            forbidden_catalog=restricted_catalog)
+        response = self.client.get(reverse("monolith:pkg_infos"), {"catalog": self.catalog_1.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.pkginfo_1_1.version)
+        self.assertNotContains(response, reverse("monolith:pkg_info_data", args=(self.pkginfo_1_1.pk,)))
+
+    def test_pkg_infos_links_only_to_authorized_repository_pkg_info_data(self):
+        other_pkg_info = force_pkg_info()
+        self.login("monolith.view_pkginfo")
+        self._set_view_pkg_info_data_policy(repository=self.repository)
+        response = self.client.get(reverse("monolith:pkg_infos"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("monolith:pkg_info_data", args=(self.pkginfo_1_1.pk,)))
+        self.assertContains(response, other_pkg_info.name.name)
+        self.assertNotContains(response, reverse("monolith:pkg_info_data", args=(other_pkg_info.pk,)))
 
     # delete pkg info
 

--- a/tests/monolith/test_setup_views.py
+++ b/tests/monolith/test_setup_views.py
@@ -1368,6 +1368,67 @@ class MonolithSetupViewsTestCase(TestCase, LoginCase):
         )
         self.assertEqual(sorted(metadata["tags"]), ["monolith", "zentral"])
 
+    # pkg info data
+
+    def test_pkg_info_data_login_redirect(self):
+        pkg_info = force_pkg_info()
+        self.login_redirect("pkg_info_data", pkg_info.pk)
+
+    def test_pkg_info_data_permission_denied(self):
+        pkg_info = force_pkg_info()
+        self.login()
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 403)
+
+    def test_pkg_info_data(self):
+        pkg_info = force_pkg_info()
+        pkg_info.data["unattended_install"] = True
+        pkg_info.data["installer_item_location"] = "yolo/fomo-1.0.pkg"
+        pkg_info.save()
+        self.login("monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "monolith/pkginfo_data.html")
+        self.assertEqual(response.context["pkg_info"], pkg_info)
+        self.assertContains(response, "unattended_install")
+        # the original location is displayed, and so is the rewritten one
+        self.assertContains(response, "yolo/fomo-1.0.pkg")
+        self.assertContains(response, response.context["served_pkg_info"]["installer_item_location"])
+
+    def test_pkg_info_data_rewrites(self):
+        pkg_info = force_pkg_info()
+        pkg_info.data["unattended_install"] = True
+        pkg_info.data["installer_item_location"] = "yolo/fomo-1.0.pkg"
+        pkg_info.save()
+        self.login("monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 200)
+        served_pkg_info = response.context["served_pkg_info"]
+        rewrites = {r["key"]: r for r in response.context["rewrites"]}
+        # the rewritten keys are reported with both values
+        self.assertEqual(rewrites["installer_item_location"]["stored"], "yolo/fomo-1.0.pkg")
+        self.assertEqual(rewrites["installer_item_location"]["served"],
+                         served_pkg_info["installer_item_location"])
+        self.assertEqual(rewrites["icon_name"]["served"], served_pkg_info["icon_name"])
+        # the catalogs are dropped from the served pkginfo
+        self.assertIsNone(rewrites["catalogs"]["served"])
+        # a key monolith does not touch is not reported
+        self.assertNotIn("unattended_install", rewrites)
+
+    def test_pkg_info_data_archived(self):
+        pkg_info = force_pkg_info(archived=True)
+        self.login("monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Archived at")
+
+    def test_pkg_info_name_links_to_pkg_info_data(self):
+        pkg_info = force_pkg_info()
+        self.login("monolith.view_pkginfoname", "monolith.view_pkginfo")
+        response = self.client.get(reverse("monolith:pkg_info_name", args=(pkg_info.name.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("monolith:pkg_info_data", args=(pkg_info.pk,)))
+
     # delete pkg info
 
     def test_delete_pkg_info_login_redirect(self):

--- a/tests/server_accounts/test_pbac_engine.py
+++ b/tests/server_accounts/test_pbac_engine.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from pbac.engine import (
     ActionGroupBasename,
     ActionRegistrationConflict,
@@ -8,14 +7,14 @@ from pbac.engine import (
     engine,
 )
 from pbac.types import (
-    AppliesTo,
-    AttrSpec,
     LEGACY_PERM_APPLIES_TO,
-    ResourceType,
     ROLE,
     SERVICE_ACCOUNT,
     SYSTEM,
     USER,
+    AppliesTo,
+    AttrSpec,
+    ResourceType,
 )
 
 

--- a/zentral/contrib/monolith/pbac.py
+++ b/zentral/contrib/monolith/pbac.py
@@ -1,7 +1,12 @@
-from pbac.engine import ActionGroupBasename, engine
-from pbac.entities import Namespace
-from pbac.types import LEGACY_PERM_APPLIES_TO
+from typing import Iterable
 
+from pbac.engine import ActionGroupBasename, engine
+from pbac.entities import Namespace, Principal, Request, Resource
+from pbac.types import LEGACY_PERM_APPLIES_TO, USER, AppliesTo, ResourceType
+
+from zentral.contrib.inventory.pbac import MBU_RESOURCE_TYPE, get_mbu_resource
+
+from .models import Catalog, PkgInfo, Repository
 
 # namespace
 
@@ -11,6 +16,15 @@ NAMESPACE_ID = "Monolith"
 
 def get_namespace() -> Namespace:
     return engine.get_namespace(NAMESPACE_ID)
+
+
+# resource types
+
+
+REPOSITORY_RESOURCE_TYPE = ResourceType("Repository", get_namespace(), parents=(MBU_RESOURCE_TYPE,))
+CATALOG_RESOURCE_TYPE = ResourceType("Catalog", get_namespace(), parents=(REPOSITORY_RESOURCE_TYPE,))
+PKG_INFO_RESOURCE_TYPE = ResourceType("PkgInfo", get_namespace(),
+                                      parents=(REPOSITORY_RESOURCE_TYPE, CATALOG_RESOURCE_TYPE))
 
 
 # actions
@@ -28,3 +42,68 @@ sync_repository_action = engine.register_action(
     legacy_perm="monolith.sync_repository",
     help_text="Synchronize a Munki repository, and update the catalogs and the manifests.",
 )
+
+
+# the raw pkginfo carries the install check and pre/postinstall scripts, so it is
+# not part of the viewer actions like the other monolith view permissions
+#
+# viewPkgInfoData takes the pkginfo as its resource, with its repository and its active
+# catalogs as parents, so a policy can be scoped to one pkginfo, to a catalog, to a
+# repository, or to the meta business unit that already scopes the machines. Nothing goes
+# in the context: the catalogs are the containers of the pkginfo, and not parameters of the
+# action. A scope on a catalog is existential - a pkginfo in that catalog and in another one
+# matches it - so a restricted catalog is taken back with a forbid policy, and not with an
+# allow list of catalogs.
+#
+# It costs one decision per pkginfo on the lists, which PkgInfo.objects.alles() does not
+# paginate.
+#
+# It carries no legacy_perm: the typed PBAC path is the only way in. Only User principals:
+# the pkginfo data has no API endpoint, so no service account can reach the action.
+
+
+view_pkg_info_data_action = engine.register_action(
+    "viewPkgInfoData",
+    get_namespace(),
+    [ActionGroupBasename.ADMIN],
+    applies_to=AppliesTo(
+        principals=(USER,),
+        resources=(PKG_INFO_RESOURCE_TYPE,),
+        context={},
+    ),
+    help_text="See the raw pkginfo of a package, as it is stored and as it is served in the catalogs.",
+)
+
+
+# resources
+
+
+def get_repository_resource(repository: Repository) -> Resource:
+    parents = []
+    if repository.meta_business_unit:
+        parents.append(get_mbu_resource(repository.meta_business_unit))
+    return Resource("Repository", str(repository.pk), get_namespace(), parents)
+
+
+def get_catalog_resource(catalog: Catalog) -> Resource:
+    return Resource("Catalog", str(catalog.pk), get_namespace(),
+                    [get_repository_resource(catalog.repository)])
+
+
+def get_pkg_info_resource(pkg_info: PkgInfo, catalogs: Iterable[Catalog]) -> Resource:
+    return Resource(
+        "PkgInfo", str(pkg_info.pk), get_namespace(),
+        [get_repository_resource(pkg_info.repository)] + [get_catalog_resource(c) for c in catalogs],
+    )
+
+
+# requests
+
+
+class ViewPkgInfoDataRequest(Request):
+    def __init__(self, user_obj, pkg_info: PkgInfo, catalogs: Iterable[Catalog]) -> None:
+        super().__init__(
+            Principal.from_user(user_obj),
+            view_pkg_info_data_action,
+            get_pkg_info_resource(pkg_info, catalogs),
+        )

--- a/zentral/contrib/monolith/templates/monolith/pkg_info_name.html
+++ b/zentral/contrib/monolith/templates/monolith/pkg_info_name.html
@@ -91,7 +91,7 @@
     {% for pkg_info in pkg_infos %}
     <tr>
       <td id="{{ pkg_info.pk }}">
-        {{ pkg_info.version }}
+        <a href="{% url 'monolith:pkg_info_data' pkg_info.pk %}">{{ pkg_info.version }}</a>
       </td>
       <td>
         {% for catalog in pkg_info.catalogs %}{% if perms.monolith.view_catalog %}<a href="{% url 'monolith:catalog' catalog.pk %}">{{ catalog }}</a>{% else %}{{ catalog }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}

--- a/zentral/contrib/monolith/templates/monolith/pkg_info_name.html
+++ b/zentral/contrib/monolith/templates/monolith/pkg_info_name.html
@@ -91,7 +91,7 @@
     {% for pkg_info in pkg_infos %}
     <tr>
       <td id="{{ pkg_info.pk }}">
-        <a href="{% url 'monolith:pkg_info_data' pkg_info.pk %}">{{ pkg_info.version }}</a>
+        {% if pkg_info.view_data_request.is_authorized %}<a href="{% url 'monolith:pkg_info_data' pkg_info.pk %}">{{ pkg_info.version }}</a>{% else %}{{ pkg_info.version }}{% endif %}
       </td>
       <td>
         {% for catalog in pkg_info.catalogs %}{% if perms.monolith.view_catalog %}<a href="{% url 'monolith:catalog' catalog.pk %}">{{ catalog }}</a>{% else %}{{ catalog }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}

--- a/zentral/contrib/monolith/templates/monolith/pkginfo_data.html
+++ b/zentral/contrib/monolith/templates/monolith/pkginfo_data.html
@@ -1,0 +1,94 @@
+{% extends 'base.html' %}
+{% load base_extras ui_extras %}
+
+{% block content %}
+<ol class="breadcrumb">
+  <li class="breadcrumb-item"><a href="/">Home</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'monolith:index' %}">Monolith</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'monolith:pkg_infos' %}">PkgInfos</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'monolith:pkg_info_name' pkg_info.name.pk %}">{{ pkg_info.name }}</a></li>
+  <li class="breadcrumb-item active">{{ pkg_info.version }}</li>
+</ol>
+
+<div class="object-details">
+    <div class="d-flex align-items-center mb-1">
+        <h2>{{ pkg_info.name }} {{ pkg_info.version }}</h2>
+    </div>
+    <div class="d-flex align-items-center mb-3">
+        <h3 class="m-0 fs-5 text-secondary">PkgInfo</h3>
+    </div>
+
+    <table class="table-object-properties">
+        <thead>
+        <tr>
+            <th scope="col">Attribute</th>
+            <th scope="col">Value</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>Repository</td>
+            <td>
+                {% if perms.monolith.view_repository %}
+                <a href="{{ pkg_info.repository.get_absolute_url }}">{{ pkg_info.repository }}</a>
+                {% else %}
+                {{ pkg_info.repository }}
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
+            <td>Local</td>
+            <td>{{ pkg_info.local|yesno }}</td>
+        </tr>
+        <tr>
+            <td>Catalogs</td>
+            <td>
+                {% for catalog in pkg_info.active_catalogs %}
+                {% if perms.monolith.view_catalog %}<a href="{{ catalog.get_absolute_url }}">{{ catalog }}</a>{% else %}{{ catalog }}{% endif %}{% if not forloop.last %}, {% endif %}
+                {% empty %}
+                -
+                {% endfor %}
+            </td>
+        </tr>
+        {% if pkg_info.archived_at %}
+        <tr>
+            <td>Archived at</td>
+            <td>{{ pkg_info.archived_at }}</td>
+        </tr>
+        {% endif %}
+        </tbody>
+    </table>
+
+    {% created_updated_at pkg_info %}
+
+</div>
+
+<h3 class="mt-5 text-secondary">Data</h3>
+<table class="table-object-properties">
+    <thead>
+    <tr>
+        <th scope="col">Rewritten key</th>
+        <th scope="col">Stored</th>
+        <th scope="col">Served</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for rewrite in rewrites %}
+        <tr>
+            <td>{{ rewrite.key }}</td>
+            <td>{{ rewrite.stored|default_if_none:"-" }}</td>
+            <td>{{ rewrite.served|default_if_none:"-" }}</td>
+        </tr>
+    {% empty %}
+        <tr>
+            <td colspan="3">The served pkginfo is identical to the stored one.</td>
+        </tr>
+    {% endfor %}
+        <tr>
+            <td></td>
+            <td>{{ pkg_info.data|jsonprettyprint }}</td>
+            <td>{{ served_pkg_info|jsonprettyprint }}</td>
+        </tr>
+    </tbody>
+</table>
+{% endblock %}

--- a/zentral/contrib/monolith/templates/monolith/pkginfo_data.html
+++ b/zentral/contrib/monolith/templates/monolith/pkginfo_data.html
@@ -84,10 +84,9 @@
             <td colspan="3">The served pkginfo is identical to the stored one.</td>
         </tr>
     {% endfor %}
-        <tr>
-            <td></td>
-            <td>{{ pkg_info.data|jsonprettyprint }}</td>
-            <td>{{ served_pkg_info|jsonprettyprint }}</td>
+        <tr class="table-primary">
+            <td><b>Munki configuration</b></td>
+            <td colspan="2"><div class="my-2">{{ pkg_info.data|jsonprettyprint }}</div></td>
         </tr>
     </tbody>
 </table>

--- a/zentral/contrib/monolith/templates/monolith/pkginfo_list.html
+++ b/zentral/contrib/monolith/templates/monolith/pkginfo_list.html
@@ -71,7 +71,7 @@
   </tr>
   {% for pkg_info in pkg_info_name.pkg_infos %}
   <tr>
-    <td width="25%"><a href="{% url 'monolith:pkg_info_data' pkg_info.pk %}">{{ pkg_info.version }}</a></td>
+    <td width="25%">{% if pkg_info.view_data_request.is_authorized %}<a href="{% url 'monolith:pkg_info_data' pkg_info.pk %}">{{ pkg_info.version }}</a>{% else %}{{ pkg_info.version }}{% endif %}</td>
     <td>
       {% for catalog in pkg_info.catalogs %}{% if perms.monolith.view_catalog %}<a href="{% url 'monolith:catalog' catalog.pk %}">{{ catalog }}</a>{% else %}{{ catalog }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}
     </td>

--- a/zentral/contrib/monolith/templates/monolith/pkginfo_list.html
+++ b/zentral/contrib/monolith/templates/monolith/pkginfo_list.html
@@ -71,7 +71,7 @@
   </tr>
   {% for pkg_info in pkg_info_name.pkg_infos %}
   <tr>
-    <td width="25%">{{ pkg_info.version }}</td>
+    <td width="25%"><a href="{% url 'monolith:pkg_info_data' pkg_info.pk %}">{{ pkg_info.version }}</a></td>
     <td>
       {% for catalog in pkg_info.catalogs %}{% if perms.monolith.view_catalog %}<a href="{% url 'monolith:catalog' catalog.pk %}">{{ catalog }}</a>{% else %}{{ catalog }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}
     </td>

--- a/zentral/contrib/monolith/urls.py
+++ b/zentral/contrib/monolith/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
          views.UpdatePkgInfoCatalogView.as_view(),
          name='update_pkg_info_catalog'),
     path('pkginfos/<int:pk>/delete/', views.DeletePkgInfoView.as_view(), name='delete_pkg_info'),
+    path('pkginfos/<int:pk>/data/', views.PkgInfoDataView.as_view(), name='pkg_info_data'),
 
     # pkg info names
     path('pkginfo_names/create/', views.CreatePkgInfoNameView.as_view(), name='create_pkg_info_name'),

--- a/zentral/contrib/monolith/views.py
+++ b/zentral/contrib/monolith/views.py
@@ -5,12 +5,14 @@ from base.notifier import notifier
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.db.models import Prefetch
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
 from django.views.generic import DetailView, ListView, TemplateView, View
 from django.views.generic.edit import DeleteView, FormView
+from pbac.engine import engine
 
 from zentral.contrib.inventory.forms import EnrollmentSecretForm
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaMachine, Tag
@@ -20,7 +22,13 @@ from zentral.core.stores.views import EventsStoreRedirectView, EventsView, Fetch
 from zentral.utils.terraform import build_config_response
 from zentral.utils.text import encode_args, get_version_sort_key
 from zentral.utils.text import shard as compute_shard
-from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
+from zentral.utils.views import (
+    CreateViewWithAudit,
+    DeleteViewWithAudit,
+    PBACViewMixin,
+    UpdateViewWithAudit,
+    UserPaginationListView,
+)
 
 from .conf import monolith_conf
 from .forms import (
@@ -58,6 +66,7 @@ from .models import (
     SubManifest,
     SubManifestPkgInfo,
 )
+from .pbac import ViewPkgInfoDataRequest
 from .repository_backends import RepositoryBackend
 from .repository_backends.azure import AzureRepositoryForm
 from .repository_backends.s3 import S3RepositoryForm
@@ -305,6 +314,35 @@ class DeleteRepositoryView(PermissionRequiredMixin, DeleteView):
 # pkg infos
 
 
+def add_view_data_pbac_requests(pkg_infos, user):
+    """Attach the batch-authorized view data PBAC requests to the serialized pkg infos.
+
+    The resource of viewPkgInfoData is the pkginfo, with its repository and its active
+    catalogs as parents, so a decision is taken for each pkginfo. The catalogs are read
+    from the DB, and not from the serialized pkg infos, which only carry the catalog the
+    list was filtered on.
+    """
+    pkg_info_objects = (
+        PkgInfo.objects.filter(pk__in=[pkg_info["pk"] for pkg_info in pkg_infos])
+                       .defer("data")
+                       .select_related("repository")
+                       .prefetch_related(Prefetch("catalogs",
+                                                  queryset=Catalog.objects.filter(archived_at__isnull=True)
+                                                                          .select_related("repository"),
+                                                  to_attr="pbac_catalogs"))
+                       .in_bulk()
+    )
+    pbac_requests = []
+    for pkg_info in pkg_infos:
+        pkg_info_object = pkg_info_objects.get(pkg_info["pk"])
+        if pkg_info_object is None:
+            continue
+        pbac_request = ViewPkgInfoDataRequest(user, pkg_info_object, pkg_info_object.pbac_catalogs)
+        pbac_requests.append(pbac_request)
+        pkg_info["view_data_request"] = pbac_request
+    engine.authorize_requests(pbac_requests)
+
+
 class PkgInfosView(PermissionRequiredMixin, TemplateView):
     permission_required = "monolith.view_pkginfo"
     template_name = "monolith/pkginfo_list.html"
@@ -318,6 +356,10 @@ class PkgInfosView(PermissionRequiredMixin, TemplateView):
             include_empty_names=True,
             **form.cleaned_data
         )
+        add_view_data_pbac_requests(
+            [pkg_info for pkg_name in ctx['pkg_names'] for pkg_info in pkg_name['pkg_infos']],
+            self.request.user
+        )
         if not form.is_initial():
             bc = [(reverse("monolith:pkg_infos"), "PkgInfos"),
                   (None, "Search")]
@@ -327,13 +369,21 @@ class PkgInfosView(PermissionRequiredMixin, TemplateView):
         return ctx
 
 
-class PkgInfoDataView(PermissionRequiredMixin, DetailView):
-    permission_required = "monolith.view_pkginfo"
+class PkgInfoDataView(PBACViewMixin, DetailView):
+    pbac_request_class = ViewPkgInfoDataRequest
     template_name = "monolith/pkginfo_data.html"
     context_object_name = "pkg_info"
 
-    def get_queryset(self):
-        return PkgInfo.objects.select_related("name", "repository")
+    def get_pbac_request_kwargs(self, kwargs):
+        self.pkg_info = get_object_or_404(
+            PkgInfo.objects.select_related("name", "repository"),
+            pk=kwargs["pk"]
+        )
+        return {"pkg_info": self.pkg_info,
+                "catalogs": self.pkg_info.active_catalogs().select_related("repository")}
+
+    def get_object(self, queryset=None):
+        return self.pkg_info
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -438,6 +488,7 @@ class PkgInfoNameView(PermissionRequiredMixin, DetailView):
             # should never happen
             logger.error("Could not get pkg infos for name ID %d", pkg_info_name.pk)
             ctx["pkg_infos"] = []
+        add_view_data_pbac_requests(ctx["pkg_infos"], self.request.user)
         return ctx
 
 

--- a/zentral/contrib/monolith/views.py
+++ b/zentral/contrib/monolith/views.py
@@ -1,47 +1,68 @@
 import logging
 from urllib.parse import urlencode
+
+from base.notifier import notifier
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.urls import reverse_lazy
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.views.generic import DetailView, ListView, TemplateView, View
 from django.views.generic.edit import DeleteView, FormView
-from base.notifier import notifier
+
 from zentral.contrib.inventory.forms import EnrollmentSecretForm
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaMachine, Tag
 from zentral.core.events.base import AuditEvent
 from zentral.core.stores.conf import stores
-from zentral.core.stores.views import EventsView, FetchEventsView, EventsStoreRedirectView
+from zentral.core.stores.views import EventsStoreRedirectView, EventsView, FetchEventsView
 from zentral.utils.terraform import build_config_response
-from zentral.utils.text import get_version_sort_key, shard as compute_shard, encode_args
+from zentral.utils.text import encode_args, get_version_sort_key
+from zentral.utils.text import shard as compute_shard
 from zentral.utils.views import CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit, UserPaginationListView
+
 from .conf import monolith_conf
-from .forms import (AddManifestCatalogForm, EditManifestCatalogForm, DeleteManifestCatalogForm,
-                    AddManifestEnrollmentPackageForm,
-                    AddManifestSubManifestForm, EditManifestSubManifestForm, DeleteManifestSubManifestForm,
-                    CatalogForm,
-                    EnrollmentForm,
-                    ManifestForm, ManifestSearchForm,
-                    PackageForm, PkgInfoSearchForm,
-                    RepositoryForm,
-                    SubManifestForm, SubManifestSearchForm,
-                    SubManifestPkgInfoForm)
-from .models import (Catalog, CacheServer,
-                     EnrolledMachine,
-                     Manifest, ManifestEnrollmentPackage, PkgInfo, PkgInfoName,
-                     Condition, ManifestCatalog, ManifestSubManifest,
-                     Repository,
-                     SUB_MANIFEST_PKG_INFO_KEY_CHOICES, SubManifest, SubManifestPkgInfo)
+from .forms import (
+    AddManifestCatalogForm,
+    AddManifestEnrollmentPackageForm,
+    AddManifestSubManifestForm,
+    CatalogForm,
+    DeleteManifestCatalogForm,
+    DeleteManifestSubManifestForm,
+    EditManifestCatalogForm,
+    EditManifestSubManifestForm,
+    EnrollmentForm,
+    ManifestForm,
+    ManifestSearchForm,
+    PackageForm,
+    PkgInfoSearchForm,
+    RepositoryForm,
+    SubManifestForm,
+    SubManifestPkgInfoForm,
+    SubManifestSearchForm,
+)
+from .models import (
+    SUB_MANIFEST_PKG_INFO_KEY_CHOICES,
+    CacheServer,
+    Catalog,
+    Condition,
+    EnrolledMachine,
+    Manifest,
+    ManifestCatalog,
+    ManifestEnrollmentPackage,
+    ManifestSubManifest,
+    PkgInfo,
+    PkgInfoName,
+    Repository,
+    SubManifest,
+    SubManifestPkgInfo,
+)
 from .repository_backends import RepositoryBackend
 from .repository_backends.azure import AzureRepositoryForm
 from .repository_backends.s3 import S3RepositoryForm
 from .terraform import iter_resources
 from .utils import test_monolith_object_inclusion, test_pkginfo_catalog_inclusion
-
 
 logger = logging.getLogger('zentral.contrib.monolith.views')
 
@@ -303,6 +324,31 @@ class PkgInfosView(PermissionRequiredMixin, TemplateView):
         else:
             bc = [(None, "PkgInfos")]
         ctx["breadcrumbs"] = bc
+        return ctx
+
+
+class PkgInfoDataView(PermissionRequiredMixin, DetailView):
+    permission_required = "monolith.view_pkginfo"
+    template_name = "monolith/pkginfo_data.html"
+    context_object_name = "pkg_info"
+
+    def get_queryset(self):
+        return PkgInfo.objects.select_related("name", "repository")
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        # the pkginfo as served in the catalogs, to make the monolith rewrites visible
+        served_pkg_info = self.object.get_pkg_info()
+        ctx["served_pkg_info"] = served_pkg_info
+        # compared key by key, because get_pkg_info() re-adds the keys it rewrites, which moves them
+        # to the end of the dict and would show up as differences in a line by line comparison
+        ctx["rewrites"] = [
+            {"key": key,
+             "stored": self.object.data.get(key),
+             "served": served_pkg_info.get(key)}
+            for key in sorted(set(self.object.data) | set(served_pkg_info))
+            if self.object.data.get(key) != served_pkg_info.get(key)
+        ]
         return ctx
 
 


### PR DESCRIPTION
The version of a PkgInfo in the *PkgInfos* list and on a PkgInfo name page
links to its data now: the pkginfo as stored, the pkginfo as served in the
catalogs, and the rewrites between the two.

Gated by a new `Monolith::Action::"viewPkgInfoData"` PBAC action, because the
raw pkginfo carries the installation checks and the pre/postinstall scripts.
It is admin-only – not part of the viewer action groups – and takes User
principals only, since the data has no API endpoint.

The action takes the PkgInfo as its resource, with its repository and its
active catalogs as parents, and the repository with its meta business unit as
parent. Nothing goes in the context. A policy can be scoped to one PkgInfo, to
a catalog, to a repository, or to the meta business unit that already scopes
the machines.

A scope on a catalog is existential, so a restricted catalog is taken back
with a `forbid` policy. Every active catalog of a PkgInfo is a parent of the
resource, whatever the list is filtered on.

One decision per PkgInfo on the lists, batched in a single call.

Docs and CHANGELOG included.