### PR TITLE
Bump snowflake-connector-python to 4.7.1 (CVE-2026-15925)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Zentral is a Django application for managing Apple devices. It orchestrates Appl
 
 ## Stack
 
-- **Python 3.10** / **Django** (settings: [server/server/settings.py](server/server/settings.py))
+- **Python 3.14** / **Django** (settings: [server/server/settings.py](server/server/settings.py))
 - **PostgreSQL** for the primary database
 - **Celery** for background tasks (app: [server/server/celery.py](server/server/celery.py))
 - **Message broker / event queue**: RabbitMQ is the dev default so everything fits in a single docker compose setup; production uses **AWS SQS** when available, otherwise **GCP Pub/Sub**

--- a/requirements_constraints.txt
+++ b/requirements_constraints.txt
@@ -141,7 +141,7 @@ rsa==4.9.1
 s3transfer==0.17.0
 six==1.17.0
 sniffio==1.3.1
-snowflake-connector-python==4.5.0
+snowflake-connector-python==4.7.1
 sortedcontainers==2.4.0
 stack-data==0.6.3
 std-uritemplate==2.0.8


### PR DESCRIPTION
## Why

`snowflake-connector-python` 4.5.0 is affected by [GHSA-5cc2-282f-jjq2](https://github.com/advisories/GHSA-5cc2-282f-jjq2) / CVE-2026-15925, a critical advisory (CVSS 9.2).

Versions `>= 4.0.0, < 4.7.1` do not verify the TLS hostname. The connector accepts a certificate signed by any trusted CA, for any domain. An attacker on the network path can intercept the connection to the warehouse. The attacker can then read credentials and query results, or send arbitrary SQL in the session.

This advisory is reachable. It applies to each deployment that configures the Snowflake event store backend. All of the connections of that backend go through the affected code path.

## What changed

One pin in `requirements_constraints.txt`: 4.5.0 to 4.7.1.

The second commit corrects the Python version in `CLAUDE.md`. It said 3.10, but the Dockerfile has built on `python:3.14` for a while. The Dockerfile is the only place that pins an interpreter version.

## Checks

4.7.1 is a minor release, not a patch release. These points were verified:

- **The runtime dependency set does not change.** The only differences in the metadata are in the `development` and `pandas` extras. This project requests neither, so no other pin moves.
- **`requires_python` goes from `>=3.9` to `>=3.10`.** The 3.14 images satisfy this.
- **cp314 manylinux wheels are available** for x86_64 and aarch64. The Docker build gets a binary wheel for this C-extension package. The image builds, and the connector reports 4.7.1.
- **The fix is in the installed code.** A diff of `ssl_wrap_socket.py` between the two versions shows that 4.7.1 adds a `_verify_hostname_after_handshake()` call after `ssl_wrap_socket()`. It matches the peer certificate against the server hostname, and it fails closed when there is no hostname.

## Tests

`tests.core_stores` passes: 302 tests, of which 23 are in `tests/core_stores/test_snowflake.py`.

Note the limit of these tests. Each one patches `snowflake.connector.connect`, so no test opens a socket. They show that the `SnowflakeStore` wrapper still works. They do not exercise the TLS path of the advisory. A green run is not evidence that the vulnerability is corrected.

The risk stays low, because the store uses a small and stable part of the connector API: `connect(**kwargs)`, `DictCursor`, `execute`, `fetchall`/`fetchone` and `close`. The evidence for the fix is the diff of the shipped source above.

## Related

`pyarrow` is pinned at `24.0.0`. 4.7.1 declares `pyarrow<24` on Python 3.14, but only for the `pandas` extra. pip does not evaluate that requirement, because this project does not request the extra. If someone adds `snowflake-connector-python[pandas]` later, this becomes a true conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
