### PR TITLE
monolith: sync each repository in its own transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,8 @@ The `rebuild_manifest_enrollment_packages` command takes a `--manifest` option w
 
 Fixed the links of the Santa cdhash event store redirect, which had the Signing ID target type. The view sends the user back to the events page of the target when the store gives no event URL. It sent them to the Signing ID events page instead, with a cdhash identifier that this page cannot find. The events the view read were the correct ones.
 
+The `sync_monolith_repositories` command uses one transaction for each repository now, and releases the lock of a repository at the end of its own synchronization. With one transaction for all of them, a database error stopped the command and rolled back the repositories already synchronized, and a failed synchronization kept its partial changes.
+
 
 ## 2026.5
 

--- a/tests/monolith/test_sync_monolith_repositories_cmd.py
+++ b/tests/monolith/test_sync_monolith_repositories_cmd.py
@@ -1,9 +1,10 @@
 from io import StringIO
 from unittest.mock import call, patch
 from django.core.management import call_command
-from django.db import connections
+from django.db import connection, connections
 from django.test import TestCase
-from zentral.contrib.monolith.models import Repository
+from zentral.contrib.monolith.exceptions import RepositoryError
+from zentral.contrib.monolith.models import Catalog, Repository
 from zentral.contrib.monolith.tasks import SYNC_REPOSITORY_LOCK_ID
 from .utils import force_repository
 
@@ -86,6 +87,49 @@ class SyncMonolithRepositoriesTestCase(TestCase):
         sync_catalogs.assert_not_called()
         self.assertEqual(len(callbacks), 0)
         send_notification.assert_not_called()
+
+    @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
+    @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")
+    def test_sync_error_rolls_the_repository_back(self, sync_catalogs, send_notification):
+        repository = force_repository()
+
+        def sync_catalogs_side_effect(*args, **kwargs):
+            Catalog.objects.create(repository=repository, name="yolo")
+            raise RepositoryError("YOLO")
+
+        sync_catalogs.side_effect = sync_catalogs_side_effect
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            stdout, stderr = self.call_command()
+        self.assertEqual(stdout, f"Sync {repository.name} repository\n")
+        self.assertEqual(stderr, f"Could not sync {repository.name}: YOLO\n")
+        self.assertEqual(len(callbacks), 0)
+        send_notification.assert_not_called()
+        self.assertFalse(Catalog.objects.filter(repository=repository, name="yolo").exists())
+
+    @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
+    @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")
+    def test_sync_database_error_on_first_repository(self, sync_catalogs, send_notification):
+        force_repository()
+        force_repository()
+        repository1, repository2 = Repository.objects.all()
+
+        def sync_catalogs_side_effect(*args, **kwargs):
+            if sync_catalogs.call_count == 1:
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT * FROM monolith_repository_yolo")
+
+        sync_catalogs.side_effect = sync_catalogs_side_effect
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            stdout, stderr = self.call_command()
+        # the second repository is synced with a healthy connection
+        self.assertEqual(
+            stdout,
+            f"Sync {repository1.name} repository\nSync {repository2.name} repository\nOK\n"
+        )
+        self.assertIn(f"Could not sync {repository1.name}:", stderr)
+        self.assertEqual(sync_catalogs.call_count, 2)
+        self.assertEqual(len(callbacks), 1)
+        send_notification.assert_called_once_with("monolith.repository", str(repository2.pk))
 
     @patch("zentral.contrib.monolith.management.commands.sync_monolith_repositories.notifier.send_notification")
     @patch("zentral.contrib.monolith.repository_backends.base.BaseRepository.sync_catalogs")

--- a/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
+++ b/zentral/contrib/monolith/management/commands/sync_monolith_repositories.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from django.db import transaction
 from django.core.management.base import BaseCommand
 from base.notifier import notifier
@@ -16,22 +18,22 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         self.verbosity = kwargs.get("verbosity", 1)
-        with transaction.atomic():
-            for db_repository in Repository.objects.all():
-                repository = load_repository_backend(db_repository)
-                self.write(f"Sync {repository.name} repository")
-                if not try_lock_repository_sync(db_repository.pk):
-                    self.stderr.write(f"Could not sync {repository.name}: a sync is already running")
-                    continue
-                try:
+        for db_repository in Repository.objects.all():
+            repository = load_repository_backend(db_repository)
+            self.write(f"Sync {repository.name} repository")
+            # the try must stay outside the atomic block: the exception has to reach __exit__ to
+            # roll this repository back and to release its transaction scoped advisory lock
+            try:
+                with transaction.atomic():
+                    if not try_lock_repository_sync(db_repository.pk):
+                        self.stderr.write(f"Could not sync {repository.name}: a sync is already running")
+                        continue
                     repository.sync_catalogs()
-                except Exception as e:
-                    self.stderr.write(f"Could not sync {repository.name}: {e}")
-                else:
-                    self.write("OK")
-
-                    def notify(pk=str(db_repository.pk)):
-                        notifier.send_notification("monolith.repository", pk)
-
-                    transaction.on_commit(notify)
+            except Exception as e:
+                self.stderr.write(f"Could not sync {repository.name}: {e}")
+            else:
+                self.write("OK")
+                transaction.on_commit(
+                    partial(notifier.send_notification, "monolith.repository", str(db_repository.pk))
+                )
         queues.stop()


### PR DESCRIPTION
## Summary

Follow-up of #1668. The `sync_monolith_repositories` command wrapped the full loop in one `transaction.atomic()` block, and caught the errors inside that block. This gives the command two failure modes.

**A database error stops the command.** The `except Exception` block looks like it isolates each repository, but it only does that for the errors that do not touch the database. A database error puts the connection in an aborted state. The command catches it, writes to stderr, and continues, and then the advisory lock of the next repository fails with `current transaction is aborted, commands ignored until end of transaction block`. That exception is outside the `try`, so the command stops. The repositories that the command synchronized before the error are rolled back with it. One bad catalog can stop the synchronization of every repository.

**An error keeps the partial changes of the repository that failed.** The `except` block catches the error inside the atomic block, so `__exit__` never rolls it back. `BaseRepository.sync_catalogs()` imports the pkg infos, archives the pkg infos and the catalogs, and then reads the client resources. The S3 backend raises a `RepositoryError` on that read, so the archived pkg infos stay, the synchronization date does not change, and the manifests do not get their new version.

## Changes

Each repository gets its own transaction, and the `try` block is outside of it, like in `sync_repository_task`:

- An exception reaches `__exit__`, which rolls that repository back. The command synchronizes the next repository with a healthy connection.
- The advisory lock is transaction scoped, so it is released at the end of the synchronization of its own repository. Before, the command held the locks of all the repositories until the end of the run, and an operator who used the *Sync* button on a repository the command was done with got "a sync is already running".
- The audit events of a repository are published when that repository commits, and not at the end of the command.

The notification callback carries its arguments in a `functools.partial`, so nothing reads the loop variable when the callback runs. The callback of #1668 used a default argument for this. The default argument is not necessary with one transaction for each repository, but only when Zentral runs the command outside of a transaction. A `partial` is correct in the two cases.

## Tests

Two new tests, both fail before this change:

- `test_sync_error_rolls_the_repository_back`: the sync of a repository writes a catalog and raises. The catalog must not exist after the command. Before: `AssertionError: True is not false`.
- `test_sync_database_error_on_first_repository`: the sync of the first of two repositories makes a database error. The second repository must be synchronized, and get its notification. Before: `InternalError: current transaction is aborted, commands ignored until end of transaction block`.

`tests.monolith` and `tests.server_accounts` are green (1114 tests). The command test file passed 10 runs out of 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
