### PR TITLE
santa: fix the target type of the cdhash event store redirect view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,8 @@ Munki installs the Osquery enrollment package on a machine that has the Turbo ag
 
 The `rebuild_manifest_enrollment_packages` command takes a `--manifest` option with one or more manifest IDs now, to rebuild the enrollment packages of a part of the manifests only. It also takes a `--new-version` option, which increases the version of each enrollment package that it rebuilds, and gives it a new filename. The enrollment versions do not change with it, so the machines that are up to date do not install the packages again.
 
+Fixed the links of the Santa cdhash event store redirect, which had the Signing ID target type. The view sends the user back to the events page of the target when the store gives no event URL. It sent them to the Signing ID events page instead, with a cdhash identifier that this page cannot find. The events the view read were the correct ones.
+
 
 ## 2026.5
 

--- a/tests/santa/test_targets_views.py
+++ b/tests/santa/test_targets_views.py
@@ -3,13 +3,15 @@ from unittest.mock import patch
 
 from accounts.models import User
 from django.contrib.auth.models import Group
-from django.test import TestCase
-from django.urls import reverse
+from django.test import SimpleTestCase, TestCase
+from django.urls import resolve, reverse
 from django.utils.crypto import get_random_string
 
 from tests.zentral_test_utils.login_case import LoginCase
 from zentral.contrib.inventory.models import File, Source
 from zentral.contrib.santa.models import Target, TargetCounter, TargetState
+from zentral.contrib.santa.urls import urlpatterns as santa_urlpatterns
+from zentral.contrib.santa.views.targets import EventsMixin
 from zentral.core.stores.conf import stores
 from zentral.utils.provisioning import provision
 from zentral.utils.time import naive_utcnow
@@ -937,3 +939,49 @@ class SantaSetupViewsTestCase(TestCase, LoginCase):
             {'file': [f'sha256|{self.file_sha256}'],
              'santa_configuration': [str(configuration.pk)]},
         )
+
+
+class SantaTargetEventsViewsURLsTestCase(SimpleTestCase):
+    # every link a target events view builds is derived from its target_type. A view carrying the
+    # target_type of a different target keeps serving the right events, but sends the users to the
+    # other target's pages, with an identifier those pages cannot resolve.
+    maxDiff = None
+    identifier = "0123456789abcdef0123456789abcdef01234567"
+
+    def iter_target_events_views(self):
+        for url_pattern in santa_urlpatterns:
+            view_class = getattr(url_pattern.callback, "view_class", None)
+            if view_class is not None and issubclass(view_class, EventsMixin):
+                yield url_pattern.name, view_class
+
+    def test_target_type_matches_url_name(self):
+        errors = []
+        url_names = {}
+        for url_name, view_class in self.iter_target_events_views():
+            prefix = view_class.target_type.lower()
+            expected = (f"{prefix}_events", f"fetch_{prefix}_events", f"{prefix}_events_store_redirect")
+            if url_name not in expected:
+                errors.append(f"{view_class.__name__} {view_class.target_type} routed as santa:{url_name}")
+            url_names.setdefault(view_class.target_type, set()).add(url_name)
+        self.assertEqual(errors, [])
+        # the target detail view builds the events links for every native target type
+        self.assertEqual(
+            url_names,
+            {target_type: {f"{target_type.lower()}_events",
+                           f"fetch_{target_type.lower()}_events",
+                           f"{target_type.lower()}_events_store_redirect"}
+             for target_type in Target.Type if target_type.is_native}
+        )
+
+    def test_target_events_views_links_stay_on_the_target(self):
+        errors = []
+        for _, view_class in self.iter_target_events_views():
+            view = view_class()
+            view.identifier = self.identifier
+            links = {m: getattr(view, m)() for m in ("get_fetch_url", "get_redirect_url", "get_store_redirect_url")}
+            links["target_url"] = reverse(view_class.target_type.url_name, args=(self.identifier,))
+            for link_name, url in links.items():
+                target_type = resolve(url).func.view_class.target_type
+                if target_type != view_class.target_type:
+                    errors.append(f"{view_class.__name__}.{link_name} links to a {target_type} page")
+        self.assertEqual(errors, [])

--- a/zentral/contrib/santa/views/targets.py
+++ b/zentral/contrib/santa/views/targets.py
@@ -387,7 +387,7 @@ class FetchCDHashEventsView(EventsMixin, FetchEventsView):
 
 
 class CDHashEventsStoreRedirectView(EventsMixin, EventsStoreRedirectView):
-    target_type = Target.Type.SIGNING_ID
+    target_type = Target.Type.CDHASH
     object_key = "file"
     identifier_key = "cdhash"
 


### PR DESCRIPTION
## What changed

`CDHashEventsStoreRedirectView` had `target_type = Target.Type.SIGNING_ID`. It is `Target.Type.CDHASH` now.

The two sibling views for the same target, `CDHashEventsView` and `FetchCDHashEventsView`, both use `CDHASH`, and this view reads its events with the `"file"` / `"cdhash"` pair.

## Why

`EventsMixin` builds every URL from `target_type`: `get_fetch_url`, `get_redirect_url`, `get_store_redirect_url` and the `target_url` context variable all interpolate `self.target_type.lower()`. With the wrong value, all of them resolve a `santa:signingid_*` name and carry a cdhash identifier.

`EventsStoreRedirectView.get()` calls `get_redirect_url()` when the selected store gives no event URL. A user who clicked a store link on the cdhash events page went to the Signing ID events page. That page searches on `apple_signing_id`, so it shows no event.

The events the view read were always the correct ones. They come from `object_key` and `identifier_key`, not from `target_type`.

## The other target views

I compared the class name, the `target_type`, the `object_key` and the `identifier_key` of each view against its siblings, for the seven target types. I also compared the `object_key` and `identifier_key` pairs against the linked object keys that the Santa events publish, and the `add_rule_link_key` and `add_rule_link_attr` of each `TargetView` against what `CreateConfigurationRuleView` reads. The cdhash view is the only one that was wrong.

## The test

`SantaTargetEventsViewsURLsTestCase` walks the Santa URL configuration for the `EventsMixin` subclasses and makes three checks:

- the `target_type` of each view agrees with the URL name that it is routed under;
- each native target type has its three event views, so a walk that finds nothing cannot pass;
- the URLs that `get_fetch_url`, `get_redirect_url` and `get_store_redirect_url` build, and the target detail URL, all resolve to a view of the same target.

With the bug put back, the two tests fail and name the class and the wrong page:

```
CDHashEventsStoreRedirectView SIGNINGID routed as santa:cdhash_events_store_redirect
CDHashEventsView.get_store_redirect_url links to a SIGNINGID page
```

## Tests

`tests.santa` passes: 804 tests. `ruff` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)