### PR TITLE
pbac: add the view actions to the User action groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,10 @@ A task belongs to the user or the service account that launched it, and `/api/ta
 
 A task that a device launched, and a task that Zentral launched before version 2025.11, has no user, so only a superuser can read those. The exports are temporary: launch the export again to get a file that you can download.
 
+#### 🧨 PBAC User action groups
+
+The `UserActions` action groups contain the view actions of the models now. A role with a permit on `Action::"GlobalUserActions"`, or on the `UserActions` group of one namespace, reads the pages and the API endpoints of the models in that scope. Review your policies before you update.
+
 
 ### Bug fixes
 

--- a/docs/configuration/pbac.md
+++ b/docs/configuration/pbac.md
@@ -56,6 +56,10 @@ permit (
 
 Each contrib app's actions are members of `<Namespace>::Action::"AdminActions"`, `"UserActions"` and `"ViewerActions"` action groups. Globally, the same buckets exist as `Action::"GlobalAdminActions"`, `Action::"GlobalUserActions"` and `Action::"GlobalViewerActions"` — these aggregate the per-namespace groups so a single reference covers every app.
 
+The three groups are nested. `ViewerActions` contains the read actions. `UserActions` contains the same read actions, and adds the daily operations, for example a machine tag change or a Santa clean sync. `AdminActions` contains all of them, and adds the configuration changes. A role with `UserActions` can thus do all that a role with `ViewerActions` can do.
+
+A small number of actions read a secret — the MDM admin password, device lock PIN, FileVault PRK and recovery password. They have a `view` prefix, but they are members of `UserActions` and not of `ViewerActions`.
+
 ```
 // Anyone in this Role can perform every "view" action across every Zentral app.
 permit (

--- a/server/pbac/engine.py
+++ b/server/pbac/engine.py
@@ -234,7 +234,8 @@ class Engine:
             else:
                 action_action = operation
                 if operation == "view":
-                    group_basenames.append(ActionGroupBasename.VIEWER)
+                    # User is a superset of Viewer.
+                    group_basenames.extend([ActionGroupBasename.USER, ActionGroupBasename.VIEWER])
             action_id = f"{action_action}{object_name}"
             codename = get_permission_codename(operation, opts)
             self.register_action(

--- a/tests/server_accounts/test_pbac_engine.py
+++ b/tests/server_accounts/test_pbac_engine.py
@@ -529,11 +529,11 @@ class PBACEngineTestCase(TestCase):
             ],
         )
 
-    def test_user_actions(self):
-        user_action_keys = (
+    def test_user_only_actions(self):
+        # The actions a user role gets on top of a viewer role.
+        user_only_action_keys = (
             ("createMachineTag", "Inventory"),
             ("deleteMachineTag", "Inventory"),
-            ("viewMachineTag", "Inventory"),
             ("disownDEPDevice", "MDM"),
             ("forceInstallArtifact", "MDM"),
             ("viewAdminPassword", "MDM"),
@@ -542,10 +542,10 @@ class PBACEngineTestCase(TestCase):
             ("viewRecoveryPassword", "MDM"),
             ("syncRepository", "Monolith"),
             ("forceCleanSync", "Santa"),
-            ("viewEnrolledMachine", "Santa"),
         )
-        found_user_actions = 0
+        found_user_only_actions = 0
         global_user_action_group = engine.get_action_group(ActionGroupBasename.USER)
+        global_viewer_action_group = engine.get_action_group(ActionGroupBasename.VIEWER)
         for (action_id, namespace_id), action in engine.actions.items():
             # NOOP is the module-level placeholder used by has_module_perms.
             # It belongs to admin/user/viewer in every namespace by design,
@@ -557,14 +557,52 @@ class PBACEngineTestCase(TestCase):
                 ActionGroupBasename.USER,
                 engine.get_namespace(namespace_id)
             )
-            if (action_id, namespace_id) in user_action_keys:
+            if (action_id, namespace_id) in user_only_action_keys:
                 self.assertIn(global_user_action_group, action.parents)
                 self.assertIn(user_action_group, action.parents)
-                found_user_actions += 1
-            else:
+                # The MDM secret readers are named view* but reveal a secret.
+                self.assertNotIn(global_viewer_action_group, action.parents)
+                found_user_only_actions += 1
+            elif global_viewer_action_group not in action.parents:
                 self.assertNotIn(global_user_action_group, action.parents)
                 self.assertNotIn(user_action_group, action.parents)
-        self.assertEqual(found_user_actions, len(user_action_keys))
+        self.assertEqual(found_user_only_actions, len(user_only_action_keys))
+
+    def test_action_groups_are_nested(self):
+        # A viewer action is a user action, a user action an admin action.
+        found_viewer_actions = found_user_actions = 0
+        for (_, namespace_id), action in engine.actions.items():
+            namespace = engine.get_namespace(namespace_id)
+            in_viewer_group = engine.get_action_group(ActionGroupBasename.VIEWER, namespace) in action.parents
+            if in_viewer_group:
+                found_viewer_actions += 1
+                self.assertIn(engine.get_action_group(ActionGroupBasename.VIEWER), action.parents)
+            if in_viewer_group or engine.get_action_group(ActionGroupBasename.USER, namespace) in action.parents:
+                found_user_actions += 1
+                self.assertIn(engine.get_action_group(ActionGroupBasename.USER, namespace), action.parents)
+                self.assertIn(engine.get_action_group(ActionGroupBasename.USER), action.parents)
+                self.assertIn(engine.get_action_group(ActionGroupBasename.ADMIN, namespace), action.parents)
+                self.assertIn(engine.get_action_group(ActionGroupBasename.ADMIN), action.parents)
+        self.assertTrue(found_viewer_actions)
+        self.assertGreater(found_user_actions, found_viewer_actions)
+
+    def test_model_default_view_action_groups(self):
+        # The model-default actions the engine auto-registers.
+        namespace = engine.get_namespace("Inventory")
+        for action_id, basenames in (
+            ("viewTag", (ActionGroupBasename.ADMIN, ActionGroupBasename.USER, ActionGroupBasename.VIEWER)),
+            ("createTag", (ActionGroupBasename.ADMIN,)),
+            ("updateTag", (ActionGroupBasename.ADMIN,)),
+            ("deleteTag", (ActionGroupBasename.ADMIN,)),
+        ):
+            action = engine.get_action(action_id, namespace)
+            expected = []
+            for basename in basenames:
+                expected.extend((
+                    engine.get_action_group(basename, namespace),
+                    engine.get_action_group(basename),
+                ))
+            self.assertEqual(action.parents, expected)
 
 
 class PBACEngineRegistrationTestCase(TestCase):


### PR DESCRIPTION
## Problem

The PBAC engine registers one Cedar action for each default permission of each model. It made the `view` action a member of the `AdminActions` and the `ViewerActions` groups only. The `UserActions` group was thus not a superset of the `ViewerActions` group.

A policy that granted `Action::"GlobalUserActions"`, or the `UserActions` group of one namespace, gave a role the modules in the navigation and no page behind them. The `NOOP` module action is a member of the three groups, so `has_module_perms` passed and the link showed up. No view action matched, so every list page and every detail page answered a `403`.

The view actions that the contrib `pbac` modules register by hand, `Inventory::Action::"viewMachineTag"` and `Santa::Action::"viewEnrolledMachine"`, already carried the three basenames. Only the actions that the engine registers from the model default permissions were different.

## Fix

`Engine._register_model_default_legacy_perm_actions` adds `ActionGroupBasename.USER` together with `ActionGroupBasename.VIEWER` on a `view` operation. The three groups nest now: a `ViewerActions` action is a `UserActions` action, and a `UserActions` action is an `AdminActions` action.

The MDM actions that read a secret — the admin password, the device lock PIN, the FileVault PRK and the recovery password — have a `view` prefix, but the MDM `pbac` module registers them by hand with the Admin and User basenames. This change does not touch them. They stay out of the `ViewerActions` groups.

## Backward incompatibility

The change is additive to the Cedar schema, so no policy in a database becomes invalid. It widens what the policies that are already there grant: a role with a permit on `Action::"GlobalUserActions"`, or on the `UserActions` group of one namespace, reads the pages and the API endpoints of the models in that scope. The `CHANGELOG.md` entry is in the *Backward incompatibilities* section of 2026.6, and it asks the operator to review the policies before the update.

## Tests

`tests/server_accounts/test_pbac_engine.py`:

* `test_user_actions` becomes `test_user_only_actions`. Its list pins the actions that a user role gets on top of a viewer role. It also verifies that the four MDM secret readers stay out of the `ViewerActions` groups. It keeps the assertion that the admin only mutations stay out of the `UserActions` groups.
* `test_action_groups_are_nested` verifies the invariant on every registered action: a viewer action is a user action, and a user action is an admin action, in the namespace scoped group and in the global group.
* `test_model_default_view_action_groups` pins the parent list that the changed line builds. `Inventory::Action::"viewTag"` is admin, user and viewer. `createTag`, `updateTag` and `deleteTag` are admin only.

## Verification

* Full test suite with docker compose: 8267 tests, `OK`.
* `ruff` clean. `mkdocs build --strict` clean.
* Coverage of `server/pbac/engine.py` on the changed line: 100%.

## Documentation

The *Action groups* section of `docs/configuration/pbac.md` describes the nesting of the three groups and the exception of the actions that read a secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

