### PR TITLE
mdm: align the linked objects of the events with the models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ A task that a device launched, and a task that Zentral launched before version 2
 
 The `UserActions` action groups contain the view actions of the models now. A role with a permit on `Action::"GlobalUserActions"`, or on the `UserActions` group of one namespace, reads the pages and the API endpoints of the models in that scope. Review your policies before you update.
 
+#### 🧨 MDM event object keys
+
+Some MDM events linked an object under a key that did not match the key of the model, so a search found one half of the events only: the `zentral_audit` events of the object always used the model key. `mdm_artifactversion` is `mdm_artifact_version` now, `mdm_enrolleddevice` is `mdm_enrolled_device`, `mdm_enrolleduser` is `mdm_enrolled_user`, `mdm_command` is `mdm_device_command`, and `mdm_depenrollmentsession` is `mdm_dep_enrollment_session`, with the other enrollment sessions. Update a probe or a query that filters on an old key. No backfill is necessary: the stored events keep the old key, and they disappear with the retention of the event store.
+
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,10 @@ The `UserActions` action groups contain the view actions of the models now. A ro
 
 Some MDM events linked an object under a key that did not match the key of the model, so a search found one half of the events only: the `zentral_audit` events of the object always used the model key. `mdm_artifactversion` is `mdm_artifact_version` now, `mdm_enrolleddevice` is `mdm_enrolled_device`, `mdm_enrolleduser` is `mdm_enrolled_user`, `mdm_command` is `mdm_device_command`, and `mdm_depenrollmentsession` is `mdm_dep_enrollment_session`, with the other enrollment sessions. Update a probe or a query that filters on an old key. No backfill is necessary: the stored events keep the old key, and they disappear with the retention of the event store.
 
+#### 🧨 MDM asset event payloads
+
+The `mdm_asset_created` and `mdm_asset_updated` events put the asset in an `asset` object now, like the other apps & books events. The attributes of the asset were at the top level of the payload, so the two events linked no object at all: `get_linked_objects_keys()` reads the asset from the `asset` key. Update a probe or a query that reads `adam_id`, `pricing_param`, `name` or another attribute of the asset at the top level of these two payloads.
+
 
 ### Bug fixes
 

--- a/tests/core_events/test_audit_event_objects.py
+++ b/tests/core_events/test_audit_event_objects.py
@@ -78,7 +78,7 @@ class RedundantSelfKeysTestCase(SimpleTestCase):
 
     A model that writes its own key with its own pk in linked_objects_keys_for_event() does the
     same work a second time. A model that writes its own key with something else keeps control of
-    it — the MDM device commands link themselves by uuid — so only the pk spelling is a defect.
+    it — the MDM commands link themselves by uuid — so only the pk spelling is a defect.
     """
 
     def iter_hooks(self):

--- a/tests/mdm/test_account_configuration_command.py
+++ b/tests/mdm/test_account_configuration_command.py
@@ -300,5 +300,5 @@ class AccountConfigurationCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "admin_password"})

--- a/tests/mdm/test_api_commands_views.py
+++ b/tests/mdm/test_api_commands_views.py
@@ -457,3 +457,14 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
              'updated_at': db_cmd.updated_at.isoformat(),
              'uuid': str(cmd.uuid)}
         )
+
+    def test_enrolled_user_command_linked_objects_keys(self):
+        a, (av,) = force_artifact(channel=Channel.USER, version_count=1)
+        cmd = InstallProfile.create_for_target(Target(self.enrolled_device, self.enrolled_user), artifact_version=av)
+        db_command = cmd.db_command
+        self.assertEqual(
+            db_command.linked_objects_keys_for_event(),
+            {"mdm_user_command": [(str(cmd.uuid),)],
+             "mdm_artifact_version": [(str(av.pk),)],
+             "mdm_artifact": [(str(a.pk),)]}
+        )

--- a/tests/mdm/test_apps_books_assets_assignments_sync.py
+++ b/tests/mdm/test_apps_books_assets_assignments_sync.py
@@ -45,9 +45,13 @@ class MDMAppsBooksAssetsAssignmentsSyncTestCase(TestCase):
         event = events[0]
         self.assertIsInstance(event, AssetCreatedEvent)
         self.assertEqual(event.payload["notification_id"], notification_id)
-        self.assertEqual(event.payload["pk"], asset.pk)
-        self.assertEqual(event.payload["adam_id"], "yolo")
-        self.assertEqual(event.payload["pricing_param"], "fomo")
+        self.assertEqual(event.payload["asset"]["pk"], asset.pk)
+        self.assertEqual(event.payload["asset"]["adam_id"], "yolo")
+        self.assertEqual(event.payload["asset"]["pricing_param"], "fomo")
+        self.assertEqual(
+            event.get_linked_objects_keys(),
+            {"mdm_asset": [("yolo", "fomo")]}
+        )
         self.assertEqual(collected_objects, {"asset": asset})
 
     def test_update_or_create_asset_noop(self):
@@ -87,10 +91,14 @@ class MDMAppsBooksAssetsAssignmentsSyncTestCase(TestCase):
         event = events[0]
         self.assertIsInstance(event, AssetUpdatedEvent)
         self.assertEqual(event.payload["notification_id"], notification_id)
-        self.assertEqual(event.payload["pk"], asset.pk)
-        self.assertEqual(event.payload["adam_id"], asset.adam_id)
-        self.assertEqual(event.payload["pricing_param"], asset.pricing_param)
-        self.assertEqual(event.payload["supported_platforms"], ["iOS"])
+        self.assertEqual(event.payload["asset"]["pk"], asset.pk)
+        self.assertEqual(event.payload["asset"]["adam_id"], asset.adam_id)
+        self.assertEqual(event.payload["asset"]["pricing_param"], asset.pricing_param)
+        self.assertEqual(event.payload["asset"]["supported_platforms"], ["iOS"])
+        self.assertEqual(
+            event.get_linked_objects_keys(),
+            {"mdm_asset": [(asset.adam_id, asset.pricing_param)]}
+        )
         asset.refresh_from_db()
         self.assertEqual(asset.supported_platforms, ["iOS"])
         self.assertEqual(collected_objects, {"asset": asset})
@@ -562,7 +570,11 @@ class MDMAppsBooksAssetsAssignmentsSyncTestCase(TestCase):
         self.assertEqual(len(post_event.call_args_list), 1)
         event = post_event.call_args_list[0].args[0]
         self.assertIsInstance(event, AssetUpdatedEvent)
-        self.assertEqual(event.payload["name"], asset_name)
+        self.assertEqual(event.payload["asset"]["name"], asset_name)
+        self.assertEqual(
+            event.get_linked_objects_keys(),
+            {"mdm_asset": [(asset.adam_id, asset.pricing_param)]}
+        )
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_refresh_asset_metadata_not_in_storefront(self, post_event):

--- a/tests/mdm/test_artifacts.py
+++ b/tests/mdm/test_artifacts.py
@@ -1811,7 +1811,7 @@ class TestMDMArtifacts(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["objects"], {"mdm_artifact": [str(profile_a.pk)],
-                                               "mdm_artifactversion": [str(profile_av.pk)]})
+                                               "mdm_artifact_version": [str(profile_av.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["mdm"])
         # v2
         status_report = build_status_report([(profile_av2, True, True, None)])
@@ -1853,7 +1853,7 @@ class TestMDMArtifacts(TestCase):
         )
         metadata = created_event.metadata.serialize()
         self.assertEqual(metadata["objects"], {"mdm_artifact": [str(profile_a.pk)],
-                                               "mdm_artifactversion": [str(profile_av2.pk)]})
+                                               "mdm_artifact_version": [str(profile_av2.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["mdm"])
         deleted_event = post_event.call_args_list[2].args[0]
         self.assertEqual(
@@ -1882,7 +1882,7 @@ class TestMDMArtifacts(TestCase):
         )
         metadata = deleted_event.metadata.serialize()
         self.assertEqual(metadata["objects"], {"mdm_artifact": [str(profile_a.pk)],
-                                               "mdm_artifactversion": [str(profile_av.pk)]})
+                                               "mdm_artifact_version": [str(profile_av.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["mdm"])
         # v2 again
         self.enrolled_device.os_version = "10.5.4"

--- a/tests/mdm/test_device_lock_command.py
+++ b/tests/mdm/test_device_lock_command.py
@@ -134,5 +134,5 @@ class DeviceLockCommandTestCase(TestCase):
         self.assertEqual(
             metadata["machine_serial_number"], self.enrolled_device.serial_number
         )
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "device_lock_pin"})

--- a/tests/mdm/test_event_linked_objects_keys.py
+++ b/tests/mdm/test_event_linked_objects_keys.py
@@ -1,0 +1,254 @@
+import ast
+import importlib
+import pkgutil
+from django.apps import apps
+from django.test import SimpleTestCase
+import zentral.contrib.mdm.events
+import zentral.contrib.mdm.models
+from zentral.contrib.mdm.events.admin_password import AdminPasswordUpdatedEvent
+from zentral.contrib.mdm.events.apps_books import AssetCountNotificationEvent
+from zentral.contrib.mdm.events.artifacts import TargetArtifactUpdateEvent
+from zentral.contrib.mdm.events.device_lock_pin import DeviceLockPinSetEvent
+from zentral.contrib.mdm.events.downloads import MDMDownloadEvent
+from zentral.contrib.mdm.events.filevault import FileVaultPRKUpdatedEvent
+from zentral.contrib.mdm.events.mdm import (
+    DEPEnrollmentRequestEvent,
+    OTAEnrollmentRequestEvent,
+    UserEnrollmentRequestEvent,
+)
+from zentral.contrib.mdm.events.recovery_password import RecoveryPasswordSetEvent
+from zentral.contrib.mdm.models import (
+    Artifact,
+    ArtifactVersion,
+    Asset,
+    DEPEnrollment,
+    DEPEnrollmentSession,
+    DeviceCommand,
+    EnrolledDevice,
+    EnrolledUser,
+    Location,
+    OTAEnrollment,
+    Package,
+    ReEnrollmentSession,
+    UserEnrollment,
+)
+from zentral.core.events.base import BaseEvent, EventMetadata, linked_objects_key
+
+
+# Every event below is pinned to the models it links, never to a key spelling: the expected
+# keys are derived with linked_objects_key(), the same way the audit events derive theirs.
+# A hand-written key that drifts from the model-derived one splits the store needles in two.
+
+CASES = (
+    (
+        MDMDownloadEvent,
+        {"outcome": "success",
+         "target_type": "package_manifest",
+         "enrolled_device": {"pk": 17},
+         "enrolled_user": {"pk": 42},
+         "package": {"pk": "pkg-uuid"}},
+        {EnrolledDevice: [(17,)], EnrolledUser: [(42,)], Package: [("pkg-uuid",)]},
+    ),
+    (
+        MDMDownloadEvent,
+        {"outcome": "success",
+         "target_type": "data_asset",
+         "data_asset": {"pk": "av-uuid", "artifact": {"pk": "a-uuid"}}},
+        {ArtifactVersion: [("av-uuid",)], Artifact: [("a-uuid",)]},
+    ),
+    (
+        MDMDownloadEvent,
+        {"outcome": "session_not_found",
+         "target_type": "package_manifest",
+         "package": {"pk": "pkg-uuid"},
+         "enrollment_session": {"model": DEPEnrollmentSession._meta.model_name, "pk": "42"}},
+        {Package: [("pkg-uuid",)], DEPEnrollmentSession: [("42",)]},
+    ),
+    (
+        MDMDownloadEvent,
+        {"outcome": "session_not_found",
+         "target_type": "package_manifest",
+         "package": {"pk": "pkg-uuid"},
+         "enrollment_session": {"model": ReEnrollmentSession._meta.model_name, "pk": "43"}},
+        {Package: [("pkg-uuid",)], ReEnrollmentSession: [("43",)]},
+    ),
+    (
+        MDMDownloadEvent,
+        {"outcome": "bad_token"},
+        {},
+    ),
+    (
+        TargetArtifactUpdateEvent,
+        {"target_artifact": {"artifact_version": {"pk": "av-uuid", "artifact": {"pk": "a-uuid"}}},
+         "enrolled_user": {"pk": 42}},
+        {Artifact: [("a-uuid",)], ArtifactVersion: [("av-uuid",)], EnrolledUser: [(42,)]},
+    ),
+    (
+        AdminPasswordUpdatedEvent,
+        {"command": {"request_type": "AccountConfiguration", "uuid": "cmd-uuid"}},
+        {DeviceCommand: [("cmd-uuid",)]},
+    ),
+    (
+        FileVaultPRKUpdatedEvent,
+        {"command": {"request_type": "RotateFileVaultKey", "uuid": "cmd-uuid"}},
+        {DeviceCommand: [("cmd-uuid",)]},
+    ),
+    (
+        RecoveryPasswordSetEvent,
+        {"command": {"request_type": "SetRecoveryLock", "uuid": "cmd-uuid"}},
+        {DeviceCommand: [("cmd-uuid",)]},
+    ),
+    (
+        DeviceLockPinSetEvent,
+        {"command": {"request_type": "DeviceLock", "uuid": "cmd-uuid"}},
+        {DeviceCommand: [("cmd-uuid",)]},
+    ),
+    (
+        AssetCountNotificationEvent,
+        {"asset": {"adam_id": "123", "pricing_param": "STDQ"}, "location": {"pk": 1}},
+        {Asset: [("123", "STDQ")], Location: [(1,)]},
+    ),
+    (
+        DEPEnrollmentRequestEvent,
+        {"dep_enrollment": {"pk": 1}},
+        {DEPEnrollment: [(1,)]},
+    ),
+    (
+        OTAEnrollmentRequestEvent,
+        {"ota_enrollment": {"pk": 2}},
+        {OTAEnrollment: [(2,)]},
+    ),
+    (
+        UserEnrollmentRequestEvent,
+        {"user_enrollment": {"pk": 3}},
+        {UserEnrollment: [(3,)]},
+    ),
+)
+
+
+KEY_FUNCTIONS = ("get_linked_objects_keys", "linked_objects_keys_for_event")
+
+
+def iter_key_literals(path):
+    """Every string constant that a linked objects key function writes a key with.
+
+    A subscript that is read is a payload lookup, not a key, so only the written ones count, and a
+    dict literal counts only where it maps a key to its values. A key that is composed at run time
+    — the enrollment request events build theirs from the payload key — leaves no literal to
+    collect; the cases above pin those.
+    """
+    with open(path, "r") as f:
+        tree = ast.parse(f.read(), path)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name not in KEY_FUNCTIONS:
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Subscript):
+                if isinstance(child.ctx, ast.Store) and isinstance(child.slice, ast.Constant):
+                    yield child.slice.value
+            elif isinstance(child, ast.Dict):
+                # a key dict maps a key to its values, [(...)]. a dict that maps a key to anything
+                # else is a payload dict — a get() default, a lookup table — and its keys are not
+                # object keys.
+                yield from (
+                    k.value
+                    for k, v in zip(child.keys, child.values)
+                    if isinstance(k, ast.Constant) and isinstance(v, (ast.List, ast.Tuple))
+                )
+            elif (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and child.func.attr == "setdefault"
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+            ):
+                yield child.args[0].value
+
+
+def iter_event_modules():
+    """Every module of the events package, the package itself included.
+
+    walk_packages() descends into the sub-packages, which iter_modules() does not, and neither
+    yields an __init__ — where the other Zentral apps keep their event classes.
+    """
+    yield zentral.contrib.mdm.events
+    for module_info in pkgutil.walk_packages(zentral.contrib.mdm.events.__path__,
+                                             f"{zentral.contrib.mdm.events.__name__}."):
+        yield importlib.import_module(module_info.name)
+
+
+def needs_a_case(event_class):
+    """The class writes its own keys, or it changes what an inherited key function writes.
+
+    The enrollment request events inherit theirs and set enrollment_payload_key only — the key is
+    built from it — so a class that overrides an attribute of the class the key function belongs to
+    needs a case of its own.
+    """
+    owner = next(c for c in event_class.__mro__ if "get_linked_objects_keys" in c.__dict__)
+    if owner is event_class:
+        return True
+    if owner is BaseEvent:
+        return False
+    attrs = {n for n in vars(owner) if not n.startswith("__")} - {"get_linked_objects_keys"}
+    return not attrs.isdisjoint(n for n in vars(event_class) if not n.startswith("__"))
+
+
+def iter_mdm_event_classes():
+    for module in iter_event_modules():
+        for obj in vars(module).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, BaseEvent)
+                and obj.__module__ == module.__name__
+                and needs_a_case(obj)
+            ):
+                yield obj
+
+
+class MDMEventLinkedObjectsKeysTestCase(SimpleTestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model_keys = {linked_objects_key(model) for model in apps.get_models()}
+
+    def test_event_linked_objects_keys(self):
+        for event_class, payload, expected_models in CASES:
+            with self.subTest(event_class.__name__, payload=payload):
+                event = event_class(EventMetadata(), payload)
+                self.assertEqual(
+                    event.get_linked_objects_keys(),
+                    {linked_objects_key(model): values for model, values in expected_models.items()},
+                )
+
+    def test_unknown_enrollment_session_model(self):
+        payload = {"outcome": "session_not_found",
+                   "target_type": "package_manifest",
+                   "package": {"pk": "pkg-uuid"},
+                   "enrollment_session": {"model": "goneenrollmentsession", "pk": "42"}}
+        with self.assertLogs("zentral.contrib.mdm.events.downloads", level="ERROR") as cm:
+            keys = MDMDownloadEvent(EventMetadata(), payload).get_linked_objects_keys()
+        self.assertEqual(keys, {"mdm_package": [("pkg-uuid",)]})
+        self.assertEqual(
+            cm.output[0],
+            "ERROR:zentral.contrib.mdm.events.downloads:Unknown enrollment session model: goneenrollmentsession",
+        )
+
+    def test_every_mdm_event_is_pinned(self):
+        pinned = set()
+        for event_class, _, _ in CASES:
+            pinned.add(event_class)
+            pinned.update(c for c in event_class.__mro__ if "get_linked_objects_keys" in c.__dict__)
+        event_classes = set(iter_mdm_event_classes())
+        self.assertTrue(event_classes)
+        self.assertEqual(event_classes - pinned, set())
+
+    def test_hand_written_keys_are_model_keys(self):
+        sources = [zentral.contrib.mdm.models.__file__]
+        sources.extend(module.__file__ for module in iter_event_modules())
+        found = set()
+        for source in sources:
+            found.update(iter_key_literals(source))
+        self.assertTrue(found)
+        self.assertEqual(found - self.model_keys, set())

--- a/tests/mdm/test_event_linked_objects_keys.py
+++ b/tests/mdm/test_event_linked_objects_keys.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase
 import zentral.contrib.mdm.events
 import zentral.contrib.mdm.models
 from zentral.contrib.mdm.events.admin_password import AdminPasswordUpdatedEvent
-from zentral.contrib.mdm.events.apps_books import AssetCountNotificationEvent
+from zentral.contrib.mdm.events.apps_books import AssetCountNotificationEvent, AssetCreatedEvent
 from zentral.contrib.mdm.events.artifacts import TargetArtifactUpdateEvent
 from zentral.contrib.mdm.events.device_lock_pin import DeviceLockPinSetEvent
 from zentral.contrib.mdm.events.downloads import MDMDownloadEvent
@@ -107,6 +107,11 @@ CASES = (
         AssetCountNotificationEvent,
         {"asset": {"adam_id": "123", "pricing_param": "STDQ"}, "location": {"pk": 1}},
         {Asset: [("123", "STDQ")], Location: [(1,)]},
+    ),
+    (
+        AssetCreatedEvent,
+        {"asset": {"pk": 6, "adam_id": "123", "pricing_param": "STDQ", "product_type": "App"}},
+        {Asset: [("123", "STDQ")]},
     ),
     (
         DEPEnrollmentRequestEvent,

--- a/tests/mdm/test_mdm_download_event.py
+++ b/tests/mdm/test_mdm_download_event.py
@@ -27,7 +27,7 @@ from zentral.contrib.mdm.events.downloads import (
     post_mdm_download_error_event,
 )
 from zentral.contrib.mdm.models import Artifact, Package
-from zentral.core.events.base import EventMetadata
+from zentral.core.events.base import EventMetadata, linked_objects_key
 
 from .utils import force_dep_enrollment_session, force_enrolled_user
 
@@ -86,8 +86,8 @@ class MDMDownloadEventTestCase(TestCase):
         self.assertEqual(
             event.get_linked_objects_keys(),
             {
-                "mdm_enrolleddevice": [(17,)],
-                "mdm_enrolleduser": [(42,)],
+                "mdm_enrolled_device": [(17,)],
+                "mdm_enrolled_user": [(42,)],
                 "mdm_package": [("pkg-uuid",)],
             },
         )
@@ -103,7 +103,7 @@ class MDMDownloadEventTestCase(TestCase):
         )
         self.assertEqual(
             event.get_linked_objects_keys(),
-            {"mdm_artifactversion": [("av-uuid",)], "mdm_artifact": [("a-uuid",)]},
+            {"mdm_artifact_version": [("av-uuid",)], "mdm_artifact": [("a-uuid",)]},
         )
 
     def test_get_linked_objects_keys_minimal(self, post_event):
@@ -122,7 +122,7 @@ class MDMDownloadEventTestCase(TestCase):
         )
         self.assertEqual(
             event.get_linked_objects_keys(),
-            {"mdm_package": [("pkg-uuid",)], "mdm_depenrollmentsession": [("42",)]},
+            {"mdm_package": [("pkg-uuid",)], "mdm_dep_enrollment_session": [("42",)]},
         )
 
     # success path: package_manifest
@@ -151,7 +151,7 @@ class MDMDownloadEventTestCase(TestCase):
         self.assertEqual(
             metadata["objects"],
             {
-                "mdm_enrolleddevice": [str(enrolled_device.pk)],
+                "mdm_enrolled_device": [str(enrolled_device.pk)],
                 "mdm_package": [str(package.pk)],
             },
         )
@@ -235,7 +235,7 @@ class MDMDownloadEventTestCase(TestCase):
             metadata["objects"],
             {
                 "mdm_package": [str(package.pk)],
-                f"mdm_{session_model_name}": [str(session_pk)],
+                linked_objects_key(session): [str(session_pk)],
             },
         )
 
@@ -264,7 +264,7 @@ class MDMDownloadEventTestCase(TestCase):
         metadata = event.metadata.serialize()
         # the missing user is still queryable via linked_objects.
         self.assertEqual(
-            metadata["objects"]["mdm_enrolleduser"], [str(user_pk)]
+            metadata["objects"]["mdm_enrolled_user"], [str(user_pk)]
         )
         # machine_serial_number is set because the device DID resolve.
         self.assertEqual(metadata["machine_serial_number"], session.enrolled_device.serial_number)

--- a/tests/mdm/test_rotate_filevault_key_command.py
+++ b/tests/mdm/test_rotate_filevault_key_command.py
@@ -141,7 +141,7 @@ class RotateFileVaultKeyCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(metadata["tags"], ["mdm"])
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")

--- a/tests/mdm/test_security_info_command.py
+++ b/tests/mdm/test_security_info_command.py
@@ -166,7 +166,7 @@ class SecurityInfoCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(metadata["tags"], ["mdm"])
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -262,7 +262,7 @@ class SecurityInfoCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -298,7 +298,7 @@ class SecurityInfoCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -334,7 +334,7 @@ class SecurityInfoCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -386,7 +386,7 @@ class SecurityInfoCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -429,7 +429,7 @@ class SecurityInfoCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")

--- a/tests/mdm/test_set_auto_admin_password_command.py
+++ b/tests/mdm/test_set_auto_admin_password_command.py
@@ -159,5 +159,5 @@ class SetAutoAdminPasswordCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "admin_password"})

--- a/tests/mdm/test_set_recovery_lock_command.py
+++ b/tests/mdm/test_set_recovery_lock_command.py
@@ -140,7 +140,7 @@ class SetRecoveryLockCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -174,7 +174,7 @@ class SetRecoveryLockCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
@@ -208,7 +208,7 @@ class SetRecoveryLockCommandTestCase(TestCase):
         )
         metadata = event.metadata.serialize()
         self.assertEqual(metadata["machine_serial_number"], self.enrolled_device.serial_number)
-        self.assertEqual(metadata["objects"], {"mdm_command": [str(cmd.uuid)]})
+        self.assertEqual(metadata["objects"], {"mdm_device_command": [str(cmd.uuid)]})
         self.assertEqual(set(metadata["tags"]), {"mdm", "recovery_password"})
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")

--- a/zentral/contrib/mdm/apps_books.py
+++ b/zentral/contrib/mdm/apps_books.py
@@ -384,7 +384,7 @@ def _update_or_create_asset(adam_id, pricing_param, defaults, notification_id, c
     )
     collected_objects["asset"] = asset
     if created:
-        payload = asset.serialize_for_event(keys_only=False)
+        payload = {"asset": asset.serialize_for_event(keys_only=False)}
         if notification_id:
             payload["notification_id"] = notification_id
         yield AssetCreatedEvent(EventMetadata(), payload)
@@ -397,7 +397,7 @@ def _update_or_create_asset(adam_id, pricing_param, defaults, notification_id, c
                 updated = True
         if updated:
             asset.save()
-            payload = asset.serialize_for_event(keys_only=False)
+            payload = {"asset": asset.serialize_for_event(keys_only=False)}
             if notification_id:
                 payload["notification_id"] = notification_id
             yield AssetUpdatedEvent(EventMetadata(), payload)
@@ -566,7 +566,7 @@ def refresh_asset_metadata(client, asset):
         if not updated:
             return False
         asset.save()
-        event = AssetUpdatedEvent(EventMetadata(), asset.serialize_for_event(keys_only=False))
+        event = AssetUpdatedEvent(EventMetadata(), {"asset": asset.serialize_for_event(keys_only=False)})
     event.post()
     return True
 

--- a/zentral/contrib/mdm/events/admin_password.py
+++ b/zentral/contrib/mdm/events/admin_password.py
@@ -14,7 +14,7 @@ class AdminPasswordUpdatedEvent(BaseEvent):
         keys = {}
         cmd_uuid = self.payload.get("command", {}).get("uuid")
         if cmd_uuid:
-            keys["mdm_command"] = [(cmd_uuid,)]
+            keys["mdm_device_command"] = [(cmd_uuid,)]
         return keys
 
 

--- a/zentral/contrib/mdm/events/artifacts.py
+++ b/zentral/contrib/mdm/events/artifacts.py
@@ -25,14 +25,14 @@ class TargetArtifactUpdateEvent(BaseEvent):
             logging.warning("Missing event information")
         else:
             keys["mdm_artifact"] = [(a_pk,)]
-            keys["mdm_artifactversion"] = [(av_pk,)]
+            keys["mdm_artifact_version"] = [(av_pk,)]
         # enrolled user
         try:
             eu_pk = self.payload["enrolled_user"]["pk"]
         except KeyError:
             pass
         else:
-            keys["mdm_enrolleduser"] = [(eu_pk,)]
+            keys["mdm_enrolled_user"] = [(eu_pk,)]
         return keys
 
 

--- a/zentral/contrib/mdm/events/device_lock_pin.py
+++ b/zentral/contrib/mdm/events/device_lock_pin.py
@@ -14,7 +14,7 @@ class BaseDeviceLockPinEvent(BaseEvent):
         keys = {}
         cmd_uuid = self.payload.get("command", {}).get("uuid")
         if cmd_uuid:
-            keys["mdm_command"] = [(cmd_uuid,)]
+            keys["mdm_device_command"] = [(cmd_uuid,)]
         return keys
 
 

--- a/zentral/contrib/mdm/events/downloads.py
+++ b/zentral/contrib/mdm/events/downloads.py
@@ -1,6 +1,7 @@
 import logging
+from django.apps import apps
 from zentral.core.events import register_event_type
-from zentral.core.events.base import BaseEvent, EventMetadata, EventRequest
+from zentral.core.events.base import BaseEvent, EventMetadata, EventRequest, linked_objects_key
 from zentral.contrib.mdm.declarations.exceptions import (
     TokenDeviceInactiveError,
     TokenSessionNotFoundError,
@@ -30,16 +31,16 @@ class MDMDownloadEvent(BaseEvent):
         keys = {}
         dev = self.payload.get("enrolled_device")
         if dev and "pk" in dev:
-            keys["mdm_enrolleddevice"] = [(dev["pk"],)]
+            keys["mdm_enrolled_device"] = [(dev["pk"],)]
         usr = self.payload.get("enrolled_user")
         if usr and "pk" in usr:
-            keys["mdm_enrolleduser"] = [(usr["pk"],)]
+            keys["mdm_enrolled_user"] = [(usr["pk"],)]
         for target_key in ("cert_asset", "data_asset", "profile", "enterprise_app"):
             target = self.payload.get(target_key)
             if not target:
                 continue
             if "pk" in target:
-                keys["mdm_artifactversion"] = [(target["pk"],)]
+                keys["mdm_artifact_version"] = [(target["pk"],)]
             artifact = target.get("artifact") or {}
             if "pk" in artifact:
                 keys["mdm_artifact"] = [(artifact["pk"],)]
@@ -48,7 +49,14 @@ class MDMDownloadEvent(BaseEvent):
             keys["mdm_package"] = [(pkg["pk"],)]
         session = self.payload.get("enrollment_session")
         if session and "pk" in session and "model" in session:
-            keys[f"mdm_{session['model']}"] = [(session["pk"],)]
+            try:
+                session_model = apps.get_model("mdm", session["model"])
+            except LookupError:
+                # a removed model whose content type was cleaned up too — the session lookup
+                # already raised DoesNotExist, so drop the key and keep the 404
+                logger.error("Unknown enrollment session model: %s", session["model"])
+            else:
+                keys[linked_objects_key(session_model)] = [(session["pk"],)]
         return keys
 
 

--- a/zentral/contrib/mdm/events/filevault.py
+++ b/zentral/contrib/mdm/events/filevault.py
@@ -14,7 +14,7 @@ class FileVaultPRKUpdatedEvent(BaseEvent):
         keys = {}
         cmd_uuid = self.payload.get("command", {}).get("uuid")
         if cmd_uuid:
-            keys["mdm_command"] = [(cmd_uuid,)]
+            keys["mdm_device_command"] = [(cmd_uuid,)]
         return keys
 
 

--- a/zentral/contrib/mdm/events/recovery_password.py
+++ b/zentral/contrib/mdm/events/recovery_password.py
@@ -14,7 +14,7 @@ class BaseRecoveryPasswordEvent(BaseEvent):
         keys = {}
         cmd_uuid = self.payload.get("command", {}).get("uuid")
         if cmd_uuid:
-            keys["mdm_command"] = [(cmd_uuid,)]
+            keys["mdm_device_command"] = [(cmd_uuid,)]
         return keys
 
 

--- a/zentral/contrib/mdm/models.py
+++ b/zentral/contrib/mdm/models.py
@@ -3644,6 +3644,11 @@ class UserCommand(Command):
                          name="apns_user_opti")
         ]
 
+    def linked_objects_keys_for_event(self):
+        keys = super().linked_objects_keys_for_event()
+        keys["mdm_user_command"] = [(str(self.uuid),)]
+        return keys
+
 
 # Apple software lookup service
 

--- a/zentral/core/events/base.py
+++ b/zentral/core/events/base.py
@@ -587,7 +587,7 @@ class AuditEvent(BaseEvent):
             em_kwargs["machine_serial_number"] = machine_serial_number
         metadata = EventMetadata(**em_kwargs)
         # the object the event is about is always linked. a model that declares its own key keeps
-        # control of it — DeviceCommand links itself by uuid, not by pk — but a model that only
+        # control of it — the MDM commands link themselves by uuid, not by pk — but a model that only
         # declares its parents no longer drops the link to itself.
         get_extra_keys = getattr(instance, "linked_objects_keys_for_event", None)
         extra_keys = get_extra_keys() if get_extra_keys is not None else {}

--- a/zentral/core/events/base.py
+++ b/zentral/core/events/base.py
@@ -545,17 +545,17 @@ register_event_type(BaseEvent)
 # Zentral audit event
 
 
-def linked_objects_key(instance):
-    """The metadata objects key of a model instance.
+def linked_objects_key(model):
+    """The metadata objects key of a model class or of one of its instances.
 
     A model sets linked_objects_key to override it, for a verbose name that does not read well.
     """
-    key = getattr(instance, "linked_objects_key", None)
+    key = getattr(model, "linked_objects_key", None)
     if key:
         return key
-    key = instance._meta.verbose_name.replace(" ", "_")
-    if instance._meta.app_label != "inventory":  # shorter names for the inventory objects
-        key = f"{instance._meta.app_label}_{key}"
+    key = model._meta.verbose_name.replace(" ", "_")
+    if model._meta.app_label != "inventory":  # shorter names for the inventory objects
+        key = f"{model._meta.app_label}_{key}"
     return key
 
 


### PR DESCRIPTION
## What changed

Three fixes to the objects that the MDM events and models link in `metadata.objects`. One commit for each.

### 1. The events use the key of the model

Some MDM events wrote a linked object under a hand-written key that did not match the key that `linked_objects_key()` derives from the model:

| Old key | New key | Model |
| --- | --- | --- |
| `mdm_artifactversion` | `mdm_artifact_version` | `ArtifactVersion` |
| `mdm_enrolleddevice` | `mdm_enrolled_device` | `EnrolledDevice` |
| `mdm_enrolleduser` | `mdm_enrolled_user` | `EnrolledUser` |
| `mdm_command` | `mdm_device_command` | `DeviceCommand` |
| `mdm_depenrollmentsession`, … | `mdm_dep_enrollment_session`, … | `DEPEnrollmentSession`, … |

The events that carry the new keys are `mdm_download`, `target_artifact_update`, `admin_password_updated`, `filevault_prk_updated`, `recovery_password_set`, `recovery_password_updated`, `recovery_password_cleared`, `device_lock_pin_set` and `device_lock_pin_cleared`.

`serialize_needles()` makes one needle for each key, `_o:<key>:<value>`. An old key put the events of one object in a second token: the `zentral_audit` events of that object used the key of the model, and these events used the other one. A search for the events of an artifact version found one half only.

No `EventsMixin` view exists for those objects today, so nothing queries either key yet. The split becomes visible as soon as something does.

### 2. A user command links itself by its uuid

`DeviceCommand` writes its own key in `linked_objects_keys_for_event()`, so an audit event links it by the uuid. The uuid is the identifier that the API and the web console show. `UserCommand` wrote no key, so `AuditEvent.build()` used the primary key instead: the needle of a user command held an auto-increment id, and the needle of a device command holds a CommandUUID.

Nothing builds an audit event for a user command today. The API lists them and reads them, and it does not delete them. No stored event changes.

### 3. The asset events carry the asset in the `asset` key

`BaseAppsBooksEvent.get_linked_objects_keys()` reads the asset from the `asset` key of the payload. Every apps & books event put it there, except `mdm_asset_created` and `mdm_asset_updated`. Those two were posted with a flat `asset.serialize_for_event()`: the attributes of the asset were at the top level, so the two events linked no object at all.

They carry an `asset` object now, like the location asset events and the notification events. `notification_id` keeps its place at the top level.

## Notes for the reviewer

- `mdm_command` was the worst of the set. It named no model at all, while `DeviceCommand` links itself under `mdm_device_command`. The four events that used it post from `Channel.DEVICE` commands only, so `mdm_device_command` is correct for all of them.
- The enrollment session key was built from `_meta.model_name`, which the token carries. It comes from the model now. `linked_objects_key()` accepts a class as well as an instance, which `tests/core_events/test_audit_event_objects.py` already relied on, so the lookup makes no throwaway instance.
- The token is signature-verified before that point, so the model name is not attacker-controlled. A model that is removed from the code, and whose content type is removed too, makes the session lookup raise `DoesNotExist` upstream. The key is then skipped and logged, and the `404` stands.
- The other thirteen descendants of `BaseAppsBooksEvent` were already correct. The seven notification events set `payload["asset"]` in the preprocessor. The location asset and the device assignment events serialize the location asset, which nests the asset. `DeviceAssignmentRequestEvent` and `DeviceAssignmentRequestErrorEvent` are registered, and no code posts them.
- The other hand-written keys agree with their model: `mdm_artifact`, `mdm_package`, `mdm_location`, `mdm_dep_enrollment`, `mdm_ota_enrollment`, `mdm_user_enrollment`, `mdm_dep_virtual_server`, `mdm_device_command`.
- No backfill. The events already in an event store keep the old key and the old payload, and they go away with the retention of the store. The CHANGELOG has an entry for each of the two incompatibilities.
- An asset keeps the `adamId` and pricing parameter pair as its only value. A primary key beside it was in an earlier version of this branch, and it is out. A view reads one key and one value — `fetch_object_events(key, val)` — so one needle must carry every event of an asset. The seven notification events hold the pair only, and they always will: Apple sends the notification before Zentral creates the asset. So the pair is the value that can cover all of them, and the primary key is not. The `zentral_audit` events of an asset are the ones to move, with a `linked_objects_keys_for_event()` on the model, and no audit event of an asset exists yet.

### The same defect in other apps

`linked_objects_key()` does not agree with the hand-written key in four more places. None of them splits anything today, because no audit event exists for those models:

| Hand-written | Model key | File |
| --- | --- | --- |
| `incident`, `machine_incident` | `incidents_incident`, `incidents_machine_incident` | `zentral/core/incidents/events/__init__.py` |
| `realm_user` | `realms_realm_user` | `zentral/contrib/santa/events/__init__.py` |
| `santa_ruleset` | `santa_rule_set` | `zentral/contrib/santa/events/__init__.py` |
| `munki_pkginfo`, `munki_pkginfo_name` | `monolith_pkg_info`, `monolith_pkg_info_name` | `zentral/contrib/munki/events/__init__.py` |

The munki pair carries a natural key, `(name, version)`, so it looks intentional. For the other three, a `linked_objects_key` attribute on the model is the cheaper fix: it moves the model to the event, and it breaks no stored event. `zentral/core/incidents/views.py` already queries `incident`, so that one has a consumer.

## Test

`tests/mdm/test_event_linked_objects_keys.py` writes no key spelling of its own. It builds the expected keys with `linked_objects_key()`, so the events and the models can only move together:

- `test_event_linked_objects_keys` pins 15 payload cases to the model classes they link. Two of them are real asset payloads: the notification, and the asset event, which carries a primary key that it does not link.
- `test_every_mdm_event_is_pinned` walks the events package and fails on an event that no case covers. A class needs a case where it writes the keys itself, and also where it changes what an inherited key function writes: the enrollment request events set `enrollment_payload_key` only, and their key is built from it, so a class that overrides an attribute of the class the key function belongs to counts too. The walk uses `walk_packages()`, and it reads the package itself first. `iter_modules()` does not descend into a sub-package, and neither function yields an `__init__` — where the other Zentral apps keep their event classes.
- `test_hand_written_keys_are_model_keys` parses the key functions with `ast` and rejects a written key that names no model in any app. It counts the written keys only: a subscript that is read is a payload lookup, and a dict literal counts where it maps a key to its values, `[(...)]`. A dict that maps a key to anything else is a payload dict — a `get()` default, a lookup table — and its keys are not object keys. The rule keeps the one real case, `mdm_dep_virtual_server`, which a key function returns as a dict literal.
- `test_unknown_enrollment_session_model` covers the lookup failure.

`tests/mdm/test_apps_books_assets_assignments_sync.py` asserts the keys that `mdm_asset_created` and `mdm_asset_updated` link, and not only the shape of the payload.

Mutation proves the guard. Four changes, all caught:

| Mutation | Test that fails |
| --- | --- |
| `mdm_artifact_version` back to `mdm_artifactversion` | `test_event_linked_objects_keys` and `test_hand_written_keys_are_model_keys` |
| a new event class, with a key that names no model, in `events/sub/inner.py` | `test_every_mdm_event_is_pinned` and `test_hand_written_keys_are_model_keys` |
| the same class in `events/__init__.py` | `test_every_mdm_event_is_pinned` and `test_hand_written_keys_are_model_keys` |
| a key written through another name, `out["mdm_usercommand"]` | `test_hand_written_keys_are_model_keys` |

The two walk mutations are the reason for that walk. With `iter_modules()` alone, both classes pass both guards.

The guard was measured for false alarms too. A `get()` default with contents, `self.payload.get("asset", {"adam_id": None, ...})`, is an ordinary line that writes no key, and it does not fail the test. A real bad key in the same function, `keys.update({"mdm_not_a_model": [(1,)]})`, still does.

A key that is composed at run time leaves no literal. `EnrollmentRequestEvent` builds `f"mdm_{self.enrollment_payload_key}"`, so a case is the only guard on those three keys — and `test_every_mdm_event_is_pinned` is what makes a fourth subclass ask for one. A subclass with `enrollment_payload_key = "not_a_model_at_all"` fails it.

## Verification

- `tests.mdm`, `tests.core_events` and `tests.core_stores`: 3237 tests, all pass, on the rebased branch.
- Patch coverage: no uncovered added line. `coverage json` missing lines ∩ `git diff -U0` hunks.
- `ruff` is clean on all the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




