### PR TITLE
turbo: does the storage agree? the second axis of an upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,13 @@ When the storage backend is S3, the agent sends the file directly to the bucket 
 
 The configuration payload publishes `upload_max_size` and `upload_digests` now, so the agent can refuse a file that is too large before it collects it, and read the file one time to compute every digest.
 
-The result of a run that collects files carries a `run.id`, and one `result.uploads` entry for each artifact. The entry reports the upload, or the reason it failed. Zentral compares the key the agent echoes with the key it built, and refuses an echo that does not match. Partial success is a normal outcome: a `file_export` that sends its manifest and fails on its archive keeps the manifest. The report of the agent is the first axis; the verification against the storage is a second axis, and it comes later.
+The result of a run that collects files carries a `run.id`, and one `result.uploads` entry for each artifact. The entry reports the upload, or the reason it failed. Zentral compares the key the agent echoes with the key it built, and refuses an echo that does not match. Partial success is a normal outcome: a `file_export` that sends its manifest and fails on its archive keeps the manifest. The report of the agent is the first axis; whether the storage agrees is a second axis.
+
+Zentral verifies the upload. It compares the size and the SHA-256 of the stored object with the ones the agent declared when it asked for the destination. Those values were signed into the upload, so the storage refused any body that did not match them, and they came back a second time in the result: verification is where the two copies meet, and on a storage that signs, Zentral reads no part of the file to do it. Where the storage keeps no digest of its own, Zentral reads the object and hashes it, which is affordable because that is the storage with the low size limit. A result that echoes a size or a digest which is not the one it asked for is a mismatch too, whatever is at the key.
+
+The upload carries the outcome next to its status, and each `result.uploads` entry of the result event carries it too, as `verification`: `verified`, `mismatch` when something else is at the key, or `missing` when nothing is. A storage that times out, a key the deployment cannot read, and an object with no stored digest all leave the verification `pending` with a log entry, and no `verification` on the event: recording a transient failure as `missing` would make the row say for ever that a file which is very probably there is gone. A bucket policy without `s3:ListBucket` makes S3 answer 403 for a key that does not exist, so such a deployment never sees `missing` — the upload stays `pending`.
+
+Verification never reopens a one-time job. The job was done on that machine when the agent reported, whatever the storage says afterwards.
 
 
 ### Backward incompatibilities

--- a/docs/apps/turbo.md
+++ b/docs/apps/turbo.md
@@ -389,7 +389,32 @@ The result closes the upload. It carries a `run.id`, and one entry in `result.up
 
 Partial success is a normal outcome. A `file_export` that sends its manifest and fails on its archive keeps the manifest: the two artifacts are two rows, and they close one at a time.
 
-The agent's report is the first axis, and Zentral records it immediately. Verification against the storage is a second axis, and it comes later. Verification never reopens a one-time job: a one-time job that reported an upload does not get another destination.
+The agent's report is the first axis, and Zentral records it immediately. Whether the storage agrees is a second axis.
+
+#### Verification
+
+When the agent reports an upload, Zentral compares the size and the SHA-256 of the stored object with the ones the agent declared when it asked for the destination.
+
+Those two numbers reach the comparison by two independent paths. They went out at the request for a destination and were signed into the upload, so the storage refused any body that did not match them, and they come back as the checksum the storage recorded. They also come home a second time in the result. Verification is where the two copies meet, and on a storage that signs, Zentral reads no part of the file to do it. Where the storage records no digest of its own, Zentral reads the object and hashes it — which is affordable because that is the same storage that has the low size limit.
+
+Zentral checks both paths. A result that echoes a size or a digest which is not the one it asked for is a `mismatch`, whatever is at the key: an agent that requests a destination for one file and reports another has described two files, and only one of them was stored. Echoing them at all is optional — the request for the destination is what was signed either way.
+
+The outcome is a separate field on the upload, next to the status:
+
+|Verification|Meaning|
+|---|---|
+|`pending`|Not decided yet.|
+|`verified`|The stored object is the size and the SHA-256 the agent declared.|
+|`mismatch`|Something is at the key and it is not what the agent declared, or the result contradicts the request for the destination.|
+|`missing`|There is nothing at the key.|
+
+The outcome rides the result event as well, as `verification` on the `result.uploads` entry. It is the outcome itself and not a yes or no, because `mismatch` and `missing` are different problems and a consumer of the event cannot go to the database to tell them apart.
+
+Some answers are not answers, and Zentral records none of them. A storage that times out, a key the deployment cannot read, or an object with no stored digest all leave the verification `pending`, with a log entry, and put no `verification` on the event. Recording a transient failure as `missing` would be worse than recording nothing: the object is very likely there, and the row would say for ever that it is not.
+
+Give Zentral `s3:ListBucket` on the bucket. Without it S3 answers 403 rather than 404 for a key that does not exist, and Zentral cannot tell a missing object from one it may not read: the upload stays `pending`, and every result for it writes an error to the log.
+
+**Verification never reopens a one-time job.** That is what the two axes are for: the job was done on that machine when the agent reported, whatever the storage says afterwards. A `mismatch` does not give the agent another destination, and it does not make Zentral ask for the file again.
 
 ### Tolerant batches
 
@@ -1982,6 +2007,8 @@ Each entry in `result.uploads` reports one artifact, and it is what closes that 
 |`error`|Present instead of `key` when the artifact did not go up. `error.reason` is one of `expired`, `http_status`, `network`, `too_large` or `mint_rejected`; `error.attempts` and `error.last_http_status` are informational. A reason this release does not know still closes the upload as failed – the artifact is not coming either way.|
 
 An entry that reports an artifact Zentral never minted a destination for is logged and ignored. It never fails the batch: the run happened, and its result is worth keeping.
+
+The `turbo_result` event carries the entries back, each with a `verification` added when [verification](#verification) reached an answer. The event also carries `run.id`, which is what an upload is keyed on.
 
 Response:
 

--- a/tests/turbo/test_public_uploads.py
+++ b/tests/turbo/test_public_uploads.py
@@ -4,14 +4,16 @@ import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.core.files.base import ContentFile
 from django.core.files.storage import storages
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from zentral.contrib.turbo.command_backends import CommandBackend
-from zentral.contrib.turbo.events import TurboRequestEvent
-from zentral.contrib.turbo.models import Job, JobUpload, OneTimeJobMachine, UploadStatus
+from zentral.contrib.turbo.events import TurboRequestEvent, TurboResultEvent
+from zentral.contrib.turbo.models import (Job, JobUpload, OneTimeJobMachine, UploadStatus,
+                                          UploadVerification)
 from zentral.contrib.turbo.uploads import (MAX_PENDING_UPLOADS, MAX_UPLOAD_ATTEMPTS,
                                            sign_hosted_upload)
 
@@ -710,6 +712,246 @@ class TurboUploadConfigTestCase(TurboPublicTestCase):
         self.assertEqual(response.json(), {"error": "too_large"})
 
 
+class TurboUploadVerificationTestCase(TurboPublicTestCase):
+    """The second axis: does the storage agree with what the agent reported?
+
+    The test storage cannot presign an upload, so nothing signed these bodies on the way in and the
+    verifier reads the object to hash it — the fallback branch, end to end, with no mocking.
+    """
+
+    def _results(self, token, body):
+        return self.client.post(
+            reverse("turbo_public:results"),
+            data=json.dumps(body),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"TurboEnrolledMachine {token}",
+        )
+
+    def _minted(self, body=b"yolo", artifact="archive"):
+        """A run that asked for a destination, with `body` optionally already at the key."""
+        configuration = force_configuration()
+        _, serial_number, token = force_enrolled_machine(configuration=configuration,
+                                                         meta_business_unit=self.mbu)
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job,
+                                          serial_numbers=[serial_number])
+        run_id = uuid.uuid4()
+        minted = self.client.post(
+            reverse("turbo_public:uploads"),
+            data=json.dumps({"schedule_pk": str(one_time_job.pk), "run_id": str(run_id),
+                             "artifact": artifact, "size": len(body),
+                             "sha256": hashlib.sha256(body).hexdigest()}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"TurboEnrolledMachine {token}",
+        ).json()
+        return token, one_time_job, run_id, minted
+
+    def _store(self, key, body):
+        storage = storages["default"]
+        storage.save(key, ContentFile(body))
+        self.addCleanup(storage.delete, key)
+
+    @staticmethod
+    def _result(one_time_job, run_id, uploads):
+        return {"results": [{"kind": one_time_job.job.kind, "pk": str(one_time_job.job.pk),
+                             "version": one_time_job.job.version,
+                             "run": {"at": "2026-09-03T10:00:00Z", "duration": 1.0,
+                                     "schedule_pk": str(one_time_job.pk), "id": str(run_id),
+                                     "mode": "one_time"},
+                             "result": {"exit_code": 0, "uploads": uploads}}]}
+
+    def _report(self, token, one_time_job, run_id, minted, body=b"yolo"):
+        return self._results(token, self._result(one_time_job, run_id, [
+            {"artifact": "archive", "key": minted["key"], "size": len(body),
+             "sha256": hashlib.sha256(body).hexdigest()}]))
+
+    @staticmethod
+    def _result_event(post_event):
+        return [c.args[0] for c in post_event.call_args_list
+                if isinstance(c.args[0], TurboResultEvent)][0]
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_an_object_that_matches_is_verified(self, post_event):
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        self._report(token, one_time_job, run_id, minted)
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.verification, UploadVerification.VERIFIED)
+        self.assertIsNotNone(upload.verified_at)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_the_verdict_rides_the_echoed_entry_into_the_event(self, post_event):
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        self._report(token, one_time_job, run_id, minted)
+        event = self._result_event(post_event)
+        entry = event.payload["result"]["uploads"][0]
+        self.assertEqual(entry["verification"], UploadVerification.VERIFIED)
+        # and the key the agent echoed is still there, next to the verdict
+        self.assertEqual(entry["key"], minted["key"])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_the_run_id_rides_the_event(self, post_event):
+        # what an upload row is keyed on: without it the event describes an artifact nothing can find
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        self._report(token, one_time_job, run_id, minted)
+        event = self._result_event(post_event)
+        self.assertEqual(event.payload["run"]["id"], str(run_id))
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_missing_object_is_missing(self, post_event):
+        token, one_time_job, run_id, minted = self._minted()
+        self._report(token, one_time_job, run_id, minted)
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.verification, UploadVerification.MISSING)
+        # the verdict, not a boolean: a consumer can tell this apart from a mismatch
+        entry = self._result_event(post_event).payload["result"]["uploads"][0]
+        self.assertEqual(entry["verification"], UploadVerification.MISSING)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_different_size_is_a_mismatch(self, post_event):
+        # the size was signed into the destination, so a storage that can sign would have refused
+        # this body — the check earns its keep on the storage that cannot
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo-and-then-some")
+        self._report(token, one_time_job, run_id, minted)
+        self.assertEqual(JobUpload.objects.get(run_id=run_id).verification,
+                         UploadVerification.MISMATCH)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_the_same_size_and_different_bytes_is_a_mismatch(self, post_event):
+        # the size check alone would pass this one
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"nope")
+        self._report(token, one_time_job, run_id, minted)
+        self.assertEqual(JobUpload.objects.get(run_id=run_id).verification,
+                         UploadVerification.MISMATCH)
+        # and the event says which "no" it is: something is at the key, it is the wrong thing
+        entry = self._result_event(post_event).payload["result"]["uploads"][0]
+        self.assertEqual(entry["verification"], UploadVerification.MISMATCH)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_report_that_contradicts_its_own_mint_is_a_mismatch(self, post_event):
+        # the second leg. The object at the key is exactly what the mint signed, so comparing the
+        # storage against the mint alone would pass — but the agent asked for a destination for one
+        # file and reported another, and only one of the two is there.
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        with self.assertLogs("zentral.contrib.turbo.uploads", level="WARNING") as cm:
+            self._results(token, self._result(one_time_job, run_id, [
+                {"artifact": "archive", "key": minted["key"], "size": 4,
+                 "sha256": hashlib.sha256(b"something-else").hexdigest()}]))
+        self.assertIn("contradicts the minted", cm.output[0])
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        self.assertEqual(upload.verification, UploadVerification.MISMATCH)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_reported_size_that_contradicts_the_mint_is_a_mismatch(self, post_event):
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        with self.assertLogs("zentral.contrib.turbo.uploads", level="WARNING"):
+            self._results(token, self._result(one_time_job, run_id, [
+                {"artifact": "archive", "key": minted["key"], "size": 9999,
+                 "sha256": hashlib.sha256(b"yolo").hexdigest()}]))
+        self.assertEqual(JobUpload.objects.get(run_id=run_id).verification,
+                         UploadVerification.MISMATCH)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_report_that_echoes_nothing_but_the_key_still_verifies(self, post_event):
+        # the size and the digest are optional on the way back: the row holds what was signed either
+        # way, so their absence is not a contradiction
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        self._results(token, self._result(one_time_job, run_id, [
+            {"artifact": "archive", "key": minted["key"]}]))
+        self.assertEqual(JobUpload.objects.get(run_id=run_id).verification,
+                         UploadVerification.VERIFIED)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_mismatch_does_not_reopen_the_gate(self, post_event):
+        # the whole point of two axes: the shot was consumed when the agent reported, whatever the
+        # storage says afterwards
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"nope")
+        self._report(token, one_time_job, run_id, minted)
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.verification, UploadVerification.MISMATCH)
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        response = self.client.post(
+            reverse("turbo_public:uploads"),
+            data=json.dumps({"schedule_pk": str(one_time_job.pk), "run_id": str(uuid.uuid4()),
+                             "artifact": "archive", "size": 4, "sha256": SHA256}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"TurboEnrolledMachine {token}",
+        )
+        self.assertEqual(response.status_code, 410)
+        self.assertEqual(response.json(), {"error": "gate_closed"})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_reported_failure_is_never_verified(self, post_event):
+        # there is nothing to ask the storage about, so the axis stays undecided and the entry
+        # carries no verdict
+        token, one_time_job, run_id, minted = self._minted()
+        self._results(token, self._result(one_time_job, run_id, [
+            {"artifact": "archive", "error": {"reason": "network"}}]))
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.status, UploadStatus.FAILED)
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+        self.assertIsNone(upload.verified_at)
+        entry = self._result_event(post_event).payload["result"]["uploads"][0]
+        self.assertNotIn("verification", entry)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_an_object_that_cannot_be_read_leaves_the_row_pending(self, post_event):
+        # the stat said it is there and the right size, and then the read failed. Same reasoning as a
+        # storage that never answered: not an answer, so not recorded.
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        with (patch("zentral.contrib.turbo.uploads.sha256_object",
+                    side_effect=OSError("the disk is having a day")),
+              self.assertLogs("zentral.contrib.turbo.uploads", level="ERROR")):
+            self._report(token, one_time_job, run_id, minted)
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_storage_that_cannot_answer_leaves_the_row_pending(self, post_event):
+        # NOT missing: a transient blip that permanently marked artifacts missing would be worse than
+        # no answer at all. The status is still closed — the agent's word did that.
+        token, one_time_job, run_id, minted = self._minted()
+        self._store(minted["key"], b"yolo")
+        with (patch("zentral.contrib.turbo.uploads.stat_object",
+                    side_effect=Exception("the storage is having a day")),
+              self.assertLogs("zentral.contrib.turbo.uploads", level="ERROR")):
+            self._report(token, one_time_job, run_id, minted)
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+        self.assertIsNone(upload.verified_at)
+        entry = self._result_event(post_event).payload["result"]["uploads"][0]
+        self.assertNotIn("verification", entry)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_signing_storage_with_no_stored_digest_is_undecided(self, post_event):
+        # every object we PUT to a storage that signs carries the checksum we signed, so one that
+        # does not was written by something else. Saying so beats a verdict, and beats reading a
+        # 2 GiB artifact back to hash it.
+        token, one_time_job, run_id, minted = self._minted()
+        with (patch("zentral.contrib.turbo.uploads.file_storage_has_presigned_uploads",
+                    return_value=True),
+              patch("zentral.contrib.turbo.uploads.stat_object",
+                    return_value={"size": 4, "sha256": None, "crc64nvme": None}),
+              self.assertLogs("zentral.contrib.turbo.uploads", level="ERROR") as cm):
+            self._report(token, one_time_job, run_id, minted)
+        self.assertIn("no stored sha256", cm.output[0])
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+
+
 class TurboUploadIngestTestCase(TurboPublicTestCase):
     """The other half of the round trip: result.uploads[] closes the row, on the agent's word.
 
@@ -761,8 +1003,9 @@ class TurboUploadIngestTestCase(TurboPublicTestCase):
         upload = JobUpload.objects.get(run_id=run_id)
         self.assertEqual(upload.status, UploadStatus.UPLOADED)
         self.assertIsNotNone(upload.completed_at)
-        # the second axis is untouched: nothing here asked the storage anything
-        self.assertEqual(upload.verification, "pending")
+        # nothing was ever written at that key, so the second axis says so — and the first one is
+        # unmoved by it
+        self.assertEqual(upload.verification, UploadVerification.MISSING)
 
     @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
     def test_a_reported_failure_closes_the_row_as_failed(self, post_event):

--- a/tests/utils/test_storage.py
+++ b/tests/utils/test_storage.py
@@ -2,10 +2,14 @@ import base64
 import hashlib
 from urllib.parse import parse_qs, urlparse
 
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+from django.core.files.base import ContentFile
 from django.core.files.storage import storages
-from django.test import SimpleTestCase, override_settings
-from zentral.utils.storage import (file_storage_has_presigned_uploads, file_storage_has_signed_urls,
-                                   generate_presigned_put, select_dist_storage)
+from django.test import SimpleTestCase, TestCase, override_settings
+from zentral.utils.storage import (_stat_client, file_storage_has_presigned_uploads,
+                                   file_storage_has_signed_urls, generate_presigned_put,
+                                   select_dist_storage, sha256_object, stat_object)
 
 
 S3_STORAGE = {"default": {"BACKEND": "storages.backends.s3.S3Storage",
@@ -99,3 +103,123 @@ class PresignedUploadTestCase(SimpleTestCase):
         with self.assertRaises(ValueError) as cm:
             generate_presigned_put("turbo/uploads/test", 4, "application/gzip", "yolo", 900)
         self.assertEqual(cm.exception.args[0], "Not a hex sha256: 'yolo'")
+
+
+class StatObjectS3TestCase(SimpleTestCase):
+    """The S3 branch, stubbed against the real service model — so a parameter S3 does not have, or a
+    response member that is not one, fails here instead of in production."""
+
+    def _stubbed(self):
+        storage = storages.create_storage(S3_STORAGE["default"])
+        # the client stat_object caches on the storage, primed with a stub before it can build one
+        client = storage.connection.meta.client
+        storage._zentral_stat_client = client
+        return storage, Stubber(client)
+
+    def test_the_stat_client_carries_its_own_ceiling(self):
+        # the only test that builds the real client: everything below primes the cache with a stub,
+        # so a typo in these kwargs would surface in production as an exception verify_upload
+        # swallows into "undecided", with one log line to find it by
+        client = _stat_client(storages.create_storage(S3_STORAGE["default"]))
+        self.assertEqual(client.meta.config.connect_timeout, 2)
+        self.assertEqual(client.meta.config.read_timeout, 5)
+        # botocore stores retries as a TOTAL: asking for max_attempts=1 would have meant two
+        self.assertEqual(client.meta.config.retries["total_max_attempts"], 1)
+
+    @override_settings(STORAGES={"default": {"BACKEND": "storages.backends.s3.S3Storage",
+                                             "OPTIONS": dict(S3_STORAGE["default"]["OPTIONS"],
+                                                             location="zentral")}})
+    def test_stat_object_looks_where_the_presign_wrote(self):
+        # the same normalisation the presigned PUT signs. Without it the agent writes under the
+        # prefix, this HEAD looks at the bucket root, S3 answers 404 — and `missing` is a verdict,
+        # not an undecided answer, so it sticks.
+        storage = storages.create_storage(
+            dict(S3_STORAGE["default"],
+                 OPTIONS=dict(S3_STORAGE["default"]["OPTIONS"], location="zentral")))
+        storage._zentral_stat_client = storage.connection.meta.client
+        stub = Stubber(storage.connection.meta.client)
+        stub.add_response("head_object", {"ContentLength": 4},
+                          {"Bucket": "zentral-tests", "Key": "zentral/turbo/uploads/test",
+                           "ChecksumMode": "ENABLED"})
+        with stub:
+            self.assertEqual(stat_object("turbo/uploads/test", storage=storage)["size"], 4)
+
+    def test_stat_object_asks_for_the_checksum_and_gets_hex_back(self):
+        # HeadObject reports a checksum ONLY when the request asks for it. Without ChecksumMode the
+        # response is silently checksum-free, and a comparison against it would pass for any object.
+        storage, stub = self._stubbed()
+        stub.add_response(
+            "head_object",
+            {"ContentLength": 4, "ChecksumSHA256": base64.b64encode(hashlib.sha256(b"yolo").digest()).decode()},
+            {"Bucket": "zentral-tests", "Key": "turbo/uploads/test", "ChecksumMode": "ENABLED"},
+        )
+        with stub:
+            stored = stat_object("turbo/uploads/test", storage=storage)
+        self.assertEqual(stored["size"], 4)
+        # hex, the encoding the wire carries, not the base64 S3 reports
+        self.assertEqual(stored["sha256"], hashlib.sha256(b"yolo").hexdigest())
+
+    def test_stat_object_missing_key(self):
+        # HeadObject has no body to carry an error code, so a missing key surfaces as the bare status
+        # 404 — an `except NoSuchKey` would never fire
+        storage, stub = self._stubbed()
+        stub.add_client_error("head_object", service_error_code="404", http_status_code=404)
+        with stub:
+            self.assertIsNone(stat_object("turbo/uploads/gone", storage=storage))
+
+    def test_stat_object_forbidden_is_not_missing(self):
+        # a key we may not read is not an object that is not there, and recording it as missing would
+        # blame the agent for a bucket policy
+        storage, stub = self._stubbed()
+        stub.add_client_error("head_object", service_error_code="403", http_status_code=403)
+        with stub, self.assertRaises(ClientError):
+            stat_object("turbo/uploads/test", storage=storage)
+
+    def test_stat_object_without_a_stored_checksum(self):
+        # an object something else wrote: the size is all the stat can say
+        storage, stub = self._stubbed()
+        stub.add_response("head_object", {"ContentLength": 4},
+                          {"Bucket": "zentral-tests", "Key": "k", "ChecksumMode": "ENABLED"})
+        with stub:
+            stored = stat_object("k", storage=storage)
+        self.assertEqual(stored, {"size": 4, "sha256": None, "crc64nvme": None})
+
+    def test_stat_object_composite_checksum_is_not_a_sha256(self):
+        # S3 reports a multipart composite checksum with a part-count suffix, which is not the digest
+        # of the object and must not be compared against one
+        storage, stub = self._stubbed()
+        composite = base64.b64encode(hashlib.sha256(b"yolo").digest()).decode() + "-3"
+        stub.add_response("head_object", {"ContentLength": 4, "ChecksumSHA256": composite},
+                          {"Bucket": "zentral-tests", "Key": "k", "ChecksumMode": "ENABLED"})
+        with stub:
+            self.assertIsNone(stat_object("k", storage=storage)["sha256"])
+
+
+class StatObjectLocalTestCase(TestCase):
+    """The branch for a storage that signs nothing and records no digest of its own."""
+
+    def _store(self, key, body):
+        storage = storages["default"]
+        storage.save(key, ContentFile(body))
+        self.addCleanup(storage.delete, key)
+        return storage
+
+    def test_stat_object_reports_the_size_and_no_digest(self):
+        storage = self._store("turbo/uploads/stat-test", b"yolo")
+        self.assertEqual(stat_object("turbo/uploads/stat-test", storage=storage),
+                         {"size": 4, "sha256": None, "crc64nvme": None})
+
+    def test_stat_object_missing_file(self):
+        self.assertIsNone(stat_object("turbo/uploads/never-written", storage=storages["default"]))
+
+    def test_both_helpers_default_to_the_default_storage(self):
+        self._store("turbo/uploads/default-storage", b"yolo")
+        self.assertEqual(stat_object("turbo/uploads/default-storage"),
+                         {"size": 4, "sha256": None, "crc64nvme": None})
+        self.assertEqual(sha256_object("turbo/uploads/default-storage"),
+                         hashlib.sha256(b"yolo").hexdigest())
+
+    def test_sha256_object(self):
+        storage = self._store("turbo/uploads/hash-test", b"yolo" * 1024)
+        self.assertEqual(sha256_object("turbo/uploads/hash-test", storage=storage),
+                         hashlib.sha256(b"yolo" * 1024).hexdigest())

--- a/zentral/contrib/turbo/public_views/results.py
+++ b/zentral/contrib/turbo/public_views/results.py
@@ -1,10 +1,12 @@
 import logging
 
+from django.core.files.storage import storages
 from django.utils import timezone
 
 from ..events import post_turbo_result_events
 from ..models import JobUpload, UploadErrorReason, UploadStatus, resolve_machine_schedules
 from ..results import ParsedResult, ResultsBatch
+from ..uploads import verify_upload
 from ..wire import WireResultsSerializer
 from .base import BaseEnrolledMachinePostView, WireError
 
@@ -85,6 +87,10 @@ class ResultsView(BaseEnrolledMachinePostView):
                 continue
             kind = job.kind
             outcome = entry["result"]
+            # before the wire ref is built, not after: the verification verdict rides the echoed
+            # upload entry into the event, and enriching `outcome` in place afterwards would only
+            # work by aliasing a dict two callers hold
+            uploads_ref = self._close_uploads(schedule_pk, run.get("id"), outcome)
             batch.add(ParsedResult(
                 job=job,
                 definition=job.definition,
@@ -95,32 +101,39 @@ class ResultsView(BaseEnrolledMachinePostView):
                 exit_code=outcome.get("exit_code"),
                 ran_at=ran_at,
                 sort_key=(ran_at, index),
-                wire_ref=self._wire_ref(job, kind, entry["version"], run, ran_at, outcome),
+                wire_ref=self._wire_ref(job, kind, entry["version"], run, ran_at, outcome,
+                                        uploads_ref),
             ))
-            self._close_uploads(schedule_pk, run.get("id"), outcome)
             accepted.append(ack)
         return accepted, skipped
 
     def _close_uploads(self, schedule_pk, run_id, outcome):
-        """Move this run's upload rows out of `pending`, on the agent's word.
+        """Move this run's upload rows out of `pending`, on the agent's word, then ask the storage.
 
-        The gate closes here and nowhere else: whether the storage agrees is a *second* axis, decided
-        later and never able to reopen a spent shot. Tolerant, like the rest of ingest — a row that
-        cannot be matched is logged and skipped, never a reason to fail the batch, because the run
-        did happen and the outcome is already recorded.
+        The gate closes here and nowhere else, and it closes on the agent's report alone. Whether the
+        storage agrees is a *second* axis: it is recorded next to the status, never instead of it, and
+        it cannot reopen a shot the report consumed. Tolerant, like the rest of ingest — a row that
+        cannot be matched is logged and skipped, never a reason to fail the batch, because the run did
+        happen and the outcome is already recorded.
+
+        Returns the echoed entries with the verdict added, for the result event, or None when there
+        was nothing to close.
         """
         uploads = outcome.get("uploads")
         if not uploads or not isinstance(uploads, list):
-            return
+            return None
         if run_id is None:
             # nothing to match on: the rows are keyed by run, and two runs of one schedule are
             # otherwise indistinguishable
             logger.warning("Turbo results from %s: uploads without a run id on schedule %s",
                            self.serial_number, schedule_pk)
-            return
+            return None
         rows = {row.artifact: row for row in JobUpload.objects.filter(
             schedule_pk=schedule_pk, serial_number=self.serial_number, run_id=run_id)}
+        storage = storages["default"]
+        uploads_ref = []
         for reported in uploads:
+            uploads_ref.append(reported)
             if not isinstance(reported, dict):
                 continue
             artifact = reported.get("artifact")
@@ -150,10 +163,20 @@ class ResultsView(BaseEnrolledMachinePostView):
                     row.status = UploadStatus.UPLOADED
                     row.truncated = bool(reported.get("truncated"))
             row.completed_at = timezone.now()
+            if row.status == UploadStatus.UPLOADED:
+                verification = verify_upload(row, reported, storage)
+                if verification is not None:
+                    row.verification = verification
+                    row.verified_at = timezone.now()
+                    # the verdict, not a boolean: `missing` and `mismatch` both answer "no" and
+                    # mean different things, and a consumer that has to tell them apart cannot go
+                    # to the database from an event
+                    uploads_ref[-1] = {**reported, "verification": verification}
             row.save()
+        return uploads_ref
 
     @staticmethod
-    def _wire_ref(job, kind, version, run, ran_at, outcome):
+    def _wire_ref(job, kind, version, run, ran_at, outcome, uploads_ref=None):
         # the result event payload: the validated wire entry, with the authoritative kind and
         # JSON-native values — the run time as aware ISO-8601 UTC, so EventMetadata parses it back
         # into the event's created_at. The definition block (script / mscp_check) carries the name /
@@ -163,6 +186,14 @@ class ResultsView(BaseEnrolledMachinePostView):
             run_ref["duration"] = run["duration"]
         if run.get("mode"):
             run_ref["mode"] = run["mode"]
+        if run.get("id"):
+            # what an upload row is keyed on, so a consumer of the event can find the artifact it
+            # describes
+            run_ref["id"] = str(run["id"])
+        result_ref = outcome
+        if uploads_ref is not None:
+            # a copy: `outcome` is also the ParsedResult's, and the verdict belongs to the event
+            result_ref = {**outcome, "uploads": uploads_ref}
         payload_key, definition_ref = job.definition_wire_ref()
         return {"kind": kind, "pk": str(job.pk), "version": version,
-                payload_key: definition_ref, "run": run_ref, "result": outcome}
+                payload_key: definition_ref, "run": run_ref, "result": result_ref}

--- a/zentral/contrib/turbo/uploads.py
+++ b/zentral/contrib/turbo/uploads.py
@@ -7,7 +7,10 @@ from django.urls import reverse
 from django.utils import timezone
 
 from zentral.conf import api_base_url
-from zentral.utils.storage import file_storage_has_presigned_uploads, generate_presigned_put
+from zentral.utils.storage import (file_storage_has_presigned_uploads, generate_presigned_put,
+                                   sha256_object, stat_object)
+
+from .models import UploadVerification
 
 
 logger = logging.getLogger("zentral.contrib.turbo.uploads")
@@ -150,6 +153,73 @@ def unsign_hosted_upload(token):
         return _hosted_upload_signer.unsign(token, max_age=UPLOAD_URL_EXPIRY)
     except BadSignature:
         return None
+
+
+def verify_upload(upload, reported, storage):
+    """Does the storage agree with what the agent reported? The SECOND axis.
+
+    It cannot reopen a spent shot. This runs after the gate has closed, and its whole output is the
+    row's verification field and the flag that rides into the result event — "the agent says it
+    uploaded" and "the storage agrees" stay two facts.
+
+    The size and the digest reach here by two independent paths. One went out at the mint and was
+    SIGNED into the upload, so the storage refused any body that did not match it, and comes back as
+    the checksum the storage recorded. The other came home in the result. Verification is where the
+    two copies meet, and on a storage that signs, Zentral reads no byte to compare them.
+
+    Both legs are checked. An agent whose result contradicts its own mint is describing a different
+    file, and comparing the stored object against the mint alone would miss it — on a signing storage
+    that comparison is nearly tautological, since S3 enforced it on the way in.
+
+    Returns an UploadVerification value, or None when nothing could be decided. Undecided is a real
+    answer and deliberately not `missing`: a storage that timed out, a key we may not read, or an
+    object something else wrote without a checksum are all "ask again later", and a transient blip
+    that permanently marked artifacts missing would be worse than no answer at all.
+    """
+    if not _report_agrees_with_the_mint(upload, reported):
+        return UploadVerification.MISMATCH
+    try:
+        stored = stat_object(upload.key, storage=storage)
+    except Exception:
+        logger.exception("Could not stat turbo upload %s", upload.pk)
+        return None
+    if stored is None:
+        return UploadVerification.MISSING
+    if stored["size"] != upload.size:
+        return UploadVerification.MISMATCH
+    sha256 = stored["sha256"]
+    if sha256 is None and not file_storage_has_presigned_uploads(storage):
+        # nothing signed this body on the way in and the storage keeps no digest, so the only way to
+        # know is to read it — which is affordable exactly because a storage that cannot sign an
+        # upload has the small ceiling
+        try:
+            sha256 = sha256_object(upload.key, storage=storage)
+        except Exception:
+            logger.exception("Could not hash turbo upload %s", upload.pk)
+            return None
+    if sha256 is None:
+        # the storage can sign, so every object we put there carries the checksum we signed. One that
+        # does not was written by something else, and saying so is more useful than a verdict.
+        logger.error("Turbo upload %s: no stored sha256 at %s", upload.pk, upload.key)
+        return None
+    return UploadVerification.VERIFIED if sha256 == upload.sha256 else UploadVerification.MISMATCH
+
+
+def _report_agrees_with_the_mint(upload, reported):
+    # the result echoes the size and the digest a second time. Where it does, they have to be the
+    # ones the mint signed: an agent that asks for a destination for one file and reports another has
+    # told us about two files, and only one of them is at the key. Absent values are not a
+    # contradiction — the row is what was signed either way.
+    for attribute, declared in (("size", upload.size), ("sha256", upload.sha256)):
+        echoed = reported.get(attribute)
+        if isinstance(echoed, str):
+            # parse_sha256 stores the digest lowercase, so the echo is read the same way
+            echoed = echoed.lower()
+        if echoed is not None and echoed != declared:
+            logger.warning("Turbo upload %s: reported %s %r contradicts the minted %r",
+                           upload.pk, attribute, echoed, declared)
+            return False
+    return True
 
 
 def build_upload_destination(upload, artifact, storage):

--- a/zentral/utils/storage.py
+++ b/zentral/utils/storage.py
@@ -1,7 +1,22 @@
 import base64
 import binascii
+import hashlib
 
 from django.core.files.storage import storages, InvalidStorageError
+
+
+# One HEAD is a single small round trip — tens of milliseconds — but it happens on a device endpoint,
+# inside the request transaction, so it gets an explicit ceiling instead of botocore's minute-scale
+# defaults: an unbounded call to a storage that has gone quiet holds a web worker AND a database
+# connection. One attempt, deliberately: a retry would double how long that transaction stays open to
+# buy an answer that was never urgent, and the caller treats "could not tell" as a normal outcome it
+# can ask about again later.
+_STAT_CONNECT_TIMEOUT = 2
+_STAT_READ_TIMEOUT = 5
+# total, not retries: botocore reads `max_attempts` as the number of RETRIES and stores
+# max_attempts + 1, so the obvious spelling of "once" asks for twice and doubles the worst case this
+# ceiling exists to bound. total_max_attempts is the key it keeps, and it means what it says.
+_STAT_TOTAL_ATTEMPTS = 1
 
 
 def file_storage_has_signed_urls(storage=None):
@@ -35,6 +50,26 @@ def _sha256_base64(sha256_hex):
         raise ValueError(f"Not a hex sha256: {sha256_hex!r}")
 
 
+def _s3_client(storage, cache_attr, **config_kwargs):
+    # a client of the storage's OWN session, so it authenticates exactly like the storage does, with
+    # the deployment's config merged under ours. Cached on the storage, which Django keeps as a
+    # singleton; racing threads would build a second one and use it safely.
+    client = getattr(storage, cache_attr, None)
+    if client is None:
+        from botocore.client import Config
+        session = storage._create_session()
+        client = session.client(
+            "s3",
+            region_name=storage.region_name,
+            use_ssl=storage.use_ssl,
+            endpoint_url=storage.endpoint_url,
+            verify=storage.verify,
+            config=storage.client_config.merge(Config(**config_kwargs)),
+        )
+        setattr(storage, cache_attr, client)
+    return client
+
+
 def _presigning_client(storage):
     """A client that signs with SigV4, whatever the deployment left unset.
 
@@ -46,20 +81,34 @@ def _presigning_client(storage):
     is forced here rather than trusted, on a client of the storage's own session so that uploads
     authenticate exactly like downloads.
     """
-    client = getattr(storage, "_zentral_presigning_client", None)
-    if client is None:
-        from botocore.client import Config
-        session = storage._create_session()
-        client = session.client(
-            "s3",
-            region_name=storage.region_name,
-            use_ssl=storage.use_ssl,
-            endpoint_url=storage.endpoint_url,
-            verify=storage.verify,
-            config=storage.client_config.merge(Config(signature_version="s3v4")),
-        )
-        storage._zentral_presigning_client = client
-    return client
+    return _s3_client(storage, "_zentral_presigning_client", signature_version="s3v4")
+
+
+def _stat_client(storage):
+    """A client for the verification HEAD, with a ceiling the deployment's config cannot lift.
+
+    Unlike the presigning client this one talks to the network, on a device endpoint, inside the
+    request transaction — so an unbounded call to a storage that has gone quiet would hold a web
+    worker AND a database connection. One attempt, deliberately: a retry would double how long that
+    transaction stays open to buy an answer that was never urgent, and the caller treats "could not
+    tell" as a normal outcome it can ask about again later.
+    """
+    return _s3_client(storage, "_zentral_stat_client",
+                      connect_timeout=_STAT_CONNECT_TIMEOUT,
+                      read_timeout=_STAT_READ_TIMEOUT,
+                      retries={"mode": "standard", "total_max_attempts": _STAT_TOTAL_ATTEMPTS})
+
+
+def _object_key(storage, key):
+    """The key S3 actually holds the object under.
+
+    With a `location` set, S3Storage prefixes every key it reads, so a bare name would write — and
+    look — outside the namespace that exists(), delete(), url() and the verification HEAD all share.
+    A private accessor, but it is the one url() itself uses, and there is no public equivalent: the
+    paths that sign a write and the paths that read it back have to agree on one string.
+    """
+    from storages.utils import clean_name
+    return storage._normalize_name(clean_name(key))
 
 
 def generate_presigned_put(key, size, content_type, sha256_hex, expires_in, storage=None):
@@ -73,7 +122,6 @@ def generate_presigned_put(key, size, content_type, sha256_hex, expires_in, stor
     """
     if storage is None:
         storage = storages["default"]
-    from storages.utils import clean_name
     client = _presigning_client(storage)
     headers = {
         "Content-Type": content_type,
@@ -84,12 +132,7 @@ def generate_presigned_put(key, size, content_type, sha256_hex, expires_in, stor
         "put_object",
         Params={
             "Bucket": storage.bucket_name,
-            # through the storage's own name normalisation, not the bare key: with a `location` set,
-            # S3Storage prefixes every key it reads, so a presigned PUT built from the bare name
-            # would write outside the namespace that exists(), delete(), url() and the verification
-            # HEAD all look in. A private name, but it is the one url() itself uses — the two paths
-            # have to agree, and there is no public accessor for it.
-            "Key": storage._normalize_name(clean_name(key)),
+            "Key": _object_key(storage, key),
             "ContentType": content_type,
             "ContentLength": size,
             "ChecksumSHA256": headers["x-amz-checksum-sha256"],
@@ -97,6 +140,66 @@ def generate_presigned_put(key, size, content_type, sha256_hex, expires_in, stor
         ExpiresIn=expires_in,
     )
     return url, headers
+
+
+def _sha256_hex(checksum_base64):
+    # the other direction of _sha256_base64: S3 reports the checksum it recorded in base64, and every
+    # caller compares it against the hex the wire carries
+    if not checksum_base64:
+        return None
+    try:
+        return binascii.hexlify(base64.b64decode(checksum_base64, validate=True)).decode("ascii")
+    except (binascii.Error, ValueError):
+        return None
+
+
+def stat_object(key, storage=None):
+    """The stored size and the whole-object digests the storage itself recorded.
+
+    Returns None when there is nothing at the key — and only then. Every other failure raises, so a
+    storage that is unreachable or a key we may not read is never mistaken for an object that is not
+    there.
+
+    Two S3 details this depends on. HeadObject reports a checksum only when the request asks for it,
+    so without ChecksumMode the response is silently checksum-free and a comparison against it would
+    pass for any object at all. And a missing key surfaces as the bare status 404, not NoSuchKey —
+    HeadObject has no body to carry an error code — so an `except NoSuchKey` would never fire.
+    """
+    if storage is None:
+        storage = storages["default"]
+    if file_storage_has_presigned_uploads(storage):
+        from botocore.exceptions import ClientError
+        client = _stat_client(storage)
+        try:
+            response = client.head_object(Bucket=storage.bucket_name, Key=_object_key(storage, key),
+                                          ChecksumMode="ENABLED")
+        except ClientError as error:
+            if error.response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 404:
+                return None
+            raise
+        return {"size": response["ContentLength"],
+                "sha256": _sha256_hex(response.get("ChecksumSHA256")),
+                "crc64nvme": response.get("ChecksumCRC64NVME") or None}
+    if not storage.exists(key):
+        return None
+    # a storage with no checksum of its own: the size is all a stat can say, and a caller that needs
+    # the digest has to read the object
+    return {"size": storage.size(key), "sha256": None, "crc64nvme": None}
+
+
+def sha256_object(key, storage=None):
+    """Read the object and hash it, for a storage that records no digest of its own.
+
+    Only ever called against a storage that cannot presign an upload, where the size cap is small
+    enough for this to be a local read.
+    """
+    if storage is None:
+        storage = storages["default"]
+    digest = hashlib.sha256()
+    with storage.open(key, "rb") as stored:
+        for chunk in stored.chunks():
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def select_dist_storage():


### PR DESCRIPTION
Stacked on #1684 — review that one first.

*Rebased onto the current #1684 head (`41454e80`), and the [review](https://github.com/zentralopensource/zentral/pull/1685#issuecomment-5542100473) round is folded in. The rebase itself carried a silent break — the presign now normalises the object key and the verification HEAD did not — and the review's nit about the stat client turned up a second: `retries.max_attempts` is read by botocore as a retry count, so the ceiling allowed two attempts while its comment said one.* It established the first axis of an upload: the agent reported, and the row closed on its word. This PR establishes the second: whether the storage agrees.

They are separate on purpose. "The agent says it uploaded" and "the storage agrees" are two facts, and the second must never be able to invalidate the first.

## `storage: stat an object, and hash one the storage did not`

`stat_object()` reports the size and the whole-object digests the storage itself recorded. It returns `None` when there is nothing at the key — and only then. Every other failure raises, so a storage that is unreachable, or a key the deployment may not read, is never mistaken for an object that is not there.

Two S3 details it depends on, each silent when missed:

 * **`HeadObject` reports a checksum only when the request asks for it.** Without `ChecksumMode` the response is checksum-free, and a comparison against it would pass for any object at all.
 * **A missing key surfaces as the bare status `404`, not `NoSuchKey`** — `HeadObject` has no body to carry an error code — so an `except NoSuchKey` would never fire.

Both are pinned by tests stubbed against the real service model, so a parameter S3 does not have fails in CI rather than in production.

The HEAD gets an explicit ceiling instead of botocore's minute-scale defaults, and **one** attempt. It runs on a device endpoint inside the request transaction, so an unbounded call to a storage that has gone quiet would hold a web worker *and* a database connection; a retry would double how long that transaction stays open to buy an answer that was never urgent.

`sha256_object()` reads an object and hashes it, for the storage that keeps no digest of its own — affordable exactly because that is the storage with the small ceiling.

## `turbo: does the storage agree? the second axis`

When the agent reports an upload, Zentral asks the storage about the object at that key and compares the size and the SHA-256.

**The two numbers reach that comparison by two independent paths.** One went out at the mint and was signed into the upload, so the storage refused any body that did not hash to it, and comes back as the checksum the storage recorded. The other came home in the result. Verification is where the two copies meet, and on a storage that signs, Zentral reads no part of the file to do it.

Both legs are checked. An agent whose result contradicts its own mint is describing a different file, and comparing the stored object against the mint alone would miss it — on a signing storage that comparison is nearly tautological, since S3 enforced it on the way in.

`verified` / `mismatch` / `missing` lands on the row's own field, next to the status and never instead of it, and rides the echoed entry into the result event as `verification` — the verdict itself, not a yes or no, because `mismatch` and `missing` are different problems and a consumer of an event cannot go to the database to tell them apart. The event now also carries `run.id` — what an upload row is keyed on, without which the event describes an artifact nothing can find.

**Some answers are not answers, and none of them is recorded.** A storage that timed out, a key we may not read, and an object with no stored digest all leave the row `pending`, with a log entry. A transient blip that marked artifacts permanently missing would be worse than no answer at all. On a signing storage a missing digest is never a reason to read the object back — that would mean downloading two gigabytes to answer a question.

**A mismatch does not reopen the gate.** That is what two axes are for: the shot was consumed when the agent reported, whatever the storage says afterwards. There is a test for it.

One structural change: the uploads now close *before* the wire ref is built rather than after. The verdict has to ride the echoed entry, and enriching the outcome in place afterwards would only have worked by aliasing a dict two callers hold — the shape that has already cost this codebase one class of lost events.

## Not in this PR

Multipart, and the console views to list and download what was collected.

## Tests

Full suite green — 8647 tests. 100% patch coverage on every production line, verified by intersecting `coverage json` against the diff hunks. 32 new tests, `mkdocs build --strict` clean, all in-page anchors resolve.

The S3 paths are covered with `botocore.stub.Stubber` rather than a mock, so the expected parameters are validated against the real service model: a parameter S3 does not have fails here, not in production.

