### PR TITLE
osquery: find the tables a query reads with a SQL parser, and reject the SQL that does not parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ The list endpoints of the Osquery API answer with a page and not with an array. 
 The `version` attribute of an Osquery query in an event payload is the version of the query again. It was the minimum Osquery version of the query, which replaced the query version when the query had one. The minimum Osquery version has its own `minimum_osquery_version` attribute now. The query payload also has the `pk`, `name` and `tag` attributes, and the compliance check of the query. This payload is a part of the `osquery_pack_query_update` events.
 
 
+#### 🧨 Osquery query SQL
+
+Zentral parses the SQL of a query with [sqlglot](https://github.com/tobymao/sqlglot) to find the Osquery tables that the query reads, and refuses a query with SQL that it cannot parse. The web console gives an error for the `sql` field, and the API answers `400` with an error for the `sql` attribute.
+
+An import of a standard Osquery pack fails if one of its queries has SQL that Zentral cannot parse. The errors give the name of every query that does not parse. A pack is imported as a unit, so no query of that pack is created or updated. Correct the SQL and import the pack again.
+
+
 #### 🧨 PATCH on the Monolith API
 
 `PATCH` gives a `405 Method Not Allowed` on the Monolith catalog, condition, enrollment and manifest enrollment package endpoints. Use `PUT`, and send all the attributes of the object.

--- a/docs/apps/osquery.md
+++ b/docs/apps/osquery.md
@@ -6,6 +6,14 @@
 
 To activate the osquery module, you need to add a `zentral.contrib.osquery` section to the `apps` section in `base.json`.
 
+## Query tables
+
+Zentral parses the SQL of a query to find the osquery tables that the query reads. The names are in lower case, and sorted. A query that reads no table, a compliance check that only returns a status, has an empty list of tables.
+
+The query page and the query list of the web console show the tables. The run list shows them too, and Zentral finds them in the SQL that the run froze when it started, so a later change to the query does not change them. Zentral computes the tables when it shows them, and does not store them.
+
+Zentral refuses a query with SQL that it cannot parse, and gives an error for the `sql` attribute. The error gives the position of the problem in the SQL when sqlglot reports one. An import of a standard pack fails if it has such a query, and the errors give the name of every query that does not parse. Correct the SQL and import the pack again.
+
 ## Audit events
 
 Zentral publishes a `zentral_audit` event when a user creates, updates or deletes an Osquery object from the web console or from the API: automatic table constructions, configurations, configuration packs, enrollments, file categories, packs, pack queries, queries, and distributed query runs. Each event carries the value of the object before and after the change, with the user, the source IP and the request that made it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ pyyaml
 requests
 requests_oauthlib               # MDM DEP
 snowflake-connector-python
+sqlglot                         # SQL parsing
 tqdm
 typing_extensions
 XlsxWriter

--- a/requirements_constraints.txt
+++ b/requirements_constraints.txt
@@ -143,6 +143,7 @@ six==1.17.0
 sniffio==1.3.1
 snowflake-connector-python==4.7.1
 sortedcontainers==2.4.0
+sqlglot==30.17.0
 stack-data==0.6.3
 std-uritemplate==2.0.8
 tomlkit==0.14.0

--- a/tests/osquery/test_api_views.py
+++ b/tests/osquery/test_api_views.py
@@ -2056,6 +2056,26 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
                                          'query': ['This field may not be blank.']}}}
         )
 
+    def test_put_query_invalid_sql(self):
+        self.set_pack_endpoint_put_permissions()
+        url = reverse("osquery_api:pack", args=(get_random_string(12),))
+        response = self.put(
+            url,
+            {"queries": {"first_query": {"query": "select * from users;", "interval": 10},
+                         "second_query": {"query": "changed sql line;", "interval": 10},
+                         "third_query": {"query": "select * from users where name = 'zen", "interval": 10}}},
+        )
+        self.assertEqual(response.status_code, 400)
+        # every query that does not parse is reported, not only the first one
+        self.assertEqual(
+            response.json(),
+            {"queries": ["Query second_query: Could not parse the SQL query at line 1, column 16.",
+                         "Query third_query: Could not parse the SQL query."]}
+        )
+        # the import is a unit: the query that parses is not created either
+        self.assertEqual(Pack.objects.count(), 0)
+        self.assertEqual(Query.objects.count(), 0)
+
     def test_put_removed_and_snapshot_query(self):
         self.set_pack_endpoint_put_permissions()
         url = reverse("osquery_api:pack", args=(get_random_string(12),))
@@ -2831,6 +2851,33 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {'name': ['query with this name already exists.']})
 
+    def test_create_query_invalid_sql(self):
+        data = {
+            "name": get_random_string(12),
+            "sql": "changed sql line;",
+            "compliance_check_enabled": False
+        }
+        self.set_permissions("osquery.add_query")
+        response = self.post(reverse("osquery_api:queries"), data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"sql": ["Could not parse the SQL query at line 1, column 16."]}
+        )
+
+    def test_update_query_invalid_sql(self):
+        query = self.force_query()
+        data = {"name": query.name, "sql": "changed sql line;"}
+        self.set_permissions("osquery.change_query")
+        response = self.put(reverse("osquery_api:query", args=(query.pk,)), data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"sql": ["Could not parse the SQL query at line 1, column 16."]}
+        )
+        query.refresh_from_db()
+        self.assertEqual(query.tables, ["osquery_schedule"])
+
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_query(self, post_event):
         data = {
@@ -3437,7 +3484,7 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
     def test_update_query_increment_version(self):
         query = self.force_query()
         self.assertEqual(query.version, 1)
-        new_sql = "changed sql line;"
+        new_sql = "select 1 from processes;"
         data = {"name": query.name, "sql": new_sql}
         self.set_permissions("osquery.change_query")
         response = self.put(reverse("osquery_api:query", args=(query.pk,)), data)
@@ -3445,7 +3492,8 @@ class APIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.json()["version"], 2)
         query.refresh_from_db()
         self.assertEqual(query.version, 2)
-        self.assertEqual(query.sql, "changed sql line;")
+        self.assertEqual(query.sql, "select 1 from processes;")
+        self.assertEqual(query.tables, ["processes"])
 
     def test_update_query_with_pack_query_snapshot_mode_validate_success(self):
         query = self.force_query(pack_query_mode="snapshot", compliance_check=False)

--- a/tests/osquery/test_query_tables.py
+++ b/tests/osquery/test_query_tables.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from zentral.contrib.osquery.models import DistributedQuery, Query
+from zentral.utils.time import naive_utcnow
+
+
+class QueryTablesTestCase(TestCase):
+    def _force_query(self, sql="select 1 from processes;"):
+        return Query.objects.create(name=get_random_string(12), sql=sql)
+
+    # Query.tables
+
+    def test_tables(self):
+        query = self._force_query("select * from users u join groups g on (u.gid = g.gid);")
+        self.assertEqual(query.tables, ["groups", "users"])
+
+    def test_tables_empty_for_a_query_without_table(self):
+        self.assertEqual(self._force_query("select 'OK' as ztl_status;").tables, [])
+
+    # the form and the serializers reject the SQL they cannot parse. this is the fallback for the
+    # paths that do not validate, the shell and the tests.
+    def test_tables_empty_for_unparsable_sql(self):
+        with self.assertLogs("zentral.utils.sql", level="DEBUG"):
+            self.assertEqual(self._force_query("changed sql line;").tables, [])
+
+    # DistributedQuery
+
+    def test_snapshot_query(self):
+        query = self._force_query()
+        query.minimum_osquery_version = "5.10.2"
+        query.platforms = ["darwin"]
+        query.save()
+        distributed_query = DistributedQuery(valid_from=naive_utcnow())
+        distributed_query.snapshot_query(query)
+        distributed_query.save()
+        distributed_query.refresh_from_db()
+        self.assertEqual(distributed_query.query, query)
+        self.assertEqual(distributed_query.query_version, query.version)
+        self.assertEqual(distributed_query.sql, query.sql)
+        self.assertEqual(distributed_query.platforms, ["darwin"])
+        self.assertEqual(distributed_query.minimum_osquery_version, "5.10.2")

--- a/tests/osquery/test_setup_distributed_queries.py
+++ b/tests/osquery/test_setup_distributed_queries.py
@@ -310,6 +310,17 @@ class OsquerySetupDistributedQueriesViewsTestCase(TestCase, LoginCase):
         self.assertTemplateUsed(response, "osquery/distributedquery_list.html")
         self.assertContains(response, distributed_query.query.name)
 
+    # the tables of a run are derived from the SQL it froze, not from the query as it is now
+    def test_distributed_queries_get_tables(self):
+        distributed_query = self._force_distributed_query()
+        distributed_query.query.sql = "select * from carves;"
+        distributed_query.query.save()
+        self.login("osquery.view_distributedquery", "osquery.view_query")
+        response = self.client.get(reverse("osquery:distributed_queries"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<code>processes</code>")
+        self.assertNotContains(response, "<code>carves</code>")
+
     # distributed query
 
     def test_distributed_query_redirect(self):

--- a/tests/osquery/test_setup_packs.py
+++ b/tests/osquery/test_setup_packs.py
@@ -211,6 +211,28 @@ class OsquerySetupPacksViewsTestCase(TestCase, LoginCase):
                          ["osquery.query", "osquery.packquery"])
         self.assertTrue(all(e.metadata.uuid == report.metadata.uuid for e in audit_events))
 
+    def test_upload_pack_invalid_sql(self):
+        pack = self._force_pack()
+        self.login("osquery.change_pack", "osquery.view_pack")
+        pack_file = BytesIO(
+            b'{"queries": {"BadQuery": {"query": "changed sql line;", "interval": 3600},'
+            b'             "WorseQuery": {"query": "not sql at all", "interval": 3600}}}'
+        )
+        pack_file.name = get_random_string(12)
+        response = self.client.post(reverse("osquery:upload_pack", args=(pack.pk,)),
+                                    {"file": pack_file,
+                                     "update_and_create_only": "on"},
+                                    follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/pack_upload.html")
+        # the serializer errors are flattened into one readable line, not a dict
+        self.assertFormError(
+            response.context["form"], "file",
+            "queries: Query BadQuery: Could not parse the SQL query at line 1, column 16., "
+            "Query WorseQuery: Could not parse the SQL query at line 1, column 14."
+        )
+        self.assertEqual(pack.packquery_set.count(), 0)
+
     def test_upload_bad_file(self):
         pack = self._force_pack()
         self.login("osquery.change_pack", "osquery.view_pack")

--- a/tests/osquery/test_setup_queries.py
+++ b/tests/osquery/test_setup_queries.py
@@ -133,6 +133,35 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(metadata["objects"], {"osquery_query": [str(query.pk)]})
         self.assertEqual(sorted(metadata["tags"]), ["osquery", "zentral"])
 
+    def test_create_query_invalid_sql_post(self):
+        self.login("osquery.add_query", "osquery.view_query")
+        response = self.client.post(reverse("osquery:create_query"),
+                                    {"name": get_random_string(12),
+                                     "sql": "changed sql line;"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/query_form.html")
+        self.assertFormError(
+            response.context["form"], "sql",
+            "Could not parse the SQL query at line 1, column 16."
+        )
+        self.assertEqual(Query.objects.count(), 0)
+
+    def test_update_query_invalid_sql_post(self):
+        query = self._force_query()
+        self.login("osquery.change_query", "osquery.view_query")
+        response = self.client.post(reverse("osquery:update_query", args=(query.pk,)),
+                                    {"name": query.name,
+                                     "sql": "changed sql line;"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/query_form.html")
+        self.assertFormError(
+            response.context["form"], "sql",
+            "Could not parse the SQL query at line 1, column 16."
+        )
+        query.refresh_from_db()
+        self.assertEqual(query.sql, "select 1 from processes;")
+        self.assertEqual(query.tables, ["processes"])
+
     def test_create_query_with_compliance_check_and_tag_error(self):
         self.login("osquery.add_query", "osquery.view_query")
         tag = Tag.objects.create(name=get_random_string(12))
@@ -387,6 +416,26 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertEqual(Query.objects.filter(pk=query.pk).count(), 0)
         self.assertNotContains(response, query.name)
 
+    # query detail
+
+    def test_query_displays_the_tables(self):
+        query = self._force_query()
+        self.login("osquery.view_query")
+        response = self.client.get(query.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "osquery/query_detail.html")
+        self.assertContains(response, "<td>Table</td>")
+        self.assertContains(response, "<code>processes</code>")
+
+    def test_query_without_table(self):
+        query = self._force_query(force_compliance_check=True)
+        self.assertEqual(query.tables, [])
+        self.login("osquery.view_query")
+        response = self.client.get(query.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<td>Tables</td>")
+        self.assertNotContains(response, "<code></code>")
+
     # query events
 
     def test_query_events_redirect(self):
@@ -448,6 +497,14 @@ class OsquerySetupQueriesViewsTestCase(TestCase, LoginCase):
         self.assertIn(query2, response.context["object_list"])
         self.assertContains(response, query.name)
         self.assertContains(response, query2.name)
+
+    def test_query_list_displays_the_tables(self):
+        query = self._force_query()
+        self.login("osquery.view_query")
+        response = self.client.get(reverse("osquery:queries"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<code>processes</code>")
+        self.assertEqual(query.tables, ["processes"])
 
     def test_filtered_query_list(self):
         self.login("osquery.view_query")

--- a/tests/utils/test_sql.py
+++ b/tests/utils/test_sql.py
@@ -1,9 +1,10 @@
 import html
 import re
 
+from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 
-from zentral.utils.sql import format_sql, tables_in_query
+from zentral.utils.sql import SQLParseError, extract_tables, extract_tables_or_empty, format_sql, validate_sql
 
 
 def html_to_text(highlighted):
@@ -38,14 +39,164 @@ class FormatSQLTestCase(SimpleTestCase):
         self.assertEqual(html_to_text(format_sql("\n" + query + "\n")), query)
 
 
-class TablesInQueryTestCase(SimpleTestCase):
+class ExtractTablesTestCase(SimpleTestCase):
     def test_simple_query(self):
-        self.assertEqual(tables_in_query("select * from users;"), {"users"})
+        self.assertEqual(extract_tables("select * from users;"), ["users"])
 
-    def test_join_and_comments(self):
+    def test_no_table(self):
+        self.assertEqual(extract_tables("select 'OK' as ztl_status;"), [])
+
+    def test_result_sorted(self):
+        self.assertEqual(
+            extract_tables("select * from users u join groups g on (u.gid = g.gid) join apps a"),
+            ["apps", "groups", "users"]
+        )
+
+    def test_table_names_folded_to_lower_case(self):
+        self.assertEqual(extract_tables("SELECT * FROM CARVES;"), ["carves"])
+
+    def test_comments_ignored(self):
         query = (
             "-- a comment\n"
             "select * from users u /* another comment */\n"
             "join groups g on (u.gid = g.gid)"
         )
-        self.assertEqual(tables_in_query(query), {"users", "groups"})
+        self.assertEqual(extract_tables(query), ["groups", "users"])
+
+    # osquery has tables named after SQL keywords
+    def test_keyword_table_names(self):
+        self.assertEqual(
+            extract_tables("select * from time, groups, file, hash, users;"),
+            ["file", "groups", "hash", "time", "users"]
+        )
+
+    def test_cte_not_a_table(self):
+        query = (
+            "with expected_versions(name, version) as (values ('first_package', '0.1.2'))\n"
+            "select * from npm_packages join expected_versions using (name, version);"
+        )
+        self.assertEqual(extract_tables(query), ["npm_packages"])
+
+    def test_union_all(self):
+        self.assertEqual(
+            extract_tables("select pid from processes union all select pid from process_open_sockets;"),
+            ["process_open_sockets", "processes"]
+        )
+
+    def test_subquery_in_from(self):
+        self.assertEqual(
+            extract_tables("select * from (select uid from users) u join groups g using (gid);"),
+            ["groups", "users"]
+        )
+
+    # the queries below come from the official osquery packs. the regex this function replaced
+    # dropped a table in each of them, always one that follows a comma in the FROM clause. it
+    # read the sub query of the XcodeGhost query correctly.
+    def test_pack_comma_join_with_aliases(self):
+        query = (
+            "select liu.*, p.name, p.cmdline, p.cwd, p.root "
+            "from logged_in_users liu, processes p where liu.pid = p.pid;"
+        )
+        self.assertEqual(extract_tables(query), ["logged_in_users", "processes"])
+
+    def test_pack_comma_join(self):
+        self.assertEqual(extract_tables("select * from time, osquery_info;"), ["osquery_info", "time"])
+
+    def test_pack_comma_join_with_keyword_table(self):
+        query = (
+            "select i.*, p.resident_size, p.user_time, p.system_time, time.minutes as counter "
+            "from osquery_info i, processes p, time where p.pid = i.pid;"
+        )
+        self.assertEqual(extract_tables(query), ["osquery_info", "processes", "time"])
+
+    def test_pack_subquery_joined_with_keyword_table(self):
+        query = (
+            "select * from ("
+            "  select apps.bundle_short_version as xcode_version, apps.path as xcode_path,"
+            "         file.path, file.type as file_type"
+            "  from apps, file"
+            "  where apps.bundle_name='Xcode' and"
+            "        file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%')"
+            ") join hash using (path) where file_type = 'regular';"
+        )
+        self.assertEqual(extract_tables(query), ["apps", "file", "hash"])
+
+    def test_pack_comma_join_with_hash(self):
+        query = (
+            "select h.md5, h.sha1, s.name, s.module_path from services s, hash h "
+            "where h.path = s.module_path and s.module_path like '%GeeSetup_x86%';"
+        )
+        self.assertEqual(extract_tables(query), ["hash", "services"])
+
+    # sqlglot wraps a function call in FROM in a table node with an empty name
+    def test_function_in_from_not_a_table(self):
+        self.assertEqual(extract_tables("select key from users, json_each(users.uid);"), ["users"])
+
+    def test_only_a_function_in_from(self):
+        self.assertEqual(extract_tables("select * from json_each('[1, 2]');"), [])
+
+    def test_invalid_sql(self):
+        with self.assertRaises(SQLParseError) as cm:
+            extract_tables("changed sql line;")
+        self.assertEqual(cm.exception.line, 1)
+        self.assertEqual(cm.exception.col, 16)
+        self.assertEqual(str(cm.exception), "Could not parse the SQL query at line 1, column 16.")
+
+    # sqlglot raises without a position when it parses nothing at all
+    def test_empty_sql(self):
+        with self.assertRaises(SQLParseError) as cm:
+            extract_tables("")
+        self.assertIsNone(cm.exception.line)
+        self.assertIsNone(cm.exception.col)
+        self.assertEqual(str(cm.exception), "Could not parse the SQL query.")
+
+    # a tokenizer error is not a parse error, and it carries no position
+    def test_unterminated_string(self):
+        with self.assertRaises(SQLParseError) as cm:
+            extract_tables("select * from users where name = 'zen")
+        self.assertIsNone(cm.exception.line)
+        self.assertEqual(str(cm.exception), "Could not parse the SQL query.")
+
+    # sqlglot repeats the offending SQL with ANSI escapes on the lines after its own message
+    def test_error_message_is_a_single_clean_line(self):
+        with self.assertRaises(SQLParseError) as cm:
+            extract_tables("not sql at all")
+        message = str(cm.exception)
+        self.assertEqual(message, "Could not parse the SQL query at line 1, column 14.")
+        self.assertNotIn("\n", message)
+        self.assertNotIn("\x1b", message)
+
+
+class ExtractTablesOrEmptyTestCase(SimpleTestCase):
+    def test_valid_sql(self):
+        self.assertEqual(extract_tables_or_empty("select * from users;"), ["users"])
+
+    def test_invalid_sql(self):
+        with self.assertLogs("zentral.utils.sql", level="DEBUG") as cm:
+            self.assertEqual(extract_tables_or_empty("changed sql line;"), [])
+        self.assertEqual(
+            cm.output,
+            ["DEBUG:zentral.utils.sql:Could not extract the tables of a SQL query. "
+             "Could not parse the SQL query at line 1, column 16."]
+        )
+
+    # the run list re-derives the tables of every row it renders. an ERROR for each row of SQL
+    # frozen before Zentral rejected the SQL it cannot parse would repeat on every page view.
+    def test_invalid_sql_not_logged_as_an_error(self):
+        with self.assertNoLogs("zentral.utils.sql", level="INFO"):
+            self.assertEqual(extract_tables_or_empty("changed sql line;"), [])
+
+
+class ValidateSQLTestCase(SimpleTestCase):
+    def test_valid_sql(self):
+        self.assertIsNone(validate_sql("select * from users;"))
+
+    def test_invalid_sql(self):
+        with self.assertRaises(ValidationError) as cm:
+            validate_sql("changed sql line;")
+        self.assertEqual(cm.exception.messages, ["Could not parse the SQL query at line 1, column 16."])
+
+    def test_invalid_sql_without_position(self):
+        with self.assertRaises(ValidationError) as cm:
+            validate_sql("select * from users where name = 'zen")
+        self.assertEqual(cm.exception.messages, ["Could not parse the SQL query."])

--- a/zentral/contrib/osquery/forms.py
+++ b/zentral/contrib/osquery/forms.py
@@ -7,6 +7,7 @@ from rest_framework.parsers import JSONParser
 from rest_framework_yaml.parsers import YAMLParser
 
 from zentral.core.events.base import AuditEvent
+from zentral.utils.sql import validate_sql
 from zentral.utils.time import naive_utcnow
 from zentral.utils.views import post_audit_event
 
@@ -134,11 +135,7 @@ class DistributedQueryForm(forms.ModelForm):
 
         # default values
         if self.query:
-            self.instance.query = self.query
-            self.instance.sql = self.query.sql
-            self.instance.query_version = self.query.version
-            self.instance.platforms = self.query.platforms
-            self.instance.minimum_osquery_version = self.query.minimum_osquery_version
+            self.instance.snapshot_query(self.query)
 
     def save(self, *args, **kwargs):
         if not self.instance.pk and self.cleaned_data.get("halt_current_runs"):
@@ -372,6 +369,8 @@ class QueryForm(forms.ModelForm):
 
     def clean_sql(self):
         sql = self.cleaned_data.get("sql")
+        if sql:
+            validate_sql(sql)
         if self.instance.pk:
             if sql and sql != self.instance.sql:
                 self.instance.version = F("version") + 1

--- a/zentral/contrib/osquery/models.py
+++ b/zentral/contrib/osquery/models.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from zentral.conf import settings
 from zentral.contrib.inventory.models import BaseEnrollment, Tag
-from zentral.utils.sql import tables_in_query, format_sql
+from zentral.utils.sql import extract_tables_or_empty, format_sql
 from zentral.utils.text import shard
 from zentral.utils.time import naive_utcnow
 from .specs import cli_only_flags
@@ -115,7 +115,7 @@ class Query(models.Model):
 
     @cached_property
     def tables(self):
-        return sorted(tables_in_query(self.sql))
+        return extract_tables_or_empty(self.sql)
 
     @property
     def type(self):
@@ -747,9 +747,12 @@ class DistributedQuery(models.Model):
     def get_sql_html(self):
         return format_sql(self.sql)
 
-    @cached_property
-    def tables(self):
-        return sorted(tables_in_query(self.sql))
+    def snapshot_query(self, query):
+        self.query = query
+        self.query_version = query.version
+        self.sql = query.sql
+        self.platforms = query.platforms
+        self.minimum_osquery_version = query.minimum_osquery_version
 
     def is_active(self):
         now = timezone.now()

--- a/zentral/contrib/osquery/serializers.py
+++ b/zentral/contrib/osquery/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
+from zentral.utils.sql import SQLParseError, extract_tables, validate_sql
 from .compliance_checks import sync_query_compliance_check
 from .models import (Configuration, Enrollment, Pack, Platform, Query, AutomaticTableConstruction, FileCategory,
                      ConfigurationPack, PackQuery)
@@ -146,6 +147,17 @@ class OsqueryPackSerializer(serializers.Serializer):
     def validate_queries(self, value):
         if isinstance(value, dict) and "" in value:
             raise serializers.ValidationError("Query name cannot be empty")
+        # a pack is imported as a unit, so all the queries are reported in one pass. the messages
+        # must name the queries, because the operator has to find them in a file that can carry
+        # hundreds of them.
+        errors = []
+        for query_name, query_data in value.items():
+            try:
+                extract_tables(query_data["query"])
+            except SQLParseError as e:
+                errors.append(f"Query {query_name}: {e}")
+        if errors:
+            raise serializers.ValidationError(errors)
         return value
 
     def get_pack_defaults(self, slug):
@@ -205,6 +217,8 @@ class QuerySerializer(serializers.ModelSerializer):
     class Meta:
         model = Query
         exclude = ("compliance_check",)
+        # the model field carries no validator, so that it needs no migration
+        extra_kwargs = {"sql": {"validators": [validate_sql]}}
 
     def validate(self, data):
         compliance_check_enabled = data.get("compliance_check_enabled")

--- a/zentral/contrib/osquery/templates/osquery/query_detail.html
+++ b/zentral/contrib/osquery/templates/osquery/query_detail.html
@@ -56,6 +56,10 @@
             <td>{{ object.get_sql_html|safe }}</td>
         </tr>
         <tr>
+            <td>Table{{ object.tables|length|pluralize }}</td>
+            <td>{% for table in object.tables %}<code>{{ table }}</code> {% empty %}-{% endfor %}</td>
+        </tr>
+        <tr>
             <td>Platform{{ object.platforms|length|pluralize }}</td>
             <td>{{ object.platforms|join:", "|default:"-" }}</td>
         </tr>

--- a/zentral/contrib/osquery/views/distributed_queries.py
+++ b/zentral/contrib/osquery/views/distributed_queries.py
@@ -7,8 +7,8 @@ from django.db import connection
 from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
-from zentral.utils.sql import tables_in_query
 from django.views.generic import DetailView, TemplateView
+from zentral.utils.sql import extract_tables_or_empty
 from zentral.contrib.osquery.forms import DistributedQueryForm, DistributedQueryMachineSearchForm
 from zentral.contrib.osquery.models import (DistributedQuery, DistributedQueryMachine, DistributedQueryResult,
                                             FileCarvingSession, Query)
@@ -44,7 +44,7 @@ class DistributedQueryListView(PermissionRequiredMixin, UserPaginationMixin, Tem
             columns = [col.name for col in c.description]
             for row in c.fetchall():
                 dq = dict(zip(columns, row))
-                dq["tables"] = sorted(tables_in_query(dq["sql"]))
+                dq["tables"] = extract_tables_or_empty(dq["sql"])
                 yield dq
 
     def get_context_data(self, **kwargs):

--- a/zentral/utils/sql.py
+++ b/zentral/utils/sql.py
@@ -1,11 +1,26 @@
 import logging
-import re
 
+from django.core.exceptions import ValidationError
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import SqlLexer
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import SqlglotError
 
 logger = logging.getLogger("zentral.utils.sql")
+
+
+class SQLParseError(Exception):
+    # only the position of the error is kept. the sqlglot descriptions are internal prose that
+    # changes between releases, and they tell a user no more than the position does.
+    def __init__(self, line=None, col=None):
+        self.line = line
+        self.col = col
+        if line is None:
+            super().__init__("Could not parse the SQL query.")
+        else:
+            super().__init__(f"Could not parse the SQL query at line {line}, column {col}.")
 
 
 # SQL → HTML
@@ -19,31 +34,34 @@ def format_sql(query):
     return highlight(query, sql_lexer, html_formatter)
 
 
-# See https://grisha.org/blog/2016/11/14/table-names-from-sql/
-def tables_in_query(sql_str):
+# SQL → table names
 
-    # remove the /* */ comments
-    q = re.sub(r"/\*[^*]*\*+(?:[^*/][^*]*\*+)*/", "", sql_str)
+def extract_tables(sql):
+    # osquery runs SQLite
+    try:
+        tree = sqlglot.parse_one(sql, read="sqlite")
+    except SqlglotError as e:
+        # a parse error carries the position of the bad token, a tokenizer error carries none
+        errors = getattr(e, "errors", None) or [{}]
+        raise SQLParseError(errors[0].get("line"), errors[0].get("col")) from e
+    # a CTE is defined by the query itself, it is not a table the query reads
+    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    # sqlglot wraps a function call in FROM, json_each() for example, in a table with no name
+    return sorted({table.name.lower() for table in tree.find_all(exp.Table) if table.name} - cte_names)
 
-    # remove whole line -- and # comments
-    lines = [line for line in q.splitlines() if not re.match(r"^\s*(--|#)", line)]
 
-    # remove trailing -- and # comments
-    q = " ".join([re.split(r"--|#", line)[0] for line in lines])
+def extract_tables_or_empty(sql):
+    try:
+        return extract_tables(sql)
+    except SQLParseError as e:
+        # the run list re-derives the tables of every row it renders, and it renders rows with
+        # SQL that was frozen before Zentral rejected the SQL it cannot parse
+        logger.debug("Could not extract the tables of a SQL query. %s", e)
+        return []
 
-    # split on blanks, parens and semicolons
-    tokens = re.split(r"[\s)(;]+", q)
 
-    # scan the tokens. if we see a FROM or JOIN, we set the get_next
-    # flag, and grab the next one (unless it's SELECT).
-
-    result = set()
-    get_next = False
-    for tok in tokens:
-        if get_next:
-            if tok.lower() not in ["", "select"]:
-                result.add(tok)
-            get_next = False
-        get_next = tok.lower() in ["from", "join"]
-
-    return result
+def validate_sql(value):
+    try:
+        extract_tables(value)
+    except SQLParseError as e:
+        raise ValidationError(str(e))


### PR DESCRIPTION
## Summary

Zentral finds the osquery tables that a query reads. It parses the SQL with [sqlglot](https://github.com/tobymao/sqlglot) in the sqlite dialect, computes the tables where it shows them — the query page, the query list and the run list — and stores nothing.

Zentral also refuses a query with SQL that sqlglot cannot parse. That is a backward incompatibility, described below.

## What it replaces

`zentral/utils/sql.py::tables_in_query()` was a regular expression that took the token after `FROM` or `JOIN`. It:

* lost every table after the first one of a comma separated list (`FROM file, hash` gave `["file,"]`),
* kept the punctuation of the name, so the first one of that list was wrong too,
* kept the case of the name (`FROM CARVES` gave `["CARVES"]`),
* gave the name of a common table expression as a table (`WITH c AS (SELECT * FROM users)` gave `["c", "users"]`).

It read the tables of a sub query correctly, in `FROM`, in `WHERE` and nested: it scanned every `FROM` and `JOIN` token wherever one appeared.

Measured on the 306 queries of the official osquery packs, with sqlglot 30.17.0, 5 queries lost a table and a 6th kept a comma in a name:

| pack | query | regular expression | SQL parser |
| --- | --- | --- | --- |
| `incident-response` | `logged_in_users` | `["logged_in_users"]` | `["logged_in_users", "processes"]` |
| `it-compliance` | `osquery_info` | `["time,"]` | `["osquery_info", "time"]` |
| `osquery-monitoring` | `osquery_info` | `["osquery_info"]` | `["osquery_info", "processes", "time"]` |
| `osx-attacks` | `XcodeGhost` | `["apps,", "hash"]` | `["apps", "file", "hash"]` |
| `windows-attacks` | `CCleaner_Trojan_stage2.Floxif` | `["services"]` | `["hash", "services"]` |
| `osx-attacks` | `OceanLotus_dropped_file_1` | `["file,"]` | `["file"]` |

The five queries that lost a table are test cases in `tests/utils/test_sql.py`. The sixth differs only by the comma in the name, which every comma join test covers. Each of the six is a comma join: `XcodeGhost` also has a sub query, but it lost `file` to the comma in `FROM apps, file`.

The corpus check itself is not in the suite: it needs the osquery repository, which this repository does not vendor. The queries that showed a difference are in the tests instead, with the structural cases: comma joins, CTEs, `UNION ALL`, sub queries in `FROM`, aliases, keyword table names and case folding.

A function call in `FROM`, `json_each()` for example, is not a table. sqlglot wraps it in a table node with an empty name, so `extract_tables()` drops the empty names. Over 28 SQL constructs that is the only result that differs from the expected one, and it changes none of the 306 pack queries.

## Backward incompatibility

**Zentral refuses a query with SQL that sqlglot cannot parse.** The console gives an error for the `sql` field, the API answers `400` with an error for the `sql` attribute, and a standard pack import fails and names the queries that do not parse.

The measured base rate is 0 out of the 306 queries of the official osquery packs — keyword named tables (`time`, `groups`, `file`, `hash`, `users`), comma joins, virtual table constraints and lower case keywords all parse. But SQL that osquery accepts and sqlglot does not is refused, and that risk is not zero.

An existing query keeps its SQL. The rejection is on the write path only, so a query that Zentral cannot parse still runs, and shows an empty list of tables until somebody edits it.

## Decisions taken

**The tables are computed and not stored.** A column would need a migration, and the migration cannot fill it for every row: a query with SQL that does not parse would keep an empty list, which is the value that means "reads no table". The parsing costs 0.073 ms per query against 0.003 ms for the regular expression, so a page of 50 rows spends 3.6 ms on it and not 0.1 ms.

**The validation is on the form and on the serializer, not on the model field.** A validator on `Query.sql` is a field change, and a field change needs a migration. `QueryForm.clean_sql()` and the `sql` entry of `QuerySerializer.Meta.extra_kwargs` carry it instead, and `makemigrations --check` reports no change.

**An error message keeps the position and not the sqlglot prose.** `SQLParseError` carries the line and the column of the bad token, and builds `Could not parse the SQL query at line 1, column 16.` A tokenizer error has no position, and gives `Could not parse the SQL query.` The sqlglot descriptions are internal prose that changes between releases, and they are either empty of meaning (`Invalid expression / Unexpected token`) or leak internals (`Required keyword: 'this' missing for <class 'sqlglot.expressions.query.Where'>`).

**A standard pack import fails as a unit.** It is validated in `OsqueryPackSerializer.validate_queries`, before any database write. One pass reports every query that does not parse, and each error names the query by its key in the pack file, because the operator has to find it in a file that can carry hundreds of them. Skipping the bad query and reporting it is worse: a partially imported pack is a half applied unit, and it combines badly with `delete_extra_queries=True`, which would silently delete an already scheduled pack query on a re-import. Both entry points are covered: `PUT /api/osquery/packs/<slug>/` and the console upload. The errors are flat strings on `queries`, because `UploadPackForm.clean` flattens `serializer.errors` with `", ".join(v)` — a nested per query dict would render as joined dict keys.

**`extract_tables_or_empty()` logs at `DEBUG`.** The run list re-derives the tables of every row it renders, from SQL that runs froze before Zentral refused the SQL it cannot parse. At `ERROR` those rows fill the log on every page view.

**`DistributedQuery.tables` is removed.** `DistributedQueryListView` builds its rows from a raw query and sets the tables on the dictionaries it yields, so no template read that property.

`DistributedQuery.snapshot_query()` is new: it gathers the five attributes a run copies from a query, which `DistributedQueryForm.clean` set inline. The planned runs endpoint can call it.

## Tests

`tests.osquery` and `tests.utils`: 766 tests, all passing. 100% patch coverage on every added line, verified by intersecting `coverage json` `missing_lines` with the `git diff -U0 origin/main` hunks. `zentral/utils/sql.py` is at 100%.

`tests/osquery/test_api_views.py::test_update_query_increment_version` used `"changed sql line;"` as SQL, which does not parse. The test uses a real query.

`mkdocs build --strict` is clean.
