### PR TITLE
turbo: add commands, the third kind of job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,14 @@ Recurring and one-time job schedules on a job anchor, with a per-machine result 
 
 Management UI and API for the configurations, enrollments, scripts, mSCP checks and jobs, the agent protocol endpoints, the script and mSCP compliance checks, and the agent request and result events.
 
+New **commands**, the third kind of job: a command collects something from a machine instead of producing a verdict. Two kinds are available. `sysdiagnose` collects a `sysdiagnose` archive and takes no options. `file_export` collects the files that match a list of path patterns, plus a manifest of what it collected, and takes `patterns` and an uncompressed `max_size`.
+
+A command is created with the `/api/turbo/commands/` endpoint, and *Turbo > Commands* lists them. The kind cannot be changed after the command is created. A change to the options bumps the version of the job, and the agent runs the command again.
+
+A command runs one time only: the server refuses to attach one to a recurring job.
+
+The new `Turbo::Action::"scheduleCommand"` action carries the kind of the command and the machine, so a policy can permit one kind and refuse another. It is applied in addition to `turbo.add_onetimejob`, which does not distinguish the kinds. The upload of the collected files comes in a later release.
+
 
 ### Backward incompatibilities
 

--- a/docs/apps/turbo.md
+++ b/docs/apps/turbo.md
@@ -78,12 +78,13 @@ Enrolled machines are listed under *Turbo > Enrolled machines*, with the date th
 
 ## Jobs
 
-A **job** is what Turbo runs on a machine. There are two kinds:
+A **job** is what Turbo runs on a machine. There are three kinds:
 
  * a **script** – a zsh script, whose exit code is the outcome,
- * an **mSCP check** – an mSCP rule, whose check logic and baseline defaults are bundled in the agent.
+ * an **mSCP check** – an mSCP rule, whose check logic and baseline defaults are bundled in the agent,
+ * a **command** – something to collect from the machine, uploaded as one or more files.
 
-Creating a script or an mSCP check only *defines* the job. It does not run anywhere until it is scheduled in a configuration, as a [recurring job](#recurring-jobs) or a [one-time job](#one-time-jobs). The same definition can be scheduled in several configurations.
+Creating a script, an mSCP check or a command only *defines* the job. It does not run anywhere until it is scheduled in a configuration, as a [recurring job](#recurring-jobs) or a [one-time job](#one-time-jobs). The same definition can be scheduled in several configurations.
 
 ### Scripts
 
@@ -125,6 +126,67 @@ The rule identifier, the baseline and the ODV together form the identity of a ch
 An mSCP check *is* a compliance check – one is created with it, named after that identity, and there is no toggle. The check logic itself, and the baseline defaults, are bundled and signed in the agent, not stored in Zentral.
 
 An mSCP check cannot be deleted while it is scheduled in a configuration.
+
+### Commands
+
+A command collects something from a machine and uploads it. Unlike a script or an mSCP check, a command has no compliance role and produces no verdict — it produces one or more files.
+
+Commands are created with the [API](#apiturbocommands), not in the web console. *Turbo > Commands* lists them and shows what each one collects. This is the same shape as the event stores and the probe actions: the kind decides which options the command takes, and the API validates them.
+
+|Attribute|Description|
+|---|---|
+|`backend`|Which kind of command this is. It cannot be changed after the command is created.|
+|`name`|A unique name.|
+|`description`|Optional.|
+|`<backend>_kwargs`|The options for that kind. A kind with no options does not need this attribute.|
+
+Two kinds are available:
+
+|Kind|Collects|Options|
+|---|---|---|
+|`sysdiagnose`|A `sysdiagnose` archive.|None. The agent runs the tool unattended and uploads the archive it produces.|
+|`file_export`|The files that match a list of path patterns, plus a manifest of what was collected.|`patterns` and `max_size`, below.|
+
+The `file_export` options:
+
+|Option|Description|
+|---|---|
+|`patterns`|1 to 32 absolute path patterns, for example `/var/log/install.log*`. Each one is at most 1024 characters, must start with a `/`, and must not contain a `..` segment or a `**`. See the syntax below.|
+|`max_size`|The maximum **uncompressed** total, in bytes. 104857600 (100 MB) by default, 524288000 (500 MB) at most. File sizes are known before anything is written, so the agent decides what to include first, in a stable path order, and reports what it skipped.|
+
+The agent matches the patterns with `fnmatch`, which macOS provides. The syntax is the shell glob syntax, with one important limit:
+
+|Pattern|Matches|
+|---|---|
+|`*`|Any sequence of characters, up to the next `/`. `/var/log/*` matches `/var/log/install.log`, and does not match `/var/log/sub/deep.log`.|
+|`?`|Any single character.|
+|`[abc]`|One character of the set.|
+
+**There is no recursive wildcard.** `fnmatch` reads `**` as a single `*`, so `/Library/Logs/**/*.log` would match `/Library/Logs/a/b.log` and not `/Library/Logs/a/b/c.log` — one level, not every level. Zentral refuses a pattern that contains `**`, because a pattern written for recursion would otherwise collect one level and give no error. Name each level you want instead:
+
+```
+/Library/Logs/Foo/*.log
+/Library/Logs/Foo/*/*.log
+/Library/Logs/Foo/*/*/*.log
+```
+
+A `file_export` run produces two files: a manifest, which lists what was matched, collected, skipped and unreadable, and an archive of the collected files. The manifest is a separate file so an operator can read what a run collected without downloading the archive. A run that matched nothing uploads the manifest and no archive.
+
+**A command runs one time only.** It cannot be attached to a recurring job — collecting the same files every hour is a log shipper, not a job. Schedule it with a one-time job, or with the *Schedule one-time job* action on a machine page.
+
+Every command carries the *changing the version re-runs the job* behaviour of the other kinds: editing the options bumps the version, and the agent runs the command again. Renaming it does not.
+
+A command cannot be deleted while it is scheduled in a configuration.
+
+Collecting a `sysdiagnose` archive, and even more so collecting arbitrary files, reads user data. Both `turbo.add_onetimejob` and the *Schedule one-time job* action apply to every kind equally, so use a [policy](../configuration/pbac.md) to say which kinds a role may collect, and from which machines. The `Turbo::Action::"scheduleCommand"` action carries the kind and the machine, so a policy can permit a `sysdiagnose` and refuse a `file_export`:
+
+```
+permit (
+  principal in Role::"<role id>",
+  action == Turbo::Action::"scheduleCommand",
+  resource
+) when { context.backend == "sysdiagnose" };
+```
 
 ### Recurring jobs
 
@@ -744,6 +806,158 @@ curl \
   -H "Authorization: Token $ZTL_API_TOKEN" \
   -o zentral_turbo_configuration.mobileconfig \
   https://$ZTL_FQDN/api/turbo/enrollments/1/configuration_profile/
+```
+
+### /api/turbo/commands/
+
+#### List all commands
+
+* method: GET
+* PBAC action: `Turbo::Action::"viewCommand"`
+* Optional filter parameters:
+    * `name`: name of the command
+    * `backend`: `sysdiagnose` or `file_export`
+    * `configuration`: primary key of a Turbo configuration – the commands scheduled in it
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/turbo/commands/ \
+  |python3 -m json.tool
+```
+
+Response:
+
+```json
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": "c2f4a6b8-1d3e-4f50-9a7b-8c5d2e1f0a3b",
+            "backend": "file_export",
+            "name": "Install logs",
+            "description": "The installer logs and Munki's",
+            "sysdiagnose_kwargs": null,
+            "file_export_kwargs": {
+                "patterns": [
+                    "/var/log/install.log*",
+                    "/Library/Logs/Munki/*.log"
+                ],
+                "max_size": 104857600
+            },
+            "version": 1,
+            "job_id": "8b1c9d7e-2a45-4c68-b9f0-3e6a7d4c5b21",
+            "created_at": "2026-09-02T14:02:11.884213",
+            "updated_at": "2026-09-02T14:02:11.884901"
+        }
+    ]
+}
+```
+
+Only the options of the command's own kind are set – the other `<backend>_kwargs` attributes are `null`. `job_id` is the primary key of the job the command anchors – it is what a one-time job schedules. `version` and `job_id` are read-only.
+
+#### Add a command
+
+* method: POST
+* Content-Type: application/json
+* PBAC action: `Turbo::Action::"createCommand"`
+
+`backend` is required. The matching `<backend>_kwargs` attribute is required for a kind that takes options, and is not needed for a kind that takes none.
+
+Example:
+
+command.json
+
+```json
+{
+  "backend": "file_export",
+  "name": "Install logs",
+  "description": "The installer logs and Munki's",
+  "file_export_kwargs": {
+    "patterns": ["/var/log/install.log*", "/Library/Logs/Munki/*.log"]
+  }
+}
+```
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @command.json \
+  https://$ZTL_FQDN/api/turbo/commands/ \
+  |python3 -m json.tool
+```
+
+A `sysdiagnose` command takes no options:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"backend": "sysdiagnose", "name": "Support archive"}' \
+  https://$ZTL_FQDN/api/turbo/commands/ \
+  |python3 -m json.tool
+```
+
+### /api/turbo/commands/`<uuid:pk>`/
+
+#### Get a command
+
+* method: GET
+* PBAC action: `Turbo::Action::"viewCommand"`
+* `<uuid:pk>`: the primary key of the command
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  https://$ZTL_FQDN/api/turbo/commands/c2f4a6b8-1d3e-4f50-9a7b-8c5d2e1f0a3b/ \
+  |python3 -m json.tool
+```
+
+#### Update a command
+
+* method: PUT
+* Content-Type: application/json
+* PBAC action: `Turbo::Action::"updateCommand"`
+* `<uuid:pk>`: the primary key of the command
+
+`backend` cannot be changed. The kind is half the identity of the command on the wire, so a different kind is a different command.
+
+Changing the options bumps `version`, and the agent runs the command again on the machines where it is scheduled. Changing only the name or the description does not.
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X PUT \
+  -d @command.json \
+  https://$ZTL_FQDN/api/turbo/commands/c2f4a6b8-1d3e-4f50-9a7b-8c5d2e1f0a3b/ \
+  |python3 -m json.tool
+```
+
+#### Delete a command
+
+* method: DELETE
+* PBAC action: `Turbo::Action::"deleteCommand"`
+* `<uuid:pk>`: the primary key of the command
+
+A command that is scheduled in a configuration cannot be deleted.
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: Token $ZTL_API_TOKEN" \
+  -X DELETE \
+  https://$ZTL_FQDN/api/turbo/commands/c2f4a6b8-1d3e-4f50-9a7b-8c5d2e1f0a3b/
 ```
 
 ### /api/turbo/scripts/
@@ -1579,7 +1793,7 @@ Each entry in `jobs` carries:
 
 |Attribute|Description|
 |---|---|
-|`kind`|`script` or `mscp_check`.|
+|`kind`|`script`, `mscp_check`, or a command kind (`sysdiagnose`, `file_export`).|
 |`pk`|The primary key of the job – the identity of the definition.|
 |`version`|The current version of the definition.|
 |`schedule.mode`|`recurring` or `one_time`.|

--- a/tests/server_accounts/test_pbac_engine.py
+++ b/tests/server_accounts/test_pbac_engine.py
@@ -494,6 +494,7 @@ class PBACEngineTestCase(TestCase):
                 "terraform.change_state",
                 "terraform.delete_state",
                 "terraform.view_state",
+                "turbo.add_command",
                 "turbo.add_configuration",
                 "turbo.add_enrolledmachine",
                 "turbo.add_enrollment",
@@ -501,6 +502,7 @@ class PBACEngineTestCase(TestCase):
                 "turbo.add_onetimejob",
                 "turbo.add_recurringjob",
                 "turbo.add_script",
+                "turbo.change_command",
                 "turbo.change_configuration",
                 "turbo.change_enrolledmachine",
                 "turbo.change_enrollment",
@@ -508,6 +510,7 @@ class PBACEngineTestCase(TestCase):
                 "turbo.change_onetimejob",
                 "turbo.change_recurringjob",
                 "turbo.change_script",
+                "turbo.delete_command",
                 "turbo.delete_configuration",
                 "turbo.delete_enrolledmachine",
                 "turbo.delete_enrollment",
@@ -515,6 +518,7 @@ class PBACEngineTestCase(TestCase):
                 "turbo.delete_onetimejob",
                 "turbo.delete_recurringjob",
                 "turbo.delete_script",
+                "turbo.view_command",
                 "turbo.view_configuration",
                 "turbo.view_enrolledmachine",
                 "turbo.view_enrollment",
@@ -542,6 +546,7 @@ class PBACEngineTestCase(TestCase):
             ("viewRecoveryPassword", "MDM"),
             ("syncRepository", "Monolith"),
             ("forceCleanSync", "Santa"),
+            ("scheduleCommand", "Turbo"),
         )
         found_user_only_actions = 0
         global_user_action_group = engine.get_action_group(ActionGroupBasename.USER)

--- a/tests/turbo/test_api_commands.py
+++ b/tests/turbo/test_api_commands.py
@@ -1,0 +1,187 @@
+from unittest.mock import patch
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+from zentral.contrib.turbo.command_backends import CommandBackend
+from zentral.contrib.turbo.command_backends.file_export import DEFAULT_MAX_SIZE
+from zentral.contrib.turbo.models import Command, Job
+from .utils import TurboAPITestCase, force_command, force_configuration, force_one_time_job
+
+
+class TurboCommandAPITestCase(TurboAPITestCase):
+    # create
+
+    def test_create_sysdiagnose_without_kwargs(self):
+        # a zero-config kind has no options to send, so an absent kwargs block is its normal case
+        self.set_permissions("turbo.add_command")
+        name = get_random_string(12)
+        response = self.post(reverse("turbo_api:commands"), {"backend": "sysdiagnose", "name": name})
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["version"], 1)
+        command = Command.objects.get(pk=data["id"])
+        self.assertEqual(command.backend, "sysdiagnose")
+        # the Job is minted with kind == backend: the two are one wire identity
+        self.assertEqual(command.job.kind, "sysdiagnose")
+        self.assertEqual(data["job_id"], str(command.job_id))
+        self.assertEqual(command.get_backend_kwargs(), {})
+
+    def test_create_file_export(self):
+        self.set_permissions("turbo.add_command")
+        response = self.post(reverse("turbo_api:commands"),
+                             {"backend": "file_export", "name": get_random_string(12),
+                              "file_export_kwargs": {"patterns": ["/var/log/install.log*"]}})
+        self.assertEqual(response.status_code, 201)
+        command = Command.objects.get(pk=response.json()["id"])
+        self.assertEqual(command.job.kind, "file_export")
+        self.assertEqual(command.get_backend_kwargs(),
+                         {"patterns": ["/var/log/install.log*"], "max_size": DEFAULT_MAX_SIZE})
+
+    def test_create_file_export_without_kwargs(self):
+        self.set_permissions("turbo.add_command")
+        response = self.post(reverse("turbo_api:commands"),
+                             {"backend": "file_export", "name": get_random_string(12)})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"file_export_kwargs": ["This field is required."]})
+
+    def test_create_command_ignores_another_backends_kwargs(self):
+        # a client that sends the wrong block gets the command it asked for, with that block dropped —
+        # the backend decides which kwargs are its own
+        self.set_permissions("turbo.add_command")
+        response = self.post(reverse("turbo_api:commands"),
+                             {"backend": "sysdiagnose", "name": get_random_string(12),
+                              "file_export_kwargs": {"patterns": ["/tmp/a.log"]}})
+        self.assertEqual(response.status_code, 201)
+        command = Command.objects.get(pk=response.json()["id"])
+        self.assertEqual(command.backend, "sysdiagnose")
+        self.assertEqual(command.get_backend_kwargs(), {})
+
+    def test_create_file_export_relative_pattern(self):
+        self.set_permissions("turbo.add_command")
+        response = self.post(reverse("turbo_api:commands"),
+                             {"backend": "file_export", "name": get_random_string(12),
+                              "file_export_kwargs": {"patterns": ["var/log/install.log"]}})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(),
+                         {"file_export_kwargs": {"patterns": {"0": ["Must be an absolute path"]}}})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_create_command_audit_event(self, post_event):
+        self.set_permissions("turbo.add_command")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.post(reverse("turbo_api:commands"),
+                                 {"backend": "sysdiagnose", "name": get_random_string(12)})
+        self.assertEqual(response.status_code, 201)
+        command = Command.objects.get(pk=response.json()["id"])
+        audit_events = self._audit_events(post_event)
+        self.assertEqual(len(audit_events), 1)
+        payload_object = audit_events[0].payload["object"]
+        self.assertEqual(payload_object["model"], "turbo.command")
+        # the backend rides the audit event for free — per-kind authorization is written against it
+        self.assertEqual(payload_object["new_value"]["backend"], "sysdiagnose")
+        self.assertEqual(audit_events[0].metadata.serialize()["objects"],
+                         {"turbo_command": [str(command.pk)]})
+
+    # read
+
+    def test_list_commands(self):
+        command = force_command()
+        self.set_permissions("turbo.view_command")
+        response = self.get(reverse("turbo_api:commands"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["results"][0]["id"], str(command.pk))
+
+    def test_list_commands_backend_filter(self):
+        force_command(backend=CommandBackend.SYSDIAGNOSE)
+        file_export = force_command(backend=CommandBackend.FILE_EXPORT)
+        self.set_permissions("turbo.view_command")
+        response = self.get(reverse("turbo_api:commands") + "?backend=file_export")
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        self.assertEqual([r["id"] for r in results], [str(file_export.pk)])
+
+    def test_list_commands_configuration_filter(self):
+        configuration = force_configuration()
+        scheduled = force_command()
+        force_one_time_job(configuration=configuration, job=scheduled.job)
+        force_command()
+        self.set_permissions("turbo.view_command")
+        response = self.get(reverse("turbo_api:commands") + f"?configuration={configuration.pk}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([r["id"] for r in response.json()["results"]], [str(scheduled.pk)])
+
+    def test_get_command_unauthorized(self):
+        command = force_command()
+        response = self.get(reverse("turbo_api:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_file_export_command(self):
+        command = force_command(backend=CommandBackend.FILE_EXPORT,
+                                backend_kwargs={"patterns": ["/tmp/a.log"], "max_size": 1024})
+        self.set_permissions("turbo.view_command")
+        response = self.get(reverse("turbo_api:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["file_export_kwargs"], {"patterns": ["/tmp/a.log"], "max_size": 1024})
+        self.assertIsNone(data["sysdiagnose_kwargs"])
+
+    # update
+
+    def test_update_command_kwargs_bumps_the_version(self):
+        # the version lives on the Job and drives a re-run, so it moves when what the agent would do
+        # moves
+        command = force_command(backend=CommandBackend.FILE_EXPORT,
+                                backend_kwargs={"patterns": ["/tmp/a.log"], "max_size": 1024})
+        self.set_permissions("turbo.change_command")
+        response = self.put(reverse("turbo_api:command", args=(command.pk,)),
+                            {"backend": "file_export", "name": command.name,
+                             "file_export_kwargs": {"patterns": ["/tmp/b.log"], "max_size": 1024}})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 2)
+        command.refresh_from_db()
+        self.assertEqual(command.get_backend_kwargs()["patterns"], ["/tmp/b.log"])
+
+    def test_update_command_name_only_keeps_the_version(self):
+        # a rename changes nothing the agent would do, so it must not force a re-run
+        command = force_command(backend=CommandBackend.FILE_EXPORT,
+                                backend_kwargs={"patterns": ["/tmp/a.log"], "max_size": 1024})
+        self.set_permissions("turbo.change_command")
+        response = self.put(reverse("turbo_api:command", args=(command.pk,)),
+                            {"backend": "file_export", "name": get_random_string(12),
+                             "file_export_kwargs": {"patterns": ["/tmp/a.log"], "max_size": 1024}})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["version"], 1)
+
+    def test_update_command_backend_immutable(self):
+        # the backend is the kind, and the kind is half the wire identity: changing it would change what
+        # the agent runs under a stable pk and version
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        self.set_permissions("turbo.change_command")
+        response = self.put(reverse("turbo_api:command", args=(command.pk,)),
+                            {"backend": "file_export", "name": command.name,
+                             "file_export_kwargs": {"patterns": ["/tmp/a.log"]}})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"backend": ["This field cannot be changed"]})
+        command.refresh_from_db()
+        self.assertEqual(command.backend, "sysdiagnose")
+        self.assertEqual(command.job.kind, "sysdiagnose")
+
+    # delete
+
+    def test_delete_command(self):
+        command = force_command()
+        job_pk = command.job_id
+        self.set_permissions("turbo.delete_command")
+        response = self.delete(reverse("turbo_api:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Command.objects.filter(pk=command.pk).exists())
+        # the Job goes with it, like a Script's
+        self.assertFalse(Job.objects.filter(pk=job_pk).exists())
+
+    def test_delete_scheduled_command(self):
+        command = force_command()
+        force_one_time_job(job=command.job)
+        self.set_permissions("turbo.delete_command")
+        response = self.delete(reverse("turbo_api:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), ["This command cannot be deleted"])
+        self.assertTrue(Command.objects.filter(pk=command.pk).exists())

--- a/tests/turbo/test_api_recurring_jobs.py
+++ b/tests/turbo/test_api_recurring_jobs.py
@@ -5,7 +5,8 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import Tag
 from zentral.contrib.turbo.models import RecurringJob
-from .utils import TurboAPITestCase, force_configuration, force_recurring_job, force_script
+from .utils import (TurboAPITestCase, force_command, force_configuration, force_recurring_job,
+                    force_script)
 
 
 class TurboRecurringJobAPITestCase(TurboAPITestCase):
@@ -23,6 +24,20 @@ class TurboRecurringJobAPITestCase(TurboAPITestCase):
         response = self.post(reverse("turbo_api:recurring_jobs"),
                              {"configuration": str(configuration.pk), "job": str(script.job.pk)})
         self.assertEqual(response.status_code, 403)
+
+    def test_create_recurring_command_rejected(self):
+        # a command kind declares itself one-time only: a recurring collection is a log shipper, not a
+        # job. The GUI narrows its choices instead; the API has to say so.
+        configuration = force_configuration()
+        command = force_command()
+        self.set_permissions("turbo.add_recurringjob")
+        response = self.post(reverse("turbo_api:recurring_jobs"),
+                             {"configuration": str(configuration.pk), "job": str(command.job.pk),
+                              "interval": 3600})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(),
+                         {"job": ["A sysdiagnose job cannot be scheduled to run repeatedly"]})
+        self.assertFalse(RecurringJob.objects.filter(job=command.job).exists())
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_recurring_job(self, post_event):

--- a/tests/turbo/test_command_backends.py
+++ b/tests/turbo/test_command_backends.py
@@ -1,0 +1,174 @@
+from django.test import TestCase
+from rest_framework import serializers
+from zentral.contrib.turbo.command_backends import (CommandBackend, get_command_backend,
+                                                    get_command_backend_class)
+from zentral.contrib.turbo.command_backends.base import BaseCommand
+from zentral.contrib.turbo.command_backends.file_export import (DEFAULT_MAX_SIZE, MAX_MAX_SIZE,
+                                                                MAX_PATTERNS)
+from zentral.contrib.turbo.models import Job, ScheduleMode
+from .utils import force_command
+
+
+class TurboCommandBackendsTestCase(TestCase):
+    maxDiff = None
+
+    # the registry
+
+    def test_every_backend_resolves(self):
+        for backend in CommandBackend:
+            self.assertIs(get_command_backend_class(backend).kind, backend)
+
+    def test_unknown_backend(self):
+        # the raise is the one gate: a value added to CommandBackend but not mapped in the factory
+        # fails here rather than returning None
+        with self.assertRaises(ValueError) as cm:
+            get_command_backend_class("not_a_backend")
+        self.assertIn("not_a_backend", str(cm.exception))
+
+    def test_base_command_wire_payload_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            BaseCommand.wire_payload(None)
+
+    def test_every_backend_is_a_job_kind(self):
+        # Job.kind IS the wire kind and the backend value: a backend with no matching kind could be
+        # defined but never scheduled
+        for backend in CommandBackend:
+            self.assertIn(backend.value, Job.Kind.values)
+
+    # the declarations every backend owes
+
+    def test_every_backend_declares_allowed_modes(self):
+        for backend in CommandBackend:
+            self.assertTrue(get_command_backend_class(backend).allowed_modes,
+                            f"{backend} declares no allowed_modes, so it is schedulable nowhere")
+
+    def test_every_backend_declares_artifacts(self):
+        for backend in CommandBackend:
+            backend_class = get_command_backend_class(backend)
+            self.assertTrue(backend_class.artifacts,
+                            f"{backend} declares no artifacts, so a run produces nothing")
+            names = [artifact.name for artifact in backend_class.artifacts]
+            self.assertEqual(len(names), len(set(names)), f"{backend} declares a duplicate artifact name")
+
+    def test_every_artifact_is_reachable_by_name(self):
+        for backend in CommandBackend:
+            backend_class = get_command_backend_class(backend)
+            for artifact in backend_class.artifacts:
+                self.assertIs(backend_class.get_artifact(artifact.name), artifact)
+            self.assertIsNone(backend_class.get_artifact("not_an_artifact"))
+
+    def test_every_upload_capable_backend_is_one_time_only(self):
+        # a stable key per run is what lets a retry overwrite in place; a recurring upload kind would
+        # need a run identity the mint request does not carry yet, and would silently overwrite the
+        # previous run's artifact
+        for backend in CommandBackend:
+            backend_class = get_command_backend_class(backend)
+            if backend_class.requires_upload:
+                self.assertEqual(backend_class.allowed_modes, frozenset([ScheduleMode.ONE_TIME]))
+
+    # allowed schedule modes
+
+    def test_command_kinds_are_one_time_only(self):
+        for backend in CommandBackend:
+            self.assertEqual(Job.allowed_schedule_modes(backend.value), frozenset([ScheduleMode.ONE_TIME]))
+
+    def test_non_command_kinds_take_every_mode(self):
+        for kind in (Job.Kind.SCRIPT, Job.Kind.MSCP_CHECK):
+            self.assertEqual(Job.allowed_schedule_modes(kind), frozenset(ScheduleMode.values))
+
+    def test_kinds_for_schedule_mode(self):
+        self.assertEqual(sorted(Job.kinds_for_schedule_mode(ScheduleMode.RECURRING)),
+                         sorted([Job.Kind.SCRIPT.value, Job.Kind.MSCP_CHECK.value]))
+        self.assertEqual(sorted(Job.kinds_for_schedule_mode(ScheduleMode.ONE_TIME)),
+                         sorted(Job.Kind.values))
+
+    # sysdiagnose
+
+    def test_sysdiagnose_wire_payload_is_empty(self):
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        self.assertEqual(command.wire_payload(), {})
+
+    def test_sysdiagnose_one_artifact(self):
+        backend = get_command_backend(force_command(backend=CommandBackend.SYSDIAGNOSE))
+        artifact, = backend.artifacts
+        self.assertEqual(artifact.name, "archive")
+        self.assertEqual(artifact.extension, ".tar.gz")
+        self.assertFalse(artifact.optional)
+
+    def test_sysdiagnose_kwargs_serializer_has_no_fields(self):
+        # zero config is what makes the machine-page one-click flow possible, and what lets the API
+        # accept a create with no kwargs block
+        backend_class = get_command_backend_class(CommandBackend.SYSDIAGNOSE)
+        self.assertEqual(backend_class.kwargs_serializer().fields, {})
+
+    # file_export
+
+    def test_file_export_wire_payload(self):
+        command = force_command(backend=CommandBackend.FILE_EXPORT,
+                                backend_kwargs={"patterns": ["/var/log/*.log"], "max_size": 2048})
+        self.assertEqual(command.wire_payload(), {"patterns": ["/var/log/*.log"], "max_size": 2048})
+
+    def test_file_export_two_artifacts_archive_optional(self):
+        backend_class = get_command_backend_class(CommandBackend.FILE_EXPORT)
+        manifest, archive = backend_class.artifacts
+        self.assertEqual(manifest.name, "manifest")
+        self.assertEqual(manifest.extension, ".json")
+        self.assertFalse(manifest.optional, "the manifest is always produced, even by a zero-match run")
+        self.assertEqual(archive.name, "archive")
+        self.assertEqual(archive.extension, ".zip")
+        self.assertTrue(archive.optional, "a zero-match run has nothing to archive")
+
+    def _validate_file_export(self, kwargs):
+        serializer = get_command_backend_class(CommandBackend.FILE_EXPORT).kwargs_serializer(data=kwargs)
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
+    def test_file_export_max_size_default(self):
+        data = self._validate_file_export({"patterns": ["/var/log/install.log"]})
+        self.assertEqual(data["max_size"], DEFAULT_MAX_SIZE)
+
+    def test_file_export_max_size_above_absolute(self):
+        with self.assertRaises(serializers.ValidationError) as cm:
+            self._validate_file_export({"patterns": ["/tmp/x"], "max_size": MAX_MAX_SIZE + 1})
+        self.assertIn("max_size", cm.exception.detail)
+
+    def test_file_export_relative_pattern(self):
+        with self.assertRaises(serializers.ValidationError) as cm:
+            self._validate_file_export({"patterns": ["var/log/install.log"]})
+        self.assertEqual(cm.exception.detail["patterns"][0][0], "Must be an absolute path")
+
+    def test_file_export_parent_segment(self):
+        # a .. segment escapes the directory the pattern appears to name; the segment is rejected rather
+        # than normalized away, so what an operator reads is what the agent walks
+        with self.assertRaises(serializers.ValidationError) as cm:
+            self._validate_file_export({"patterns": ["/var/log/../../etc/shadow"]})
+        self.assertEqual(cm.exception.detail["patterns"][0][0], "Must not contain a .. segment")
+
+    def test_file_export_recursive_wildcard(self):
+        # fnmatch does not reject **, it just reads two stars as one — so with FNM_PATHNAME
+        # "/Library/Logs/**/*.log" matches one level and not two. A pattern written for recursion would
+        # collect exactly one level, quietly, which is worse than an error.
+        with self.assertRaises(serializers.ValidationError) as cm:
+            self._validate_file_export({"patterns": ["/Library/Logs/**/*.log"]})
+        self.assertIn("no recursive wildcard", cm.exception.detail["patterns"][0][0])
+
+    def test_file_export_single_wildcard_per_level_is_fine(self):
+        # depth is spelled out, one pattern for each level
+        data = self._validate_file_export(
+            {"patterns": ["/Library/Logs/*.log", "/Library/Logs/*/*.log", "/Library/Logs/*/*/*.log"]})
+        self.assertEqual(len(data["patterns"]), 3)
+
+    def test_file_export_parent_in_a_filename_is_fine(self):
+        # ".." only escapes as a whole segment — a file called "a..b" is not a traversal
+        data = self._validate_file_export({"patterns": ["/var/log/a..b.log"]})
+        self.assertEqual(data["patterns"], ["/var/log/a..b.log"])
+
+    def test_file_export_no_patterns(self):
+        with self.assertRaises(serializers.ValidationError) as cm:
+            self._validate_file_export({"patterns": []})
+        self.assertIn("patterns", cm.exception.detail)
+
+    def test_file_export_too_many_patterns(self):
+        with self.assertRaises(serializers.ValidationError) as cm:
+            self._validate_file_export({"patterns": [f"/tmp/{i}" for i in range(MAX_PATTERNS + 1)]})
+        self.assertIn("patterns", cm.exception.detail)

--- a/tests/turbo/test_pbac.py
+++ b/tests/turbo/test_pbac.py
@@ -1,0 +1,118 @@
+from django.contrib.auth.models import Group
+from django.core.exceptions import PermissionDenied
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from accounts.models import Policy, User
+from pbac.engine import engine
+from zentral.contrib.inventory.models import MetaBusinessUnit, MetaMachine
+from zentral.contrib.turbo.command_backends import CommandBackend
+from zentral.contrib.turbo.models import ScheduleMode
+from zentral.contrib.turbo.pbac import ScheduleCommandRequest, check_schedule_command
+
+from .utils import force_command, force_script
+
+
+class TurboPBACTestCase(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("godzilla", "godzilla@zentral.io", get_random_string(12))
+        cls.group = Group.objects.create(name=get_random_string(12))
+        cls.user.groups.set([cls.group])
+        cls.mbu = MetaBusinessUnit.objects.create(name=get_random_string(12))
+
+    def _set_policy(self, condition=None):
+        source = ("permit ("
+                  f' principal in Role::"{self.group.pk}",'
+                  ' action == Turbo::Action::"scheduleCommand",'
+                  " resource"
+                  ")")
+        if condition:
+            source += f" when {{ {condition} }}"
+        Policy.objects.update_or_create(name="Turbo tests", defaults={"source": source + ";\n"})
+
+    # the request
+
+    def test_machine_request_shape(self):
+        command = force_command(backend=CommandBackend.FILE_EXPORT)
+        machine = MetaMachine(get_random_string(12))
+        request = ScheduleCommandRequest(self.user, command, ScheduleMode.ONE_TIME, machine)
+        self.assertEqual(str(request.action), 'Turbo::Action::"scheduleCommand"')
+        # the machine resource comes from inventory, so its MBU parents scope the collection
+        self.assertEqual(request.resource.full_type, "Inventory::Machine")
+        self.assertEqual(request.resource.id, machine.serial_number)
+        self.assertEqual(request.context, {"backend": "file_export", "mode": "one_time"})
+
+    def test_configuration_request_has_no_machine(self):
+        # the configuration-page flow targets a scope expression, so there is no machine to name — the
+        # kind is still policeable, which is why this action is an additional gate and not a replacement
+        # for turbo.add_onetimejob
+        command = force_command()
+        request = ScheduleCommandRequest(self.user, command, ScheduleMode.ONE_TIME)
+        self.assertEqual(request.resource.full_type, "System")
+        self.assertEqual(request.resource.id, "any")
+        self.assertEqual(request.context, {"backend": "sysdiagnose", "mode": "one_time"})
+
+    # authorization
+
+    def test_denied_by_default(self):
+        command = force_command()
+        request = ScheduleCommandRequest(self.user, command, ScheduleMode.ONE_TIME,
+                                         MetaMachine(get_random_string(12)))
+        engine.authorize_request(request)
+        self.assertFalse(request.is_authorized)
+
+    def test_authorized_by_an_unconditional_policy(self):
+        self._set_policy()
+        command = force_command()
+        request = ScheduleCommandRequest(self.user, command, ScheduleMode.ONE_TIME,
+                                         MetaMachine(get_random_string(12)))
+        engine.authorize_request(request)
+        self.assertTrue(request.is_authorized)
+
+    def test_policy_can_allow_one_kind_and_refuse_another(self):
+        # the point of the whole exercise: one turbo.add_onetimejob covers "collect a sysdiagnose" and
+        # "glob arbitrary files off a laptop" identically, and this does not
+        self._set_policy('context.backend == "sysdiagnose"')
+        machine = MetaMachine(get_random_string(12))
+        allowed = ScheduleCommandRequest(self.user, force_command(backend=CommandBackend.SYSDIAGNOSE),
+                                         ScheduleMode.ONE_TIME, machine)
+        engine.authorize_request(allowed)
+        self.assertTrue(allowed.is_authorized)
+        refused = ScheduleCommandRequest(self.user, force_command(backend=CommandBackend.FILE_EXPORT),
+                                         ScheduleMode.ONE_TIME, machine)
+        engine.authorize_request(refused)
+        self.assertFalse(refused.is_authorized)
+
+    def test_policy_can_scope_by_mode(self):
+        # "one_time" on every request today, since allowed_modes keeps a command off a recurring
+        # schedule — the attribute is what would make "no recurring collection" policy rather than code
+        self._set_policy('context.mode == "one_time"')
+        request = ScheduleCommandRequest(self.user, force_command(), ScheduleMode.ONE_TIME,
+                                         MetaMachine(get_random_string(12)))
+        engine.authorize_request(request)
+        self.assertTrue(request.is_authorized)
+
+    # the view helper
+
+    class _FakeRequest:
+        def __init__(self, user):
+            self.user = user
+
+    def test_check_is_a_noop_for_a_script(self):
+        # only a command kind carries a backend worth policing; gating the others here would change
+        # authorization for every shipped deployment
+        script = force_script()
+        check_schedule_command(self._FakeRequest(self.user), script.job, ScheduleMode.ONE_TIME)
+
+    def test_check_raises_for_an_unauthorized_command(self):
+        command = force_command()
+        with self.assertRaises(PermissionDenied):
+            check_schedule_command(self._FakeRequest(self.user), command.job, ScheduleMode.ONE_TIME)
+
+    def test_check_passes_for_an_authorized_command(self):
+        self._set_policy()
+        command = force_command()
+        check_schedule_command(self._FakeRequest(self.user), command.job, ScheduleMode.ONE_TIME)

--- a/tests/turbo/test_public_config.py
+++ b/tests/turbo/test_public_config.py
@@ -5,9 +5,10 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MachineTag, Tag
+from zentral.contrib.turbo.command_backends import CommandBackend
 from zentral.contrib.turbo.events import TurboRequestEvent
-from zentral.contrib.turbo.models import EnrolledMachine, OneTimeJobMachine
-from .utils import (TurboPublicTestCase, force_configuration, force_enrolled_machine,
+from zentral.contrib.turbo.models import EnrolledMachine, Job, OneTimeJobMachine
+from .utils import (TurboPublicTestCase, force_command, force_configuration, force_enrolled_machine,
                     force_mscp_check, force_one_time_job, force_recurring_job, force_script)
 
 
@@ -93,6 +94,48 @@ class TurboConfigPublicTestCase(TurboPublicTestCase):
         jobs = self._config(token).json()["jobs"]
         self.assertEqual(jobs[0]["kind"], "mscp_check")
         self.assertEqual(jobs[0]["payload"], {"rule_id": mscp_check.rule_id, "baseline": "cis_lvl1"})
+
+    def test_config_sysdiagnose_payload_is_empty(self):
+        # a zero-config kind still gets a payload key: the envelope is the same for every kind, so an
+        # agent decodes one shape
+        configuration = force_configuration()
+        _, _, token = force_enrolled_machine(configuration=configuration, meta_business_unit=self.mbu)
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job)
+        jobs = self._config(token).json()["jobs"]
+        self.assertEqual(jobs, [{
+            "kind": "sysdiagnose",
+            "pk": str(command.job_id),
+            "version": 1,
+            "schedule": {"mode": "one_time", "pk": str(one_time_job.pk)},
+            "payload": {},
+        }])
+
+    def test_config_file_export_payload(self):
+        configuration = force_configuration()
+        _, _, token = force_enrolled_machine(configuration=configuration, meta_business_unit=self.mbu)
+        command = force_command(backend=CommandBackend.FILE_EXPORT,
+                                backend_kwargs={"patterns": ["/var/log/install.log*"], "max_size": 2048})
+        force_one_time_job(configuration=configuration, job=command.job)
+        jobs = self._config(token).json()["jobs"]
+        self.assertEqual(jobs[0]["kind"], "file_export")
+        self.assertEqual(jobs[0]["payload"],
+                         {"patterns": ["/var/log/install.log*"], "max_size": 2048})
+
+    def test_config_unknown_kind_skipped(self):
+        # during a rolling deploy an older instance can read a Job a newer one wrote. Its definition is
+        # unreachable, so the job is skipped — dereferencing it would 500 the endpoint for every machine
+        # holding that job until the refresh finishes.
+        configuration = force_configuration()
+        _, _, token = force_enrolled_machine(configuration=configuration, meta_business_unit=self.mbu)
+        script = force_script()
+        force_recurring_job(configuration=configuration, job=script.job)
+        future_job = Job.objects.create(kind="a_kind_from_the_future")
+        force_one_time_job(configuration=configuration, job=future_job)
+        with self.assertLogs("zentral.contrib.turbo.public_views.config", level="ERROR") as cm:
+            jobs = self._config(token).json()["jobs"]
+        self.assertEqual([job["kind"] for job in jobs], ["script"])
+        self.assertIn("a_kind_from_the_future", cm.output[0])
 
     # scope
 

--- a/tests/turbo/test_public_results.py
+++ b/tests/turbo/test_public_results.py
@@ -6,12 +6,13 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MachineTag, Tag
+from zentral.contrib.turbo.command_backends import CommandBackend
 from zentral.contrib.turbo.events import (TurboMSCPCheckComplianceCheckStatusUpdated, TurboRequestEvent,
                                           TurboResultEvent, TurboScriptComplianceCheckStatusUpdated)
 from zentral.contrib.turbo.models import OneTimeJob, OneTimeJobMachine, RecurringJobMachine
 from zentral.core.compliance_checks.events import MachineComplianceChangeEvent
 from zentral.core.compliance_checks.models import MachineStatus, Status
-from .utils import (TurboPublicTestCase, force_configuration, force_enrolled_machine,
+from .utils import (TurboPublicTestCase, force_command, force_configuration, force_enrolled_machine,
                     force_mscp_check, force_one_time_job, force_recurring_job, force_script)
 
 
@@ -697,6 +698,43 @@ class TurboResultsPublicTestCase(TurboPublicTestCase):
             metadata = event.metadata.serialize()
             self.assertEqual(metadata["objects"]["turbo_job"], [str(recurring_job.job.pk)])
             self.assertEqual(metadata["objects"]["turbo_recurring_job"], [str(recurring_job.pk)])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_results_command_result_event(self, post_event):
+        # config serves command jobs, so a command result can already arrive. Its outcome rides the
+        # open result dict untouched — no verdict, no tagging — and the definition block names the
+        # backend so a store consumer can tell one command from another without a lookup.
+        configuration, _, serial_number, token = self._enrolled()
+        command = force_command(backend=CommandBackend.FILE_EXPORT)
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job)
+        entry = self._result(one_time_job, exit_code=0)
+        entry["result"]["uploads"] = [{"artifact": "manifest", "key": "turbo/uploads/x/manifest.json"}]
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._results(token, {"results": [entry]})
+        self.assertEqual(response.status_code, 200)
+        result_events = [c.args[0] for c in post_event.call_args_list if isinstance(c.args[0], TurboResultEvent)]
+        self.assertEqual(len(result_events), 1)
+        event = result_events[0]
+        self.assertEqual(event.payload["kind"], "file_export")
+        self.assertEqual(event.payload["command"],
+                         {"pk": str(command.pk), "name": command.name, "backend": "file_export"})
+        # the outcome is echoed verbatim, uploads included
+        self.assertEqual(event.payload["result"]["uploads"],
+                         [{"artifact": "manifest", "key": "turbo/uploads/x/manifest.json"}])
+        objects = event.metadata.serialize()["objects"]
+        self.assertEqual(objects["turbo_command"], [str(command.pk)])
+        self.assertEqual(objects["turbo_one_time_job"], [str(one_time_job.pk)])
+        # a command carries no compliance role, so nothing was scored
+        self.assertFalse(MachineStatus.objects.filter(serial_number=serial_number).exists())
+
+    def test_results_command_closes_the_gate(self):
+        configuration, _, serial_number, token = self._enrolled()
+        command = force_command()
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job)
+        self.assertEqual(self._results(token, {"results": [self._result(one_time_job, exit_code=0)]}).status_code,
+                         200)
+        job_machine = OneTimeJobMachine.objects.get(one_time_job=one_time_job, serial_number=serial_number)
+        self.assertIsNotNone(job_machine.last_result_at)
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_results_per_check_mscp_status_event(self, post_event):

--- a/tests/turbo/test_setup_commands.py
+++ b/tests/turbo/test_setup_commands.py
@@ -1,0 +1,141 @@
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+from zentral.contrib.turbo.command_backends import CommandBackend
+from .utils import (TurboSetupTestCase, force_command, force_configuration, force_enrolled_machine,
+                    force_one_time_job, force_script)
+
+
+class TurboSetupCommandsTestCase(TurboSetupTestCase):
+    # the console is read-only for commands, like it is for stores.Store and probes.Action: a command is
+    # defined through the API, where the per-backend kwargs serializer already validates it.
+
+    # list
+
+    def test_commands_redirect(self):
+        self.login_redirect("commands")
+
+    def test_commands_permission_denied(self):
+        self.login()
+        response = self.client.get(reverse("turbo:commands"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_commands(self):
+        force_command()
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:commands"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "turbo/command_list.html")
+
+    def test_commands_search_by_name(self):
+        command = force_command()
+        force_command()
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:commands"), {"q": command.name})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [command])
+
+    def test_commands_search_by_backend(self):
+        force_command(backend=CommandBackend.SYSDIAGNOSE)
+        file_export = force_command(backend=CommandBackend.FILE_EXPORT)
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:commands"), {"backend": "file_export"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [file_export])
+
+    def test_commands_search_by_configuration(self):
+        configuration = force_configuration()
+        scheduled = force_command()
+        force_one_time_job(configuration=configuration, job=scheduled.job)
+        force_command()  # not scheduled anywhere
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:commands"), {"configuration": configuration.pk})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [scheduled])
+
+    def test_commands_search_no_result_shows_empty_results(self):
+        force_command()
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:commands"), {"q": get_random_string(20)})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [])
+        self.assertContains(response, "We didn't find any item")
+
+    # detail
+
+    def test_command_redirect(self):
+        command = force_command()
+        self.login_redirect("command", command.pk)
+
+    def test_command_permission_denied(self):
+        command = force_command()
+        self.login()
+        response = self.client.get(reverse("turbo:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 403)
+
+    def test_sysdiagnose_command_detail(self):
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "turbo/command_detail.html")
+        self.assertContains(response, command.name)
+        # a zero-config kind has no kwargs to show, and one artifact
+        self.assertEqual(response.context["backend_kwargs"], [])
+        self.assertEqual([a.name for a in response.context["artifacts"]], ["archive"])
+
+    def test_file_export_command_detail(self):
+        command = force_command(backend=CommandBackend.FILE_EXPORT,
+                                backend_kwargs={"patterns": ["/var/log/install.log*"], "max_size": 2048})
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["backend_kwargs"],
+                         [("max_size", 2048), ("patterns", ["/var/log/install.log*"])])
+        self.assertEqual([a.name for a in response.context["artifacts"]], ["manifest", "archive"])
+        self.assertContains(response, "/var/log/install.log*")
+
+    def test_command_detail_lists_its_schedules(self):
+        # the definition detail page is where the schedules running it are listed — and the reason the
+        # page has to exist at all, since every job list links a definition's get_absolute_url
+        configuration = force_configuration()
+        command = force_command()
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job)
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:command", args=(command.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["one_time_jobs"]), [one_time_job])
+        self.assertEqual(list(response.context["recurring_jobs"]), [])
+
+    # the one-time job list links every definition, whatever its kind
+
+    def test_one_time_job_list_links_the_command(self):
+        configuration = force_configuration()
+        command = force_command()
+        force_one_time_job(configuration=configuration, job=command.job)
+        force_one_time_job(configuration=configuration, job=force_script().job)
+        self.login("turbo.view_onetimejob")
+        response = self.client.get(reverse("turbo:one_time_jobs"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("turbo:command", args=(command.pk,)))
+
+    def test_menu_hidden_without_the_permission(self):
+        self.login("turbo.view_script")
+        response = self.client.get(reverse("turbo:scripts"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, reverse("turbo:commands"))
+
+    def test_menu_shown_with_the_permission(self):
+        self.login("turbo.view_command")
+        response = self.client.get(reverse("turbo:commands"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("turbo:commands"))
+
+    def test_machine_one_time_job_form_offers_a_command(self):
+        # the one-time paths must offer what the recurring path refuses
+        command = force_command()
+        _, serial_number, _ = force_enrolled_machine(meta_business_unit=self.mbu)
+        self.login("turbo.add_onetimejob")
+        response = self.client.get(
+            reverse("turbo:schedule_machine_one_time_job", args=(serial_number,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(command.job, response.context["form"].fields["job"].queryset)

--- a/tests/turbo/test_setup_recurring_jobs.py
+++ b/tests/turbo/test_setup_recurring_jobs.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import Tag
 from zentral.contrib.turbo.models import RecurringJob
-from .utils import (TurboSetupTestCase, force_configuration, force_mscp_check,
+from .utils import (TurboSetupTestCase, force_command, force_configuration, force_mscp_check,
                     force_recurring_job, force_script)
 
 
@@ -146,6 +146,24 @@ class TurboSetupRecurringJobsTestCase(TurboSetupTestCase):
         response = self.client.get(reverse("turbo:create_recurring_job", args=(configuration.pk,)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "turbo/recurringjob_form.html")
+
+    def test_create_recurring_job_command_not_offered(self):
+        # narrowing the job queryset is the validation too: a ModelChoiceField refuses a pk outside it,
+        # so a command kind cannot be posted here even by hand
+        configuration = force_configuration()
+        command = force_command()
+        self.login("turbo.add_recurringjob", "turbo.view_configuration")
+        response = self.client.get(reverse("turbo:create_recurring_job", args=(configuration.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(command.job, response.context["form"].fields["job"].queryset)
+        response = self.client.post(
+            reverse("turbo:create_recurring_job", args=(configuration.pk,)),
+            {"job": str(command.job.pk), "interval": 3600,
+             "serial_numbers": "", "excluded_serial_numbers": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response.context["form"], "job",
+                             "Select a valid choice. That choice is not one of the available choices.")
+        self.assertFalse(RecurringJob.objects.filter(job=command.job).exists())
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_create_recurring_job(self, post_event):

--- a/tests/turbo/utils.py
+++ b/tests/turbo/utils.py
@@ -6,9 +6,10 @@ from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
 from zentral.contrib.inventory.models import EnrollmentSecret, MetaBusinessUnit
+from zentral.contrib.turbo.command_backends import CommandBackend
 from zentral.contrib.turbo.compliance_checks import sync_script_compliance_check
-from zentral.contrib.turbo.models import (Configuration, EnrolledMachine, Enrollment, MSCPCheck,
-                                          OneTimeJob, RecurringJob, Script)
+from zentral.contrib.turbo.models import (Command, Configuration, EnrolledMachine, Enrollment,
+                                          MSCPCheck, OneTimeJob, RecurringJob, Script)
 from zentral.core.events.base import AuditEvent
 from zentral.core.stores.conf import stores
 from zentral.utils.provisioning import provision
@@ -34,6 +35,19 @@ def force_mscp_check(rule_id=None, baseline="", odv_int=None, odv_string=None, o
         odv_string=odv_string,
         odv_bool=odv_bool,
     )
+
+
+def force_command(backend=CommandBackend.SYSDIAGNOSE, name=None, backend_kwargs=None):
+    # the Job (kind == backend) is auto-minted in Command.save()
+    if backend_kwargs is None:
+        backend_kwargs = (
+            {"patterns": ["/var/log/install.log*"], "max_size": 1048576}
+            if backend == CommandBackend.FILE_EXPORT else {}
+        )
+    command = Command.objects.create(name=name or get_random_string(12), backend=backend)
+    command.set_backend_kwargs(backend_kwargs)
+    command.save()
+    return command
 
 
 def force_recurring_job(configuration=None, job=None, interval=None, tags=None, serial_numbers=None):

--- a/zentral/contrib/turbo/api_urls.py
+++ b/zentral/contrib/turbo/api_urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .api_views import (ConfigurationList, ConfigurationDetail,
+from .api_views import (CommandList, CommandDetail,
+                        ConfigurationList, ConfigurationDetail,
                         EnrollmentList, EnrollmentDetail,
                         EnrollmentPlist, EnrollmentConfigurationProfile,
                         MSCPCheckList, MSCPCheckDetail,
@@ -17,6 +18,8 @@ urlpatterns = [
     path('enrollments/<int:pk>/plist/', EnrollmentPlist.as_view(), name="enrollment_plist"),
     path('enrollments/<int:pk>/configuration_profile/', EnrollmentConfigurationProfile.as_view(),
          name="enrollment_configuration_profile"),
+    path('commands/', CommandList.as_view(), name="commands"),
+    path('commands/<uuid:pk>/', CommandDetail.as_view(), name="command"),
     path('scripts/', ScriptList.as_view(), name="scripts"),
     path('scripts/<uuid:pk>/', ScriptDetail.as_view(), name="script"),
     path('mscp_checks/', MSCPCheckList.as_view(), name="mscp_checks"),

--- a/zentral/contrib/turbo/api_views/__init__.py
+++ b/zentral/contrib/turbo/api_views/__init__.py
@@ -1,3 +1,4 @@
+from .commands import *  # NOQA
 from .configurations import *  # NOQA
 from .enrollments import *  # NOQA
 from .mscp_checks import *  # NOQA

--- a/zentral/contrib/turbo/api_views/commands.py
+++ b/zentral/contrib/turbo/api_views/commands.py
@@ -1,0 +1,38 @@
+from django.db.models import Q
+from django_filters import rest_framework as filters
+from rest_framework.exceptions import ValidationError
+from zentral.utils.drf import (ListCreateAPIViewWithAudit, MaxLimitOffsetPagination,
+                               RetrieveUpdateDestroyAPIViewWithAudit)
+from ..command_backends import CommandBackend
+from ..models import Command, Configuration
+from ..serializers import CommandSerializer
+
+
+class CommandFilter(filters.FilterSet):
+    name = filters.CharFilter()
+    backend = filters.ChoiceFilter(choices=CommandBackend.choices)
+    # the configuration a command runs in is reached through its Job's schedules, matching the UI
+    # "Scheduled in" search
+    configuration = filters.ModelChoiceFilter(queryset=Configuration.objects.all(),
+                                              method="filter_configuration")
+
+    def filter_configuration(self, queryset, name, value):
+        return queryset.filter(Q(job__recurringjob__configuration=value)
+                               | Q(job__onetimejob__configuration=value)).distinct()
+
+
+class CommandList(ListCreateAPIViewWithAudit):
+    queryset = Command.objects.select_related("job").order_by("name")
+    serializer_class = CommandSerializer
+    pagination_class = MaxLimitOffsetPagination
+    filterset_class = CommandFilter
+
+
+class CommandDetail(RetrieveUpdateDestroyAPIViewWithAudit):
+    queryset = Command.objects.select_related("job").all()
+    serializer_class = CommandSerializer
+
+    def perform_destroy(self, instance):
+        if not instance.can_be_deleted():
+            raise ValidationError("This command cannot be deleted")
+        return super().perform_destroy(instance)

--- a/zentral/contrib/turbo/apps.py
+++ b/zentral/contrib/turbo/apps.py
@@ -5,5 +5,5 @@ class ZentralTurboAppConfig(ZentralAppConfig):
     name = "zentral.contrib.turbo"
     default = True
     verbose_name = "Zentral Turbo contrib app"
-    permission_models = ("configuration", "enrolledmachine", "enrollment", "mscpcheck", "onetimejob",
-                         "recurringjob", "script")
+    permission_models = ("command", "configuration", "enrolledmachine", "enrollment", "mscpcheck",
+                         "onetimejob", "recurringjob", "script")

--- a/zentral/contrib/turbo/command_backends/__init__.py
+++ b/zentral/contrib/turbo/command_backends/__init__.py
@@ -1,0 +1,30 @@
+from django.db import models
+
+
+class CommandBackend(models.TextChoices):
+    # lowercase, unlike the other BackendInstance enums: these values double as the wire `kind`, and
+    # Turbo's wire convention wins over the UPPER_SNAKE enum convention of stores / probes.
+    SYSDIAGNOSE = "sysdiagnose", "sysdiagnose"
+    FILE_EXPORT = "file_export", "File export"
+
+
+def get_command_backend_class(backend):
+    # the imports are inside the branches, like probes.action_backends: the backend modules import
+    # models.py (for ScheduleMode) and models.py imports this module (for CommandBackend.choices), so
+    # only a lazy import keeps the loop open.
+    #
+    # The value is compared as-is rather than coerced through CommandBackend() first — a TextChoices
+    # member IS its string, so the comparisons work either way, and this makes the final raise the one
+    # gate. Coercing first would make it unreachable, and a value added to the enum but not mapped here
+    # would then return None instead of failing.
+    if backend == CommandBackend.SYSDIAGNOSE:
+        from .sysdiagnose import Sysdiagnose
+        return Sysdiagnose
+    if backend == CommandBackend.FILE_EXPORT:
+        from .file_export import FileExport
+        return FileExport
+    raise ValueError(f"Unknown command backend: {backend}")
+
+
+def get_command_backend(command, load=False):
+    return get_command_backend_class(command.backend)(command, load)

--- a/zentral/contrib/turbo/command_backends/base.py
+++ b/zentral/contrib/turbo/command_backends/base.py
@@ -1,0 +1,46 @@
+import logging
+from typing import NamedTuple
+
+from zentral.utils.backend_model import Backend
+
+
+logger = logging.getLogger("zentral.contrib.turbo.command_backends.base")
+
+
+class Artifact(NamedTuple):
+    """One output a command run produces.
+
+    The declaration is the server's, never the agent's: it validates the `artifact` a mint asks for,
+    builds the object's filename, and makes a result checkable against the set that was expected.
+    `optional` means *this run may not have produced it* — a zero-match file_export has no archive to
+    send — and it is the only legitimate reason an entry is missing from a completed run's result. An
+    artifact that was produced and failed to upload is a different thing: it is reported, with its error.
+    """
+    name: str            # the wire `artifact`
+    stem: str            # filename stem, before the serial and the mint timestamp
+    extension: str
+    content_type: str
+    optional: bool = False
+
+
+class BaseCommand(Backend):
+    # the wire `kind`, equal to the CommandBackend value and to Job.kind
+    kind = None
+    # DRF serializer for backend_kwargs — the API and a future TF schema both derive from it. A kind
+    # with no options declares one with no fields rather than None, so the dispatch has no special case.
+    kwargs_serializer = None
+    # every concrete backend declares both: a set of ScheduleMode values, and the artifacts a run
+    # produces. Empty defaults would silently mean "schedulable nowhere" and "produces nothing", so
+    # test_command_backends asserts neither is left at its default.
+    allowed_modes = frozenset()
+    artifacts = ()
+    requires_upload = False
+
+    def wire_payload(self):
+        raise NotImplementedError
+
+    @classmethod
+    def get_artifact(cls, name):
+        for artifact in cls.artifacts:
+            if artifact.name == name:
+                return artifact

--- a/zentral/contrib/turbo/command_backends/file_export.py
+++ b/zentral/contrib/turbo/command_backends/file_export.py
@@ -1,0 +1,79 @@
+import logging
+
+from rest_framework import serializers
+
+from ..models import ScheduleMode
+from . import CommandBackend
+from .base import Artifact, BaseCommand
+
+
+logger = logging.getLogger("zentral.contrib.turbo.command_backends.file_export")
+
+
+# fnmatch has no recursive wildcard, so a tree costs one pattern per level (see validate_pattern):
+# a support workflow bundling a handful of directories spends patterns quickly
+MAX_PATTERNS = 32
+MAX_PATTERN_LENGTH = 1024
+DEFAULT_MAX_SIZE = 100 * 2**20
+MAX_MAX_SIZE = 500 * 2**20
+# the archive can hold nothing but the cap is on the uncompressed total, so the compressed ceiling is
+# the same as the uncompressed one — a mint is refused above it either way
+MAX_UPLOAD_SIZE = MAX_MAX_SIZE
+
+
+def validate_pattern(value):
+    if not value.startswith("/"):
+        raise serializers.ValidationError("Must be an absolute path")
+    # a .. segment escapes the directory the pattern appears to name; reject the segment rather than
+    # normalizing, so what an operator reads is what the agent walks
+    if ".." in value.split("/"):
+        raise serializers.ValidationError("Must not contain a .. segment")
+    # The agent matches with fnmatch(3), which is what macOS gives it for free — and fnmatch has no
+    # recursive wildcard. It does not reject **: two stars are simply two stars, so with FNM_PATHNAME
+    # `/Library/Logs/**/*.log` matches `/Library/Logs/a/b.log` and NOT `/Library/Logs/a/b/c.log`. A
+    # pattern written for recursion would therefore collect exactly one level, quietly. Refuse it here
+    # rather than let an operator discover it from a short archive.
+    if "**" in value:
+        raise serializers.ValidationError(
+            "Must not contain **: the patterns are matched with fnmatch, which has no recursive "
+            "wildcard. Add one pattern for each directory level."
+        )
+    return value
+
+
+class FileExportKwargsSerializer(serializers.Serializer):
+    # a list because support workflows bundle several paths into one run, one archive and one gate;
+    # a single pattern is just a list of one. fnmatch syntax — `*`, `?` and `[...]`, with `*` stopping
+    # at a `/` (FNM_PATHNAME), so a pattern names one directory level and depth is spelled out.
+    patterns = serializers.ListField(
+        child=serializers.CharField(max_length=MAX_PATTERN_LENGTH, validators=[validate_pattern]),
+        min_length=1,
+        max_length=MAX_PATTERNS,
+    )
+    # UNCOMPRESSED total, unlike os_log's compressed cap: file sizes are known from stat, so inclusion
+    # is decided before anything is written
+    max_size = serializers.IntegerField(min_value=1, max_value=MAX_MAX_SIZE, default=DEFAULT_MAX_SIZE)
+
+
+class FileExport(BaseCommand):
+    kind = CommandBackend.FILE_EXPORT
+    kwargs_keys = ("patterns", "max_size")
+    kwargs_serializer = FileExportKwargsSerializer
+    allowed_modes = frozenset([ScheduleMode.ONE_TIME])
+    requires_upload = True
+    artifacts = (
+        # the manifest used to live inside the archive, to keep one upload per run. It comes out because
+        # pulling the whole archive to read a few KB is the wrong shape for a support workflow, and
+        # because a separate artifact means the inventory of what was collected survives an archive that
+        # never uploaded.
+        Artifact(name="manifest", stem="file_export_manifest", extension=".json",
+                 content_type="application/json"),
+        # optional: a zero-match run has nothing to archive, and an empty archive would be a fiction
+        # someone has to open to disbelieve
+        Artifact(name="archive", stem="file_export", extension=".zip",
+                 content_type="application/zip", optional=True),
+    )
+    max_upload_size = MAX_UPLOAD_SIZE
+
+    def wire_payload(self):
+        return {"patterns": self.patterns, "max_size": self.max_size}

--- a/zentral/contrib/turbo/command_backends/sysdiagnose.py
+++ b/zentral/contrib/turbo/command_backends/sysdiagnose.py
@@ -1,0 +1,38 @@
+import logging
+
+from rest_framework import serializers
+
+from ..models import ScheduleMode
+from . import CommandBackend
+from .base import Artifact, BaseCommand
+
+
+logger = logging.getLogger("zentral.contrib.turbo.command_backends.sysdiagnose")
+
+
+# 2 GiB: sysdiagnose archives on a loaded system pass 1 GB, and the ceiling is a server constant
+# rather than a kwarg because there is nothing an operator could usefully tune here
+MAX_UPLOAD_SIZE = 2 * 2**30
+
+
+class SysdiagnoseKwargsSerializer(serializers.Serializer):
+    # no options: the agent owns the timeout and the invocation. Zero config is what makes the
+    # machine-page one-click flow possible.
+    pass
+
+
+class Sysdiagnose(BaseCommand):
+    kind = CommandBackend.SYSDIAGNOSE
+    kwargs_keys = ()
+    kwargs_serializer = SysdiagnoseKwargsSerializer
+    allowed_modes = frozenset([ScheduleMode.ONE_TIME])
+    requires_upload = True
+    artifacts = (
+        # the tool emits its own compressed archive and the agent does not recompress it, so the
+        # extension is the tool's, not ours
+        Artifact(name="archive", stem="sysdiagnose", extension=".tar.gz", content_type="application/gzip"),
+    )
+    max_upload_size = MAX_UPLOAD_SIZE
+
+    def wire_payload(self):
+        return {}

--- a/zentral/contrib/turbo/events/__init__.py
+++ b/zentral/contrib/turbo/events/__init__.py
@@ -14,10 +14,11 @@ class BaseTurboEvent(BaseEvent):
 
     @staticmethod
     def _link_definition(keys, ref):
-        # the payload's turbo-local definition block (script / mscp_check) → the pk-only, namespaced
-        # linked object (turbo_script / turbo_mscp_check), so one key correlates a definition's machine,
-        # audit and compliance events
-        for payload_key, linked_key in (("script", "turbo_script"), ("mscp_check", "turbo_mscp_check")):
+        # the payload's turbo-local definition block (script / mscp_check / command) → the pk-only,
+        # namespaced linked object (turbo_script / turbo_mscp_check / turbo_command), so one key
+        # correlates a definition's machine, audit and compliance events
+        for payload_key, linked_key in (("script", "turbo_script"), ("mscp_check", "turbo_mscp_check"),
+                                        ("command", "turbo_command")):
             pk = (ref.get(payload_key) or {}).get("pk")
             if pk and (pk,) not in keys.setdefault(linked_key, []):
                 keys[linked_key].append((pk,))

--- a/zentral/contrib/turbo/forms.py
+++ b/zentral/contrib/turbo/forms.py
@@ -4,9 +4,10 @@ from django.db.models import F, Q, TextField
 from django.db.models.functions import Coalesce
 
 from zentral.contrib.inventory.models import Tag
+from .command_backends import CommandBackend
 from .compliance_checks import sync_mscp_check_compliance_check, sync_script_compliance_check
-from .models import (Configuration, EnrolledMachine, Enrollment, Job, MSCPCheck, OneTimeJob,
-                     RecurringJob, Script)
+from .models import (Command, Configuration, EnrolledMachine, Enrollment, Job, MSCPCheck, OneTimeJob,
+                     RecurringJob, ScheduleMode, Script)
 
 
 class ConfigurationForm(forms.ModelForm):
@@ -95,6 +96,37 @@ class ScriptSearchForm(forms.Form):
         return qs
 
 
+class CommandSearchForm(forms.Form):
+    template_name = "django/forms/search.html"
+
+    q = forms.CharField(
+        label="Name", required=False,
+        widget=forms.TextInput(attrs={"autofocus": True, "size": 36}),
+    )
+    backend = forms.ChoiceField(
+        label="Kind", choices=[("", "...")] + list(CommandBackend.choices), required=False,
+    )
+    configuration = forms.ModelChoiceField(
+        label="Scheduled in", queryset=Configuration.objects.all(), required=False, empty_label="...",
+    )
+
+    def get_queryset(self):
+        qs = Command.objects.select_related("job").order_by("name")
+        q = self.cleaned_data.get("q")
+        if q:
+            qs = qs.filter(Q(name__icontains=q) | Q(description__icontains=q))
+        backend = self.cleaned_data.get("backend")
+        if backend:
+            qs = qs.filter(backend=backend)
+        configuration = self.cleaned_data.get("configuration")
+        if configuration:
+            qs = qs.filter(
+                Q(job__recurringjob__configuration=configuration)
+                | Q(job__onetimejob__configuration=configuration)
+            ).distinct()
+        return qs
+
+
 class MSCPCheckForm(forms.ModelForm):
     class Meta:
         model = MSCPCheck
@@ -168,7 +200,7 @@ class BaseJobScopeForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         # NB: the UUID PK default fills pk at construction, so use _state.adding (not pk) for create-vs-update
         self.configuration = configuration or (None if self.instance._state.adding else self.instance.configuration)
-        self.fields["job"].queryset = Job.objects.select_related("script", "mscp_check").all()
+        self.fields["job"].queryset = Job.objects.select_related(*Job.definition_relations()).all()
         if not self.instance._state.adding:
             # disabled keeps the initial value, whatever is posted
             self.fields["job"].disabled = True
@@ -206,6 +238,10 @@ class RecurringJobForm(BaseJobScopeForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # a kind that declares itself one-time only cannot be attached here. Narrowing the queryset is
+        # the validation too: a ModelChoiceField refuses a pk outside it.
+        self.fields["job"].queryset = self.fields["job"].queryset.filter(
+            kind__in=Job.kinds_for_schedule_mode(ScheduleMode.RECURRING))
         if self.configuration is not None and self.instance._state.adding:
             # a job can be scheduled at most once per configuration (unique constraint). Excluding the
             # scheduled jobs from the choices is enough now that an existing schedule keeps its job
@@ -230,7 +266,7 @@ class RecurringJobSearchForm(forms.Form):
     def get_queryset(self):
         qs = (
             RecurringJob.objects
-            .select_related("configuration", "job__script", "job__mscp_check")
+            .select_related("configuration", *Job.definition_relations("job__"))
             .prefetch_related("tags", "excluded_tags")
             .annotate(job_name=Coalesce("job__script__name", "job__mscp_check__rule_id",
                                         output_field=TextField()))
@@ -299,7 +335,7 @@ class OneTimeJobSearchForm(forms.Form):
     def get_queryset(self):
         qs = (
             OneTimeJob.objects
-            .select_related("configuration", "job__script", "job__mscp_check")
+            .select_related("configuration", *Job.definition_relations("job__"))
             .prefetch_related("tags", "excluded_tags")
             .order_by(F("not_before").desc(nulls_last=True), "-created_at")
         )
@@ -353,7 +389,7 @@ class MachineOneTimeJobForm(BaseOneTimeJobForm):
         super().__init__(*args, **kwargs)
         self.configuration = configuration
         self.serial_number = serial_number
-        self.fields["job"].queryset = Job.objects.select_related("script", "mscp_check").all()
+        self.fields["job"].queryset = Job.objects.select_related(*Job.definition_relations()).all()
 
     def save(self, *args, **kwargs):
         # locked to one machine: the view supplies the config + serial, no scope UI

--- a/zentral/contrib/turbo/migrations/0002_command.py
+++ b/zentral/contrib/turbo/migrations/0002_command.py
@@ -1,0 +1,60 @@
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("turbo", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="job",
+            name="kind",
+            field=models.CharField(
+                choices=[
+                    ("script", "Script"),
+                    ("mscp_check", "mSCP check"),
+                    ("sysdiagnose", "sysdiagnose"),
+                    ("file_export", "File export"),
+                ],
+                editable=False,
+                max_length=32,
+            ),
+        ),
+        migrations.CreateModel(
+            name="Command",
+            fields=[
+                ("name", models.CharField(unique=True)),
+                ("description", models.TextField(blank=True)),
+                ("backend_kwargs", models.JSONField(default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+                ),
+                (
+                    "backend",
+                    models.CharField(
+                        choices=[("sysdiagnose", "sysdiagnose"), ("file_export", "File export")]
+                    ),
+                ),
+                (
+                    "job",
+                    models.OneToOneField(
+                        editable=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="command",
+                        to="turbo.job",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+    ]

--- a/zentral/contrib/turbo/models.py
+++ b/zentral/contrib/turbo/models.py
@@ -7,7 +7,9 @@ from django.db.models import Exists, OuterRef, Q
 from django.urls import reverse
 
 from zentral.contrib.inventory.models import BaseEnrollment, MetaMachine, Tag
+from zentral.utils.backend_model import BackendInstance
 
+from .command_backends import CommandBackend, get_command_backend, get_command_backend_class
 from .compliance_checks import sync_mscp_check_compliance_check
 
 
@@ -173,12 +175,41 @@ class EnrolledMachine(models.Model):
 
 
 class Job(models.Model):
-    # Polymorphic anchor for the things Turbo runs. One row per Script / MSCPCheck (each O2Os in below).
-    # The kind is the wire `kind`; Job.pk is the wire identity of the definition (the `pk` in each job
-    # block). Per-machine delivery is tracked against the scheduling row, not the Job.
+    # Polymorphic anchor for the things Turbo runs. One row per Script / MSCPCheck / Command (each O2Os
+    # in below). The kind is the wire `kind`; Job.pk is the wire identity of the definition (the `pk` in
+    # each job block). Per-machine delivery is tracked against the scheduling row, not the Job.
     class Kind(models.TextChoices):
         SCRIPT = "script", "Script"
         MSCP_CHECK = "mscp_check", "mSCP check"
+        # one value per command backend, flat — never a "command" kind with a sub-type. A new command is
+        # then a config change for an agent rather than a protocol change, because an agent already
+        # drops a kind it does not know, element by element.
+        SYSDIAGNOSE = CommandBackend.SYSDIAGNOSE.value, CommandBackend.SYSDIAGNOSE.label
+        FILE_EXPORT = CommandBackend.FILE_EXPORT.value, CommandBackend.FILE_EXPORT.label
+
+    # every relation a definition can hang off a Job. Callers that dereference job.definition prefetch
+    # with it — one tuple, so a new kind cannot be forgotten at one of the many select_related sites.
+    DEFINITION_RELATIONS = ("script", "mscp_check", "command")
+
+    @classmethod
+    def definition_relations(cls, prefix=""):
+        # select_related() arguments for every definition relation, under an optional prefix
+        # ("job__", "one_time_job__job__"): the callers reach a Job from several depths
+        return tuple(f"{prefix}{relation}" for relation in cls.DEFINITION_RELATIONS)
+
+    @classmethod
+    def allowed_schedule_modes(cls, kind):
+        # a command backend declares the scheduling rows its kind may be attached to — the first wave is
+        # one-time only, since a recurring collection is a log shipper rather than a job. A Script or an
+        # MSCPCheck is schedulable either way. Keyed on the kind, not an instance, because the callers
+        # validate a choice before any row exists.
+        if kind in CommandBackend.values:
+            return get_command_backend_class(kind).allowed_modes
+        return frozenset(ScheduleMode.values)
+
+    @classmethod
+    def kinds_for_schedule_mode(cls, mode):
+        return [kind for kind in cls.Kind.values if mode in cls.allowed_schedule_modes(kind)]
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     kind = models.CharField(max_length=32, choices=Kind.choices, editable=False)
@@ -197,25 +228,48 @@ class Job(models.Model):
         self.refresh_from_db()
 
     @property
+    def is_command(self):
+        return self.kind in CommandBackend.values
+
+    @property
     def definition(self):
+        # None for a kind this instance does not know — an older release reading a row a newer one wrote
+        # during a rolling deploy. Callers treat that as "not deliverable" instead of dereferencing it.
         if self.kind == self.Kind.SCRIPT:
             return self.script
         elif self.kind == self.Kind.MSCP_CHECK:
             return self.mscp_check
+        elif self.is_command:
+            return self.command
+
+    @property
+    def definition_payload_key(self):
+        # the turbo-local key the definition block rides under in an event payload
+        if self.kind == self.Kind.SCRIPT:
+            return "script"
+        elif self.kind == self.Kind.MSCP_CHECK:
+            return "mscp_check"
+        elif self.is_command:
+            return "command"
 
     def definition_linked_objects_keys(self):
-        # link the definition (Script / MSCPCheck) — the page an admin navigates to — not the Job anchor
-        key = "turbo_script" if self.kind == self.Kind.SCRIPT else "turbo_mscp_check"
-        return {key: [(self.definition.pk,)]}
+        # link the definition (Script / MSCPCheck / Command) — the page an admin navigates to — not the
+        # Job anchor
+        return {f"turbo_{self.definition_payload_key}": [(self.definition.pk,)]}
 
     def definition_wire_ref(self):
         # the definition block for an event payload: (payload_key, {pk + human context}). The payload
-        # key is turbo-local (script / mscp_check); the pk-only linked object stays namespaced
-        # (turbo_script / turbo_mscp_check) — see events.get_linked_objects_keys.
+        # key is turbo-local (script / mscp_check / command); the pk-only linked object stays namespaced
+        # (turbo_script / turbo_mscp_check / turbo_command) — see events.get_linked_objects_keys.
         definition = self.definition
+        key = self.definition_payload_key
         if self.kind == self.Kind.SCRIPT:
-            return "script", {"pk": str(definition.pk), "name": definition.name}
-        return "mscp_check", {"pk": str(definition.pk), "rule_id": definition.rule_id}
+            return key, {"pk": str(definition.pk), "name": definition.name}
+        elif self.kind == self.Kind.MSCP_CHECK:
+            return key, {"pk": str(definition.pk), "rule_id": definition.rule_id}
+        # the backend is the kind, so it is redundant on the wire ref — but a store consumer reading a
+        # command result should not have to know that to tell one command from another
+        return key, {"pk": str(definition.pk), "name": definition.name, "backend": definition.backend}
 
 
 class JobDefinitionManager(models.Manager):
@@ -476,6 +530,67 @@ class MSCPCheck(models.Model):
         return result
 
 
+class Command(BackendInstance):
+    # The third definition family: verbs with a small options dict. Script and MSCPCheck each earn a
+    # table because Postgres enforces their identity (FKs with DB semantics, typed ODV columns and
+    # their constraints); a command has neither, and its variation is agent behaviour plus result
+    # handling — Python, not schema. So one table and a backend registry, the split stores.Store and
+    # probes.Action already use. A command that grows an FK or a constraint graduates to its own
+    # definition model under the same Job anchor, additively.
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    job = models.OneToOneField(Job, on_delete=models.CASCADE, related_name="command", editable=False)
+    # IMMUTABLE once set: Job.kind mirrors it, and both are the wire identity of this definition, so
+    # changing the behaviour under a stable pk and version is not an edit but a different command.
+    # Enforced by the serializer — the DB column stays writable so a create can set it.
+    backend = models.CharField(choices=CommandBackend.choices)
+    backend_enum = CommandBackend
+    # inherited from BackendInstance: name (unique), description, backend_kwargs, created_at, updated_at
+    # version lives on the Job (bumped on a kwargs change); access via self.job.version
+
+    objects = JobDefinitionManager()
+
+    def get_backend(self, load=False):
+        return get_command_backend(self, load)
+
+    def get_absolute_url(self):
+        return reverse("turbo:command", args=(self.pk,))
+
+    @property
+    def version(self):
+        return self.job.version
+
+    def save(self, *args, **kwargs):
+        # atomic so a failed insert (e.g. duplicate name) rolls the auto-minted Job back, no orphan
+        with transaction.atomic():
+            if not self.job_id:
+                self.job = Job.objects.create(kind=self.backend)
+            super().save(*args, **kwargs)
+
+    def can_be_deleted(self):
+        return Command.objects.can_be_deleted().filter(pk=self.pk).exists()
+
+    def wire_payload(self):
+        # a pure function of (kwargs, version): cached for config_refresh_interval and re-served to
+        # every in-scope machine, so nothing per-machine or per-run may enter it — which is why an
+        # upload destination is minted on its own endpoint instead
+        return self.get_backend(load=True).wire_payload()
+
+    def serialize_for_event(self, keys_only=False):
+        d = super().serialize_for_event(keys_only)
+        if not keys_only:
+            d["version"] = self.job.version
+        return d
+
+    def linked_objects_keys_for_event(self):
+        return {}
+
+    def delete(self, *args, **kwargs):
+        job = self.job
+        result = super().delete(*args, **kwargs)
+        job.delete()  # cascades to RecurringJob / OneTimeJob and their per-machine trackers
+        return result
+
+
 class JobScope(models.Model):
     # Shared by the scheduling models: WHICH configuration + machines a job is delivered to.
     configuration = models.ForeignKey(Configuration, on_delete=models.CASCADE)
@@ -702,9 +817,11 @@ def resolve_machine_schedules(configuration, serial_number, schedule_pks):
         return {}
 
     # the results path scores compliance from definition.compliance_check, so prefetch it here to keep
-    # ingest O(1) in the batch size (no per-result SELECT to dereference the check)
-    related = ("job__script__tag", "job__script__compliance_check",
-               "job__mscp_check", "job__mscp_check__compliance_check")
+    # ingest O(1) in the batch size (no per-result SELECT to dereference the check). A command carries
+    # neither a tag nor a check, so DEFINITION_RELATIONS covers it with nothing extra.
+    related = (*(f"job__{relation}" for relation in Job.DEFINITION_RELATIONS),
+               "job__script__tag", "job__script__compliance_check",
+               "job__mscp_check__compliance_check")
     pks = list(valid.values())
     recurring_jobs = {
         rj.pk: rj

--- a/zentral/contrib/turbo/pbac.py
+++ b/zentral/contrib/turbo/pbac.py
@@ -1,0 +1,85 @@
+import logging
+
+from django.core.exceptions import PermissionDenied
+from pbac.engine import ActionGroupBasename, engine
+from pbac.entities import Namespace, Principal, Request
+from pbac.types import SERVICE_ACCOUNT, SYSTEM, USER, AppliesTo, AttrSpec
+
+from zentral.contrib.inventory.pbac import MACHINE_RESOURCE_TYPE, get_meta_machine_resource
+
+
+logger = logging.getLogger("zentral.contrib.turbo.pbac")
+
+
+# namespace
+
+
+NAMESPACE_ID = "Turbo"
+
+
+def get_namespace() -> Namespace:
+    return engine.get_namespace(NAMESPACE_ID)
+
+
+# actions
+#
+# The plain CRUD of a Command stays on the legacy-perm path: it is a global definition object with its
+# own list page and no container, so there is nothing to scope by. `createCommand` in particular must
+# NOT carry the backend in its context — the console's create button reaches it through the legacy path
+# with an empty context, a policy reading context.backend would error there, an erroring policy is
+# skipped, and the button would vanish for exactly the users the policy grants.
+#
+# Scheduling is different: it names a machine and a kind, both known when the decision is made. That is
+# what lets a policy say "may collect a sysdiagnose here, may not run a file_export anywhere" — which one
+# turbo.add_onetimejob cannot express, since it covers both identically.
+
+_SCHEDULE_COMMAND_APPLIES_TO = AppliesTo(
+    principals=(USER, SERVICE_ACCOUNT),
+    # Machine on the machine page, System on the configuration page. The configuration-page flow has no
+    # machine to name — only a scope expression (tags and serial arrays, whose membership changes after
+    # the schedule is written) — so a policy keyed on the machine or its MBU holds on one path and does
+    # not apply on the other. This action is therefore an ADDITIONAL gate rather than a replacement for
+    # turbo.add_onetimejob: replacing the perm would make the configuration path look covered.
+    resources=(MACHINE_RESOURCE_TYPE, SYSTEM),
+    context={
+        "backend": AttrSpec(str, required=False),
+        "mode": AttrSpec(str, required=False),
+    },
+)
+
+
+schedule_command_action = engine.register_action(
+    "scheduleCommand",
+    get_namespace(),
+    [ActionGroupBasename.ADMIN, ActionGroupBasename.USER],
+    applies_to=_SCHEDULE_COMMAND_APPLIES_TO,
+)
+
+
+# requests
+
+
+class ScheduleCommandRequest(Request):
+    def __init__(self, user_obj, command, mode, machine=None) -> None:
+        resource = get_meta_machine_resource(machine) if machine is not None else engine.system_any_resource
+        super().__init__(
+            Principal.from_user(user_obj),
+            schedule_command_action,
+            resource,
+            # mode is "one_time" on every request today, since allowed_modes keeps a command off a
+            # recurring schedule. It is here because it is free and known, and because it is what would
+            # let "no recurring collection" be policy rather than code if that ever relaxes.
+            {"backend": command.backend, "mode": str(mode)},
+        )
+
+
+def check_schedule_command(request, job, mode, machine=None):
+    # no-op for a Script or an MSCPCheck: only a command kind carries a backend worth policing, and
+    # gating the others here would change authorization for every shipped deployment
+    if not job.is_command:
+        return
+    pbac_request = ScheduleCommandRequest(request.user, job.command, mode, machine)
+    engine.authorize_request(pbac_request)
+    if not pbac_request.is_authorized:
+        logger.error("Permission denied %s", pbac_request, extra={"request": request})
+        raise PermissionDenied

--- a/zentral/contrib/turbo/public_views/config.py
+++ b/zentral/contrib/turbo/public_views/config.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse
 from django.utils import timezone
 
 from zentral.contrib.inventory.models import MachineTag
-from ..models import OneTimeJob, OneTimeJobMachine, RecurringJob
+from ..models import Job, OneTimeJob, OneTimeJobMachine, RecurringJob
 from .base import BaseEnrolledMachineView
 
 logger = logging.getLogger("zentral.contrib.turbo.public_views.config")
@@ -14,10 +14,17 @@ logger = logging.getLogger("zentral.contrib.turbo.public_views.config")
 class ConfigView(BaseEnrolledMachineView):
     request_type = "config"
 
-    @staticmethod
-    def _wire(job, schedule):
+    def _wire(self, job, schedule):
+        # a kind this release does not know has no definition to serve — during a rolling deploy an
+        # older instance can read a row a newer one wrote. Skip it instead of dereferencing None, or
+        # every machine holding that job gets a 500 here until the refresh finishes.
+        definition = job.definition
+        if definition is None:
+            logger.error("Turbo config for %s: unknown job kind %r, skipping job %s",
+                         self.serial_number, job.kind, job.pk)
+            return None
         return {"kind": job.kind, "pk": str(job.pk), "version": job.version,
-                "schedule": schedule, "payload": job.definition.wire_payload()}
+                "schedule": schedule, "payload": definition.wire_payload()}
 
     def get(self, request, *args, **kwargs):
         configuration = self.configuration
@@ -28,13 +35,15 @@ class ConfigView(BaseEnrolledMachineView):
         # recurring — every in-scope RecurringJob; null interval falls back to the configuration default
         recurring_jobs = (
             RecurringJob.in_scope(configuration, serial_number, tag_ids)
-            .select_related("job__script", "job__mscp_check")
+            .select_related(*Job.definition_relations("job__"))
         )
         for recurring_job in recurring_jobs:
             job = recurring_job.job
             interval = recurring_job.interval or configuration.default_check_interval
             schedule = {"mode": recurring_job.wire_mode, "pk": str(recurring_job.pk), "interval": interval}
-            jobs.append(self._wire(job, schedule))
+            wired = self._wire(job, schedule)
+            if wired is not None:
+                jobs.append(wired)
 
         # one-time — in-scope and within the [not_before, not_after] window; keep serving until a result
         # comes back (last_result_at set). The OneTimeJob pk is the wire handle, so nothing is minted here.
@@ -43,7 +52,7 @@ class ConfigView(BaseEnrolledMachineView):
             OneTimeJob.in_scope(configuration, serial_number, tag_ids)
             .filter(Q(not_before__isnull=True) | Q(not_before__lte=now))
             .filter(Q(not_after__isnull=True) | Q(not_after__gte=now))
-            .select_related("job__script", "job__mscp_check")
+            .select_related(*Job.definition_relations("job__"))
         )
         done = set(
             OneTimeJobMachine.objects
@@ -56,7 +65,9 @@ class ConfigView(BaseEnrolledMachineView):
                 continue
             job = one_time_job.job
             schedule = {"mode": one_time_job.wire_mode, "pk": str(one_time_job.pk)}
-            jobs.append(self._wire(job, schedule))
+            wired = self._wire(job, schedule)
+            if wired is not None:
+                jobs.append(wired)
 
         return JsonResponse({"config_refresh_interval": configuration.config_refresh_interval,
                              "results_batch_size": configuration.results_batch_size,

--- a/zentral/contrib/turbo/serializers.py
+++ b/zentral/contrib/turbo/serializers.py
@@ -5,8 +5,10 @@ from zentral.conf import api_base_url
 from zentral.contrib.inventory.models import EnrollmentSecret
 from zentral.contrib.inventory.serializers import EnrollmentSecretSerializer
 
+from .command_backends import CommandBackend, get_command_backend_class
 from .compliance_checks import sync_mscp_check_compliance_check, sync_script_compliance_check
-from .models import Configuration, Enrollment, MSCPCheck, OneTimeJob, RecurringJob, Script
+from .models import (Command, Configuration, Enrollment, Job, MSCPCheck, OneTimeJob, RecurringJob,
+                     ScheduleMode, Script)
 
 
 class ConfigurationSerializer(serializers.ModelSerializer):
@@ -153,6 +155,66 @@ class MSCPCheckSerializer(serializers.ModelSerializer):
         return instance
 
 
+class CommandSerializer(serializers.ModelSerializer):
+    # one <backend>_kwargs field per backend, the stores / probes shape: the sub-serializer is the
+    # backend's own, so the API, the console and a future TF schema all derive from one declaration
+    sysdiagnose_kwargs = get_command_backend_class(CommandBackend.SYSDIAGNOSE).kwargs_serializer(
+        source="get_sysdiagnose_kwargs", required=False, allow_null=True)
+    file_export_kwargs = get_command_backend_class(CommandBackend.FILE_EXPORT).kwargs_serializer(
+        source="get_file_export_kwargs", required=False, allow_null=True)
+    version = serializers.IntegerField(source="job.version", read_only=True)
+    job_id = serializers.UUIDField(read_only=True)
+
+    class Meta:
+        model = Command
+        fields = ("id", "backend", "name", "description",
+                  "sysdiagnose_kwargs", "file_export_kwargs",
+                  "version", "job_id", "created_at", "updated_at")
+
+    def validate(self, data):
+        data = super().validate(data)
+        backend = data.get("backend")
+        # the backend is the kind, and the kind is half the wire identity of this definition: changing it
+        # would change what the agent runs under a stable pk and version. A different behaviour is a
+        # different command.
+        if self.instance is not None:
+            if backend is not None and backend != self.instance.backend:
+                raise serializers.ValidationError({"backend": "This field cannot be changed"})
+            backend = self.instance.backend
+        kwargs_field = f"{backend.lower()}_kwargs"
+        data["backend_kwargs"] = kwargs = data.pop(f"get_{backend.lower()}_kwargs", None)
+        # a zero-config kind has nothing to send, so an absent block is the normal case for it; a kind
+        # with options must carry them
+        if not kwargs and get_command_backend_class(backend).kwargs_serializer().fields:
+            raise serializers.ValidationError({kwargs_field: "This field is required."})
+        data["backend_kwargs"] = kwargs or {}
+        for key in list(data):
+            if key.startswith("get_") and key.endswith("_kwargs"):
+                data.pop(key)
+        return data
+
+    def create(self, validated_data):
+        backend_kwargs = validated_data.pop("backend_kwargs")
+        command = Command.objects.create(**validated_data)   # mints the Job with kind == backend
+        command.set_backend_kwargs(backend_kwargs)
+        command.save()
+        return command
+
+    def update(self, instance, validated_data):
+        backend_kwargs = validated_data.pop("backend_kwargs")
+        # the version lives on the Job and drives a re-run, so it moves when what the agent would do
+        # moves — a rename or a new description is not that
+        bump = backend_kwargs != instance.get_backend_kwargs()
+        validated_data.pop("backend", None)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.set_backend_kwargs(backend_kwargs)
+        instance.save()
+        if bump:
+            instance.job.bump_version()
+        return instance
+
+
 class JobScopeSerializerMixin:
     def _scope_conflicts(self, data):
         def current(field, many):
@@ -192,6 +254,16 @@ class RecurringJobSerializer(JobScopeSerializerMixin, serializers.ModelSerialize
         fields = ("id", "configuration", "job", "interval",
                   "tags", "excluded_tags", "serial_numbers", "excluded_serial_numbers",
                   "created_at", "updated_at")
+
+    def validate(self, data):
+        data = super().validate(data)
+        # a kind that declares itself one-time only cannot be attached to a recurring schedule. The GUI
+        # narrows its choices instead; the API has to say so.
+        job = data.get("job") or getattr(self.instance, "job", None)
+        if job is not None and ScheduleMode.RECURRING not in Job.allowed_schedule_modes(job.kind):
+            raise serializers.ValidationError(
+                {"job": f"A {job.get_kind_display()} job cannot be scheduled to run repeatedly"})
+        return data
 
 
 class OneTimeJobSerializer(JobScopeSerializerMixin, serializers.ModelSerializer):

--- a/zentral/contrib/turbo/templates/turbo/command_detail.html
+++ b/zentral/contrib/turbo/templates/turbo/command_detail.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% load ui_extras %}
+
+{% block content %}
+<ol class="breadcrumb">
+  <li class="breadcrumb-item"><a href="/">Home</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'turbo:index' %}">Turbo</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'turbo:commands' %}">Commands</a></li>
+  <li class="breadcrumb-item active">{{ object }}</li>
+</ol>
+
+<div class="object-details">
+    <div class="d-flex align-items-center mb-3">
+        <h2 class="m-0">{{ object }}</h2>
+    </div>
+
+    <div class="table-responsive mb-3">
+    <table class="table-object-properties table-fixed-scrolleable">
+    <thead>
+        <th style="width:30vw">Attribute</th>
+        <th>Value</th>
+    </thead>
+    <tbody>
+        <tr><td>Name</td><td>{{ object.name }}</td></tr>
+        <tr><td>Description</td><td>{{ object.description|default:"-"|linebreaksbr }}</td></tr>
+        <tr><td>Kind</td><td>{{ object.get_backend_display }}</td></tr>
+        <tr><td>Version</td><td>{{ object.job.version }}</td></tr>
+        {% for key, value in backend_kwargs %}
+        <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
+        {% endfor %}
+        <tr>
+            <td>Artifact{{ artifacts|length|pluralize }}</td>
+            <td>
+                {% for artifact in artifacts %}
+                {{ artifact.name }} ({{ artifact.extension }}){% if artifact.optional %} — optional{% endif %}<br>
+                {% endfor %}
+            </td>
+        </tr>
+    </tbody>
+    </table>
+    </div>
+
+    {% created_updated_at object %}
+
+    {% include "turbo/_object_jobs.html" %}
+
+</div>
+{% endblock %}

--- a/zentral/contrib/turbo/templates/turbo/command_list.html
+++ b/zentral/contrib/turbo/templates/turbo/command_list.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+{% load ui_extras %}
+
+{% block content %}
+<ol class="breadcrumb">
+  <li class="breadcrumb-item"><a href="/">Home</a></li>
+  <li class="breadcrumb-item"><a href="{% url 'turbo:index' %}">Turbo</a></li>
+  {% if form.has_changed %}
+  <li class="breadcrumb-item"><a href="{% url 'turbo:commands' %}">Commands</a></li>
+  {% if reset_link %}
+  <li class="breadcrumb-item"><a href="{{ reset_link }}">Search</a></li>
+  {% else %}
+  <li class="breadcrumb-item active">Search</li>
+  {% endif %}
+  {% else %}
+  {% if reset_link %}
+  <li class="breadcrumb-item"><a href="{{ reset_link }}">Commands</a></li>
+  {% else %}
+  <li class="breadcrumb-item active">Commands</li>
+  {% endif %}
+  {% endif %}
+  <li class="breadcrumb-item active">page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</li>
+</ol>
+
+<div class="d-flex align-items-center mb-1">
+    <h2 class="m-0">Command{{ page_obj.paginator.count|pluralize }} ({{ page_obj.paginator.count }})</h2>
+</div>
+
+<div class="d-flex flex-wrap align-items-center mb-1">
+    <form method="GET" class="search-form">
+        {{ form }}
+        <button type="submit" class="btn btn-link mx-2"><i class="bi bi-search"></i></button>
+    </form>
+</div>
+
+{% if object_list %}
+{% pagination next_url previous_url %}
+<table class="table table-striped align-middle table-hover">
+<thead>
+    <th>Name</th>
+    <th>Kind</th>
+    <th>Version</th>
+</thead>
+<tbody>
+    {% for command in object_list %}
+    <tr class="data-row">
+    <td><a href="{{ command.get_absolute_url }}">{{ command }}</a></td>
+    <td>{{ command.get_backend_display }}</td>
+    <td>{{ command.job.version }}</td>
+    </tr>
+    {% endfor %}
+</tbody>
+</table>
+{% pagination next_url previous_url %}
+{% elif form.has_changed %}
+    {% url 'turbo:commands' as empty_results_url %}
+    {% empty_results empty_results_url %}
+{% else %}
+    {% no_entities 'Turbo commands' %}
+{% endif %}
+
+{% endblock %}

--- a/zentral/contrib/turbo/urls.py
+++ b/zentral/contrib/turbo/urls.py
@@ -30,6 +30,11 @@ urlpatterns = [
     path('enrolled_machines/<str:urlsafe_serial_number>/schedule/',
          views.ScheduleMachineOneTimeJobView.as_view(), name='schedule_machine_one_time_job'),
 
+    # command — no create/update/delete: a command is defined through the API, like a store or a probe
+    # action. The detail page is what every definition link needs.
+    path('commands/', views.CommandListView.as_view(), name='commands'),
+    path('commands/<uuid:pk>/', views.CommandView.as_view(), name='command'),
+
     # script
     path('scripts/', views.ScriptListView.as_view(), name='scripts'),
     path('scripts/create/', views.CreateScriptView.as_view(), name='create_script'),
@@ -71,6 +76,7 @@ modules_menu_cfg = {
         ('enrolled_machines', 'Enrolled machines', False, ('turbo.view_enrolledmachine',)),
         ('scripts', 'Scripts', False, ('turbo.view_script',)),
         ('mscp_checks', 'mSCP checks', False, ('turbo.view_mscpcheck',)),
+        ('commands', 'Commands', False, ('turbo.view_command',)),
         ('recurring_jobs', 'Recurring jobs', False, ('turbo.view_recurringjob',)),
         ('one_time_jobs', 'One-time jobs', False, ('turbo.view_onetimejob',)),
     ),

--- a/zentral/contrib/turbo/views/__init__.py
+++ b/zentral/contrib/turbo/views/__init__.py
@@ -1,3 +1,4 @@
+from .commands import *  # NOQA
 from .configurations import *  # NOQA
 from .enrolled_machines import *  # NOQA
 from .enrollments import *  # NOQA

--- a/zentral/contrib/turbo/views/commands.py
+++ b/zentral/contrib/turbo/views/commands.py
@@ -1,0 +1,33 @@
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.views.generic import DetailView
+from ..forms import CommandSearchForm
+from ..models import Command
+from .base import JobDetailMixin, SearchFormListView
+
+
+# read-only in the console, like the other two BackendInstance consumers (stores.Store and
+# probes.Action): a command is defined through the API, where the per-backend kwargs serializer already
+# validates it. The detail page exists because onetimejob_list.html links every definition's
+# get_absolute_url, and because it is where the schedules running a command are listed.
+
+
+class CommandListView(SearchFormListView):
+    permission_required = "turbo.view_command"
+    model = Command
+    search_form_class = CommandSearchForm
+
+
+class CommandView(PermissionRequiredMixin, JobDetailMixin, DetailView):
+    permission_required = "turbo.view_command"
+
+    def get_queryset(self):
+        return Command.objects.select_related("job")
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        backend = self.object.get_backend(load=True)
+        # rendered as a table of key/value pairs rather than per-backend markup: the kwargs are a small
+        # options dict by definition, and the shape is the backend's business
+        ctx["backend_kwargs"] = sorted(self.object.get_backend_kwargs_for_event().items())
+        ctx["artifacts"] = backend.artifacts
+        return ctx

--- a/zentral/contrib/turbo/views/configurations.py
+++ b/zentral/contrib/turbo/views/configurations.py
@@ -6,7 +6,7 @@ from django.views.generic import DetailView
 from zentral.utils.views import (CreateViewWithAudit, DeleteViewWithAudit, UpdateViewWithAudit,
                                  UserPaginationListView)
 from ..forms import ConfigurationForm
-from ..models import Configuration
+from ..models import Configuration, Job
 
 
 class ConfigurationListView(PermissionRequiredMixin, UserPaginationListView):
@@ -51,7 +51,7 @@ class ConfigurationView(PermissionRequiredMixin, DetailView):
             ctx["enrollment_count"] = enrollment_count
         recurring_jobs = (
             self.object.recurringjob_set
-            .select_related("job__script", "job__mscp_check")
+            .select_related(*Job.definition_relations("job__"))
             .prefetch_related("tags", "excluded_tags")
             .annotate(job_name=Coalesce("job__script__name", "job__mscp_check__rule_id",
                                         output_field=TextField()))
@@ -62,7 +62,7 @@ class ConfigurationView(PermissionRequiredMixin, DetailView):
         ctx["recurring_job_count"] = len(recurring_jobs)
         one_time_job_qs = (
             self.object.onetimejob_set
-            .select_related("job__script", "job__mscp_check")
+            .select_related(*Job.definition_relations("job__"))
             .prefetch_related("tags", "excluded_tags")
             .order_by(F("not_before").desc(nulls_last=True), "-created_at")
         )

--- a/zentral/contrib/turbo/views/enrolled_machines.py
+++ b/zentral/contrib/turbo/views/enrolled_machines.py
@@ -6,7 +6,9 @@ from django.views.generic import TemplateView
 from zentral.contrib.inventory.models import MetaMachine
 from zentral.utils.views import CreateViewWithAudit
 from ..forms import EnrolledMachineSearchForm, MachineOneTimeJobForm
-from ..models import EnrolledMachine, Job, OneTimeJob, OneTimeJobMachine, RecurringJobMachine
+from ..models import (EnrolledMachine, Job, OneTimeJob, OneTimeJobMachine, RecurringJobMachine,
+                      ScheduleMode)
+from ..pbac import check_schedule_command
 from .base import SearchFormListView
 
 
@@ -46,13 +48,13 @@ class EnrolledMachineDetailView(PermissionRequiredMixin, TemplateView):
         one_time = (
             OneTimeJobMachine.objects
             .filter(serial_number=serial_number)
-            .select_related("one_time_job__job__script", "one_time_job__job__mscp_check")
+            .select_related(*Job.definition_relations("one_time_job__job__"))
             .order_by(*order)
         )
         recurring = (
             RecurringJobMachine.objects
             .filter(serial_number=serial_number)
-            .select_related("recurring_job__job__script", "recurring_job__job__mscp_check")
+            .select_related(*Job.definition_relations("recurring_job__job__"))
             .order_by(*order)
         )
         kind = self.request.GET.get("kind") or ""
@@ -99,6 +101,13 @@ class ScheduleMachineOneTimeJobView(PermissionRequiredMixin, CreateViewWithAudit
         ctx["urlsafe_serial_number"] = MetaMachine.make_urlsafe_serial_number(self.serial_number)
         ctx["configuration"] = self.configuration
         return ctx
+
+    def form_valid(self, form):
+        # the kind is only known once the form validates, so this cannot ride a dispatch-time mixin.
+        # This flow has the machine, so the policy can scope the collection by its MBUs.
+        check_schedule_command(self.request, form.cleaned_data["job"], ScheduleMode.ONE_TIME,
+                               MetaMachine(self.serial_number))
+        return super().form_valid(form)
 
     def get_success_url(self):
         return reverse("turbo:enrolled_machine",

--- a/zentral/contrib/turbo/views/one_time_jobs.py
+++ b/zentral/contrib/turbo/views/one_time_jobs.py
@@ -1,5 +1,6 @@
 from ..forms import OneTimeJobForm, OneTimeJobSearchForm
-from ..models import OneTimeJob
+from ..models import OneTimeJob, ScheduleMode
+from ..pbac import check_schedule_command
 from .base import (BaseCreateConfigurationScopedJobView, BaseDeleteConfigurationScopedJobView,
                    BaseUpdateConfigurationScopedJobView, SearchFormListView)
 
@@ -15,6 +16,13 @@ class CreateOneTimeJobView(BaseCreateConfigurationScopedJobView):
     model = OneTimeJob
     form_class = OneTimeJobForm
     anchor = "one-time-jobs"
+
+    def form_valid(self, form):
+        # no machine here: this flow targets a scope expression (tags and serial arrays), so a policy
+        # keyed on a machine or an MBU cannot apply. The kind is still policeable, which is why the
+        # action is an additional gate rather than a replacement for turbo.add_onetimejob.
+        check_schedule_command(self.request, form.cleaned_data["job"], ScheduleMode.ONE_TIME)
+        return super().form_valid(form)
 
 
 class UpdateOneTimeJobView(BaseUpdateConfigurationScopedJobView):


### PR DESCRIPTION
A command collects something from a machine instead of producing a verdict. Two kinds land with it: sysdiagnose, which takes no options, and file_export, which takes a list of absolute path patterns and an uncompressed max_size.

One Command model on BackendInstance with a backend registry, not one model per kind. Script and MSCPCheck each earn a table because Postgres enforces their identity — FKs with DB semantics, typed ODV columns and their constraints. A command has neither: its variation is agent behaviour, which is Python. That is the split stores.Store and probes.Action already use, and a command that grows an FK graduates to its own definition model under the same Job anchor.

Job.kind grows one value per backend, flat, so a new command is a config change for an agent rather than a protocol change: an agent already drops a kind it does not know, element by element. Job.definition returns None for a kind the release does not know, and the config endpoint skips such a job instead of dereferencing it — during a rolling deploy an older instance can read a row a newer one wrote, and every machine holding that job would otherwise get a 500. Job.definition_relations() replaces the eleven select_related sites that listed the definition relations by hand.

A command runs one time only. A backend declares its allowed_modes, the recurring form narrows its job choices to the kinds that accept a recurring schedule, and the recurring serializer says so. A recurring collection is a log shipper, not a job.

A backend also declares the artifacts a run produces — name, filename stem, extension, content type, and whether it is optional. file_export declares two: a required manifest of what was collected, and an optional archive, absent when a run matched nothing. The declaration is the server's, never the agent's.

The console is read-only for commands, like it is for stores and probe actions: the API validates the per-backend options, and the detail page exists because every job list links a definition's get_absolute_url.

New Turbo::Action::"scheduleCommand", the first typed PBAC action in the module. It carries the kind and, on the machine flow, the machine — so a policy can permit a sysdiagnose and refuse a file_export, which one turbo.add_onetimejob cannot express. It is an additional gate rather than a replacement: the configuration flow targets a scope expression with no machine to name, so a machine-keyed policy applies to one path and not the other, and replacing the permission would make that path look covered. The plain CRUD actions stay on the legacy-perm path, where the console gates its buttons.