### PR TITLE
accounts, monolith: fix the loop variable of the deferred callbacks

### DIFF
--- a/server/accounts/management/commands/remove_expired_api_tokens.py
+++ b/server/accounts/management/commands/remove_expired_api_tokens.py
@@ -111,9 +111,6 @@ class Command(BaseCommand):
 
                     token.delete()
 
-                    def on_commit_callback(event=event):
-                        event.post()
-
-                    transaction.on_commit(on_commit_callback)
+                    transaction.on_commit(event.post)
         finally:
             queues.stop()

--- a/server/accounts/management/commands/remove_expired_api_tokens.py
+++ b/server/accounts/management/commands/remove_expired_api_tokens.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
 
                     token.delete()
 
-                    def on_commit_callback():
+                    def on_commit_callback(event=event):
                         event.post()
 
                     transaction.on_commit(on_commit_callback)

--- a/tests/monolith/test_sync_monolith_repositories_cmd.py
+++ b/tests/monolith/test_sync_monolith_repositories_cmd.py
@@ -1,8 +1,9 @@
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import call, patch
 from django.core.management import call_command
 from django.db import connections
 from django.test import TestCase
+from zentral.contrib.monolith.models import Repository
 from zentral.contrib.monolith.tasks import SYNC_REPOSITORY_LOCK_ID
 from .utils import force_repository
 
@@ -44,6 +45,30 @@ class SyncMonolithRepositoriesTestCase(TestCase):
         sync_catalogs.assert_called_once()
         self.assertEqual(len(callbacks), 1)
         send_notification.assert_called_once_with("monolith.repository", str(repository.pk))
+
+    @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
+    @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")
+    def test_sync_two_repositories_ok(self, sync_catalogs, send_notification):
+        force_repository()
+        force_repository()
+        # the names are random, and the database collation orders them, not python. read the
+        # order of the sync from the queryset the command iterates.
+        repository1, repository2 = Repository.objects.all()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            stdout, stderr = self.call_command()
+        self.assertEqual(
+            stdout,
+            f"Sync {repository1.name} repository\nOK\nSync {repository2.name} repository\nOK\n"
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(sync_catalogs.call_count, 2)
+        self.assertEqual(len(callbacks), 2)
+        # the callbacks run after the loop, so each one must carry the pk of its own repository
+        self.assertEqual(
+            send_notification.call_args_list,
+            [call("monolith.repository", str(repository1.pk)),
+             call("monolith.repository", str(repository2.pk))]
+        )
 
     @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
     @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")

--- a/tests/server_accounts/test_remove_expired_api_token_cmd.py
+++ b/tests/server_accounts/test_remove_expired_api_token_cmd.py
@@ -78,6 +78,52 @@ class RemoveExpiredAPITokenCmdTestCase(TestCase, EventAssertions):
             expected_event_payload, {"accounts_api_token": [str(token.pk)]}, post_event
         )
 
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_remove_two_tokens(self, post_event):
+        user = User.objects.create_user("yolo", "fomo@example.com")
+        expired_days = 3
+        expired_date = datetime.today() - timedelta(days=(expired_days + 1))
+        # the command removes the tokens in creation order
+        token1, _ = APIToken.objects.create_for_user(
+            user, expiry=expired_date, name="api--token1"
+        )
+        token2, _ = APIToken.objects.create_for_user(
+            user, expiry=expired_date, name="api--token2"
+        )
+
+        def expected_event_payload(token):
+            return {
+                "action": "deleted",
+                "object": {
+                    "model": "accounts.apitoken",
+                    "pk": str(token.pk),
+                    "prev_value": token.serialize_for_event(),
+                },
+            }
+
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            stdout, stderr = self.call_command("--after-days", expired_days)
+        self.assertIn("Tokens to remove:", stdout)
+        self.assertEqual(stderr, "")
+        self.assertFalse(
+            APIToken.objects.filter(id__in=(token1.id, token2.id)).exists()
+        )
+
+        # the callbacks can run after the loop, so each one must carry its own token
+        self.assert_events_published(2, callbacks, post_event)
+        self.assert_is_audit_event(
+            expected_event_payload(token1),
+            {"accounts_api_token": [str(token1.pk)]},
+            post_event,
+            expected_order=0,
+        )
+        self.assert_is_audit_event(
+            expected_event_payload(token2),
+            {"accounts_api_token": [str(token2.pk)]},
+            post_event,
+            expected_order=1,
+        )
+
     def test_remove_token_by_user(self):
         self.maxDiff = None
         user = User.objects.create_user("yolo", "fomo@example.com")

--- a/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
+++ b/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
@@ -30,8 +30,8 @@ class Command(BaseCommand):
                 else:
                     self.write("OK")
 
-                    def notify():
-                        notifier.send_notification("monolith.repository", str(db_repository.pk))
+                    def notify(pk=str(db_repository.pk)):
+                        notifier.send_notification("monolith.repository", pk)
 
                     transaction.on_commit(notify)
         queues.stop()


### PR DESCRIPTION
## Summary

This PR takes the fix from #1617, adds the regression tests it needs, and removes one of the two closures. The first commit is the commit of @harshadkhetpal, with the original author.

Two `transaction.on_commit()` callbacks were defined in a loop, and they read the loop variable when they ran, not when they were defined. Django defers a callback to the commit of the outermost atomic block, so a callback can run after the loop, when the loop variable holds the value of the last iteration.

**`sync_monolith_repositories`**: the `transaction.atomic()` block contains the full loop, so all the callbacks run after the loop. A command run with N repositories sent N notifications, and each one carried the primary key of the last repository. The only subscriber of the `monolith.repository` channel is `MonolithConf._reset_repositories()`. It ignores the payload and clears the full cache, so no repository cache became stale. The notifications were wrong, and nothing read them. A default argument binds the primary key at definition time.

**`remove_expired_api_tokens`**: the `transaction.atomic()` block is in the loop, so each callback runs at the end of its own iteration. A standalone command run is correct. In an outer transaction, all the callbacks run at the end, and the audit event of the last token is posted N times.

The third commit removes the closure of this second command. `AuditEvent.post` takes no argument, and a bound method carries its own instance, so `transaction.on_commit(event.post)` defers the event of the current token. Nothing reads the loop variable anymore, so there is no binding left to get wrong.

The `sync_monolith_repositories` command keeps its closure. Its callback needs the primary key of the repository, so there is no bound method to give to `transaction.on_commit()`, and the value must be captured at definition time.

## Tests

The two command test suites built one repository and one token only, so neither one could show the problem.

This PR adds one test to each suite with two objects:

- `test_sync_two_repositories_ok` verifies that each notification carries the primary key of its own repository.
- `test_remove_two_tokens` verifies that each audit event carries its own token.

Both tests fail on the two commands before the fix, and pass after it. `tests.monolith` and `tests.server_accounts` are green (1112 tests).

The monolith test reads the order of the sync from the queryset that the command iterates. The repository names are random, and the `en_US.utf8` collation of the database does not order them like python does. A sort in python made the test fail 3 times out of 12.

No CHANGELOG entry: the behavior of Zentral does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
