### PR TITLE
pbac: key the serialized entities on their namespaced type

### DIFF
--- a/server/pbac/cedar.py
+++ b/server/pbac/cedar.py
@@ -79,7 +79,7 @@ policies_cache = PoliciesCache(with_sync=zentral_policies_sync)
 
 
 def _serialize_entity(entity: Entity, collected_entities: dict) -> None:
-    key = (entity.type, entity.id)
+    key = (entity.full_type, entity.id)
     if key not in collected_entities:
         serialized_entity = {
             "uid": {"type": entity.full_type, "id": entity.id},

--- a/tests/server_accounts/test_pbac_cedar.py
+++ b/tests/server_accounts/test_pbac_cedar.py
@@ -4,9 +4,10 @@ from django.test import TestCase
 from django.utils.crypto import get_random_string
 
 from accounts.models import Policy, User
-from pbac.cedar import authorize_request, authorize_requests, PoliciesCache, policies_cache
+from pbac.cedar import (_serialize_requests_entities, authorize_request, authorize_requests,
+                        PoliciesCache, policies_cache)
 from pbac.engine import engine
-from pbac.entities import Principal, Request
+from pbac.entities import Action, Namespace, Principal, Request, Resource
 from .utils import force_policy
 
 
@@ -145,3 +146,56 @@ class HasLegacyPermTestCase(TestCase):
 
     def test_has_legacy_perm_unknown_perm_denies(self):
         self.assertFalse(engine.has_legacy_perm(self.user, "foo.bar_baz"))
+
+
+class SerializeRequestsEntitiesTestCase(TestCase):
+    """Cedar scopes entity types and action ids to their namespace, so the
+    entities of a batch are collected per namespaced type."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            get_random_string(12),
+            f"{get_random_string(12)}@zentral.com",
+            is_superuser=False,
+        )
+
+    def _serialize(self, requests):
+        entities = _serialize_requests_entities(requests)
+        uids = [(e["uid"]["type"], e["uid"]["id"]) for e in entities]
+        self.assertEqual(len(uids), len(set(uids)))
+        # a parent that is missing from the array is an entity without attributes
+        # and without parents of its own, and cedar reports no error for it
+        for entity in entities:
+            for parent in entity["parents"]:
+                self.assertIn((parent["type"], parent["id"]), uids)
+        return dict(zip(uids, entities))
+
+    def test_same_type_name_in_two_namespaces(self):
+        principal = Principal.from_user(self.user)
+        requests = []
+        for namespace_id in ("NsOne", "NsTwo"):
+            namespace = Namespace(namespace_id)
+            requests.append(Request(
+                principal,
+                Action("look", namespace),
+                Resource("Widget", "5", namespace, [Resource("Container", "7", namespace)]),
+            ))
+        entities = self._serialize(requests)
+        for namespace_id in ("NsOne", "NsTwo"):
+            self.assertIn((f"{namespace_id}::Action", "look"), entities)
+            self.assertEqual(
+                entities[(f"{namespace_id}::Widget", "5")]["parents"],
+                [{"type": f"{namespace_id}::Container", "id": "7"}],
+            )
+
+    def test_action_groups_of_two_namespaces(self):
+        principal = Principal.from_user(self.user)
+        entities = self._serialize([
+            Request(principal, engine.legacy_perm_actions[perm], engine.system_any_resource)
+            for perm in ("accounts.view_user", "inventory.add_machinetag")
+        ])
+        # every namespace registers its own action groups, under the same ids
+        self.assertIn(("Accounts::Action", "AdminActions"), entities)
+        self.assertIn(("Inventory::Action", "AdminActions"), entities)
+        self.assertIn(("Action", "GlobalAdminActions"), entities)


### PR DESCRIPTION
`_serialize_entity` collected the entities of a request batch in a dict, keyed on
`(entity.type, entity.id)`. `entity.type` is the bare type name.

Cedar gives a namespace to the entity types and to the action ids. I verified this
with cedarpy: a schema that declares `NsOne::Widget` and `NsTwo::Widget`, and one
that declares `NsOne::Action::"look"` and `NsTwo::Action::"look"`, are both valid.
Only a **global** action id that a namespaced one repeats is rejected, with an
"illegally shadows" error. This is the reason for the `Global…Actions` prefix in
`Engine.get_action_group`.

Two entities with the same bare type and the same ID thus share one key. The
second entity is discarded from the array, together with its parents. The
entities that point to it keep a parent that is not in the array.

`Inventory::Action::"AdminActions"` and `Monolith::Action::"AdminActions"` are an
example: each namespace registers its action groups under the same IDs.

## The effect on a decision

A resource that is discarded goes to cedar as an entity with no attributes and no
parents. Cedar gives no error for it. Thus:

* A `permit` policy scoped on one of its parents denies the request.
* A `forbid` policy scoped on one of its parents does not apply.

I made a batch of two requests, one for each namespace, with the resources
`NsOne::Widget::"5"` and `NsTwo::Widget::"5"`, both in a `Container::"7"`:

```
MISSING from the entities array: ['NsTwo::Widget::"5"']
```

`permit(… resource in NsTwo::Container::"7")` gave `False`, and
`forbid(… resource in NsTwo::Container::"7")` gave `True`. The two decisions are
incorrect.

## Reachability

This does not occur today. The two callers of `authorize_requests()` each batch
one namespace, and `authorize_request()` serializes one request. But the action
groups of every namespace already share their IDs, so one batch with two
namespaces is sufficient.

## The change

The key is `(entity.full_type, entity.id)` now.

`server/pbac/schema.py` has no equivalent problem: `build_schema_ir` puts the
entity types and the actions in a `NamespaceIR` for each namespace.

## Tests

A new `SerializeRequestsEntitiesTestCase` asserts two invariants for the output of
`_serialize_requests_entities`: the entity IDs are unique, and each parent of an
entity is in the array. Two tests use it:

* `test_same_type_name_in_two_namespaces` builds `pbac.entities` objects directly.
  It registers nothing in the engine, thus it cannot change the schema that the
  other tests read.
* `test_action_groups_of_two_namespaces` uses the registered
  `Accounts::Action::"viewUser"` and `Inventory::Action::"createMachineTag"`
  actions. It shows the parent that is not in the array.

Both tests fail before the change and pass after it.

There is no CHANGELOG entry: no behavior changes today.
