### PR TITLE
turbo: multipart uploads, and the server closes them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,12 @@ The upload carries the outcome next to its status, and each `result.uploads` ent
 
 Verification never reopens a one-time job. The job was done on that machine when the agent reported, whatever the storage says afterwards.
 
+A large artifact goes up in parts on an S3 storage backend. Zentral chooses that from the size the agent declares — 128 MiB and above, in 64 MiB parts — and the response carries the geometry with the signed URLs, so the agent has nothing to predict and no part size to cache. Parts retry one at a time, and an agent whose URLs expired asks again with the `upload_id` and the numbers of the parts it still needs.
+
+Zentral completes the multipart upload itself, and the new `/public/turbo/uploads/complete/` endpoint answers `202`: completion can take several minutes, so it runs in the background, and the agent has no use for the answer. Zentral lists the parts from the storage and never takes a part list from a request. Completion is what verifies a multipart object — the whole-object CRC-64/NVME the agent declared is supplied at completion, and the storage refuses a mismatch — so Zentral declares that algorithm when it creates the upload. Without the declaration the storage would accept a wrong checksum and then report a correct one it computed itself. A multipart artifact is therefore refused when the agent asks for a destination without a `crc64nvme`: the SHA-256 cannot do that work on a multipart upload. `assembly_failed` is the new verification outcome for parts that never made the object.
+
+Configure the `AbortIncompleteMultipartUpload` lifecycle rule on the bucket. Zentral drops the parts when an agent reports that it gave up, but the rule is the only thing that removes the parts of an upload the agent never reports, and parts are stored, and billed, until something removes them.
+
 
 ### Backward incompatibilities
 

--- a/docs/apps/turbo.md
+++ b/docs/apps/turbo.md
@@ -383,6 +383,22 @@ Where the bytes go depends on the storage backend:
 
 The agent sees the same `mode: "put"` shape in both cases, and does not know which storage is behind it.
 
+#### Multipart
+
+A large artifact on an S3 storage backend goes up in parts. Zentral chooses that, not the agent: the mint response says `mode: "multipart"` and carries the geometry — the size of a part, and one signed URL for each part. The agent sends the same request either way and reads the mode off the answer, so there is nothing for it to predict and no part size for it to cache.
+
+Resumability is the reason. A 400 MiB `PUT` that fails at 95 % starts again from zero, where parts retry one at a time. An agent whose part URLs expired asks again with the `upload_id` and the numbers of the parts it still needs, and Zentral signs only those, against the part size the upload was created with.
+
+The limit is two part sizes of 64 MiB, so 128 MiB. At one part size there is nothing to gain: an artifact one byte over would be a two-part upload with a one-byte second part, and losing the first part costs the same as starting the single `PUT` again. Multipart begins to pay when a resume can save a full part.
+
+**Zentral completes the upload, not the agent.** When every part is up, the agent posts the three keys that identify the upload to [`/public/turbo/uploads/complete/`](#publicturbouploadscomplete) and gets a `202`. Zentral then lists the parts from the storage — it never takes a part list from a request — and completes the upload with its own credentials. This is the one place the agent would have needed to know something about the storage: completion means collecting entity tags, building a request body, and, on S3, finding an error inside a `200` answer.
+
+The completion runs in the background because both storages document that it can take several minutes. The agent has no use for the answer: it sent the bytes, and whether the storage assembles them is recorded on the upload's own verification field. The call is idempotent, so the agent can repeat it, and Zentral asks for a completion again by itself when a result arrives for an upload that is still waiting.
+
+A multipart upload is verified by its completion and not by a later question to the storage. The whole-object CRC-64/NVME the agent declared when it asked for the destination is supplied at completion, and the storage computes the assembled object's own and refuses a mismatch. A failure there is `assembly_failed`. This is why the config asks for that digest, and why an artifact large enough for multipart is refused without it: the SHA-256 cannot do the same work on a multipart upload.
+
+When the agent gives up on a multipart upload and says so in its result, Zentral drops the parts. Configure the `AbortIncompleteMultipartUpload` lifecycle rule on the bucket as well: it is the only thing that removes the parts of an upload the agent never reports, and parts are stored, and billed, until something removes them.
+
 [Config](#configuration) publishes `upload_max_size` and `upload_digests`. The agent can then refuse a file that is too large before it collects it, and compute the digests the storage wants in the same pass as the SHA-256.
 
 The result closes the upload. It carries a `run.id`, and one entry in `result.uploads` for each declared artifact. The entry reports the upload, or the reason it failed. Zentral compares the key the agent echoes with the key it minted, and refuses an echo that does not match: the key never comes from the wire.
@@ -404,9 +420,10 @@ The outcome is a separate field on the upload, next to the status:
 |Verification|Meaning|
 |---|---|
 |`pending`|Not decided yet.|
-|`verified`|The stored object is the size and the SHA-256 the agent declared.|
+|`verified`|The stored object is the size and the SHA-256 the agent declared, or a multipart upload assembled with the CRC-64/NVME it declared.|
 |`mismatch`|Something is at the key and it is not what the agent declared, or the result contradicts the request for the destination.|
 |`missing`|There is nothing at the key.|
+|`assembly_failed`|A [multipart](#multipart) upload could not be assembled. The parts do not make the object the agent described.|
 
 The outcome rides the result event as well, as `verification` on the `result.uploads` entry. It is the outcome itself and not a yes or no, because `mismatch` and `missing` are different problems and a consumer of the event cannot go to the database to tell them apart.
 
@@ -2157,7 +2174,9 @@ Request:
 |`artifact`|**Required.** The artifact name, as the job kind declares it.|
 |`size`|**Required.** The exact size of the file, in bytes.|
 |`sha256`|**Required.** The hex SHA-256 of the file. This is the identity of the artifact for Zentral.|
-|`digests`|Optional. The storage digests the config asked for, keyed by algorithm.|
+|`digests`|Optional. The storage digests the config asked for, keyed by algorithm. Required for an artifact large enough for [multipart](#multipart), which nothing else can validate.|
+|`upload_id`|Resume only. The `upload_id` of the multipart upload to continue. Zentral compares it with the one it holds.|
+|`missing_parts`|Resume only. The numbers of the parts that still need a URL. Send it with `upload_id`, never alone.|
 
 Response:
 
@@ -2179,6 +2198,30 @@ The agent sends the file in one `PUT` to `url`, with every header in `headers`, 
 
 `key` goes back to Zentral in the result. `expires_at` is when the signature stops being accepted; the signature is verified when the request starts, so an upload that begins in time can finish.
 
+For an artifact large enough for [multipart](#multipart), the answer carries the geometry and one URL per part instead of a single `url`:
+
+```json
+{
+    "mode": "multipart",
+    "key": "turbo/uploads/C02ZXXXXXXXX/b1d1a1f0-.../7/sysdiagnose_C02ZXXXXXXXX_20260820-091541.tar.gz",
+    "upload_id": "2~kEXAMPLEuploadIDexample",
+    "part_size": 67108864,
+    "parts": [
+        {"n": 1, "url": "https://bucket.s3.amazonaws.com/...&partNumber=1", "headers": {"Content-Length": "67108864"}},
+        {"n": 2, "url": "https://bucket.s3.amazonaws.com/...&partNumber=2", "headers": {"Content-Length": "31457280"}}
+    ],
+    "expires_at": "2026-08-20T10:15:41+00:00"
+}
+```
+
+|Attribute|Description|
+|---|---|
+|`part_size`|The size of every part but the last. The agent slices on it.|
+|`parts[].n`|The part number, which the storage needs and which a resume names.|
+|`parts[].headers`|The exact length of that part, signed. A part carries no checksum: the whole object is validated at completion.|
+
+The agent sends each part with one `PUT`, then tells Zentral it is done. See [`/public/turbo/uploads/complete/`](#publicturbouploadscomplete). A resume asks this endpoint again with `upload_id` and `missing_parts`, and gets back only the parts it named — signed against the `part_size` the upload already has, so they line up with what is in flight.
+
 The same request again, for the same run and the same artifact, returns the same `key` with a new signature. That is the retry: it replaces the object instead of adding a second one. Zentral counts the requests and stops at five.
 
 Errors:
@@ -2191,12 +2234,19 @@ Errors:
 |`400`|`{"error": "invalid_size"}`|`size` is absent, or not a positive integer.|
 |`400`|`{"error": "invalid_sha256"}`|`sha256` is absent, or not 64 hexadecimal characters.|
 |`400`|`{"error": "invalid_digests"}`|`digests` is not an object, or one of its values is not a base 64 digest.|
+|`400`|`{"error": "missing_digest"}`|The artifact is large enough for [multipart](#multipart) and `digests.crc64nvme` is absent. Nothing else can validate the assembled object.|
+|`400`|`{"error": "invalid_upload_id"}`|`upload_id` is present and is not a string.|
+|`400`|`{"error": "unknown_upload_id"}`|`upload_id` is not the one of the multipart upload Zentral holds for that run and artifact.|
+|`400`|`{"error": "invalid_missing_parts"}`|`missing_parts` is not a non-empty list of part numbers.|
+|`400`|`{"error": "missing_upload_id"}`|`missing_parts` is present without `upload_id`. A resume names the upload it resumes.|
+|`400`|`{"error": "artifact_changed"}`|A resume declares a different `size` or `sha256` than the multipart upload in flight. That is a different artifact, and it needs its own upload.|
 |`400`|`{"error": "unknown_artifact"}`|The job does not declare that artifact. Terminal – no retry changes it.|
 |`400`|`{"error": "attempts_exhausted"}`|Five destinations were already minted for that run and artifact.|
 |`404`|`{"error": "unknown_schedule"}`|The schedule is unknown, belongs to another configuration, is out of scope, or is outside its delivery window.|
 |`410`|`{"error": "gate_closed"}`|A result for that one-time job already came back. The job is done on this machine, and an artifact uploaded now could never be referenced.|
 |`410`|`{"error": "already_uploaded"}`|The result already reported that artifact as uploaded.|
 |`413`|`{"error": "too_large"}`|`size` is above the limit of the job kind, or above the limit of the deployment.|
+|`503`|`{"error": "storage_unavailable"}`|The storage did not answer when Zentral started the [multipart](#multipart) upload. Ask again later.|
 |`429`|`{"error": "too_many_pending"}`|The machine holds too many destinations on that schedule that no result has closed. Report the runs already made; a request for a destination the machine already has is never refused for this reason.|
 
 #### The hosted destination
@@ -2212,3 +2262,41 @@ When the deployment has no storage that can sign a `PUT`, the `url` of the respo
 |`404`|`{"error": "unknown_upload"}`|The token names an upload that does not exist.|
 |`409`|`{"error": "already_uploaded"}`|The result already reported that artifact as uploaded.|
 |`413`|`{"error": "too_large"}`|The body is above the body limit of the deployment.|
+
+### /public/turbo/uploads/complete/
+
+Report that every part of a [multipart](#multipart) upload is sent. Nothing else uses this endpoint: a `mode: "put"` upload is finished when its `PUT` answers, and `mode` is how the agent knows which one it has.
+
+* method: POST
+* Content-Type: application/json
+* authentication: `Authorization: TurboEnrolledMachine <token>`
+
+Request — the identity of the upload, and nothing else. Zentral already holds the key, the `upload_id` and the geometry:
+
+```json
+{
+    "schedule_pk": "b1d1a1f0-8b2a-4a76-9a4a-3a1f1d3b6f22",
+    "run_id": "0f3b06d2-3f4e-4c2a-90c7-4d6c9dbb3d4c",
+    "artifact": "archive"
+}
+```
+
+Response:
+
+```json
+{}
+```
+
+The status is `202`, not `200`: Zentral accepted the work and completes the upload in the background, because both storages document that assembling a multipart upload can take several minutes. The agent moves on and posts its result.
+
+The call is idempotent. Repeat it after a timeout or a `5xx`; completing an upload that is already complete is a success. If the agent never manages to make the call, Zentral asks for the completion itself when the result for that run arrives.
+
+Errors:
+
+|Status|Body|Meaning|
+|---|---|---|
+|`400`|`{"error": "missing_schedule_pk"}`, `{"error": "invalid_schedule_pk"}`|`schedule_pk` is absent, or not a UUID.|
+|`400`|`{"error": "missing_run_id"}`, `{"error": "invalid_run_id"}`|`run_id` is absent, or not a UUID.|
+|`400`|`{"error": "missing_artifact"}`|`artifact` is absent or empty.|
+|`400`|`{"error": "unknown_upload"}`|No upload of that run and artifact for this machine.|
+|`400`|`{"error": "not_multipart"}`|The upload is a single `PUT`. It was finished when its `PUT` answered.|

--- a/tests/turbo/test_multipart_completion.py
+++ b/tests/turbo/test_multipart_completion.py
@@ -1,0 +1,497 @@
+import json
+import uuid
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from zentral.contrib.turbo.command_backends import CommandBackend
+from zentral.contrib.turbo.models import (JobUpload, UploadMode, UploadStatus, UploadVerification)
+from zentral.contrib.turbo.tasks import abort_multipart_upload_task, complete_multipart_upload_task
+
+from .utils import (TurboPublicTestCase, force_command, force_configuration, force_enrolled_machine,
+                    force_one_time_job)
+
+
+SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+CRC = "nD+hB17SSLE="
+S3_STORAGE = {"default": {"BACKEND": "storages.backends.s3.S3Storage",
+                          "OPTIONS": {"bucket_name": "zentral-tests",
+                                      "access_key": "AKIAIOSFODNN7EXAMPLE",
+                                      "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                                      "region_name": "us-east-1"}}}
+PARTS = [{"PartNumber": 1, "ETag": '"e1"'}, {"PartNumber": 2, "ETag": '"e2"'}]
+
+
+def client_error(code, operation="CompleteMultipartUpload"):
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+class TurboUploadCompleteViewTestCase(TurboPublicTestCase):
+    """`POST uploads/complete/` — the agent says the parts are up, and the server takes it from there.
+
+    202 and not 200: both storages document that assembling a multipart upload can take several
+    minutes, so it cannot sit in a device request, and the agent has no use for the answer anyway.
+    """
+
+    def _upload(self, mode=UploadMode.MULTIPART, upload_id="mpu-1",
+                verification=UploadVerification.PENDING):
+        configuration = force_configuration()
+        _, serial_number, token = force_enrolled_machine(configuration=configuration,
+                                                         meta_business_unit=self.mbu)
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job,
+                                          serial_numbers=[serial_number])
+        upload = JobUpload.objects.create(
+            schedule_pk=one_time_job.pk, schedule_mode="one_time", serial_number=serial_number,
+            run_id=uuid.uuid4(), artifact="archive", key="turbo/uploads/test/archive.tar.gz",
+            size=200, sha256=SHA256, crc64nvme=CRC, mode=mode, upload_id=upload_id,
+            part_size=100, status=UploadStatus.UPLOADED, verification=verification,
+        )
+        return token, one_time_job, upload
+
+    def _complete(self, token, one_time_job, upload, **overrides):
+        body = {"schedule_pk": str(one_time_job.pk), "run_id": str(upload.run_id),
+                "artifact": upload.artifact, **overrides}
+        return self.client.post(
+            reverse("turbo_public:uploads_complete"),
+            data=json.dumps(body),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"TurboEnrolledMachine {token}",
+        )
+
+    def test_unauthenticated(self):
+        response = self.client.post(reverse("turbo_public:uploads_complete"), data="{}",
+                                    content_type="application/json")
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {"error": "unauthenticated"})
+
+    @patch("zentral.contrib.turbo.public_views.uploads.complete_multipart_upload_task")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_the_call_is_accepted_and_the_work_is_queued(self, post_event, task):
+        token, one_time_job, upload = self._upload()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._complete(token, one_time_job, upload)
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json(), {})
+        task.apply_async.assert_called_once_with((str(upload.pk),))
+
+    @patch("zentral.contrib.turbo.public_views.uploads.complete_multipart_upload_task")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_the_request_event_is_posted_on_the_202(self, post_event, task):
+        # the event records that the agent made the request; an endpoint that only accepts the work
+        # still made a request
+        from zentral.contrib.turbo.events import TurboRequestEvent
+        token, one_time_job, upload = self._upload()
+        with self.captureOnCommitCallbacks(execute=True):
+            self._complete(token, one_time_job, upload)
+        events = [c.args[0] for c in post_event.call_args_list
+                  if isinstance(c.args[0], TurboRequestEvent)]
+        self.assertEqual([e.payload["request_type"] for e in events], ["upload_complete"])
+
+    @patch("zentral.contrib.turbo.public_views.uploads.complete_multipart_upload_task")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_an_already_verified_upload_queues_nothing(self, post_event, task):
+        token, one_time_job, upload = self._upload(verification=UploadVerification.VERIFIED)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._complete(token, one_time_job, upload)
+        self.assertEqual(response.status_code, 202)
+        task.apply_async.assert_not_called()
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_an_unknown_upload(self, post_event):
+        token, one_time_job, upload = self._upload()
+        response = self._complete(token, one_time_job, upload, run_id=str(uuid.uuid4()))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "unknown_upload"})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_another_machine_s_upload_is_unknown(self, post_event):
+        # the row is looked up by the AUTHENTICATED serial: without that a machine could complete
+        # another machine's upload
+        _, one_time_job, upload = self._upload()
+        _, _, other_token = force_enrolled_machine(configuration=one_time_job.configuration,
+                                                   meta_business_unit=self.mbu)
+        response = self._complete(other_token, one_time_job, upload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "unknown_upload"})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_single_put_is_not_multipart(self, post_event):
+        # a single PUT is finished when its PUT returns, and `mode` is how the agent knows which it
+        # has: asking for this is a contract error, not a transient one
+        token, one_time_job, upload = self._upload(mode=UploadMode.PUT, upload_id="")
+        response = self._complete(token, one_time_job, upload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "not_multipart"})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_missing_artifact(self, post_event):
+        token, one_time_job, upload = self._upload()
+        response = self._complete(token, one_time_job, upload, artifact="")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "missing_artifact"})
+
+
+@override_settings(STORAGES=S3_STORAGE)
+class TurboCompleteMultipartTaskTestCase(TurboPublicTestCase):
+    """The assembly, and what each answer from the storage means for the verification axis."""
+
+    def _upload(self, **overrides):
+        attributes = {"schedule_pk": uuid.uuid4(), "schedule_mode": "one_time",
+                      "serial_number": "C02ZTEST", "run_id": uuid.uuid4(), "artifact": "archive",
+                      "key": "turbo/uploads/test/archive.tar.gz", "size": 200, "sha256": SHA256,
+                      "crc64nvme": CRC, "mode": UploadMode.MULTIPART, "upload_id": "mpu-1",
+                      "part_size": 100, "status": UploadStatus.UPLOADED}
+        attributes.update(overrides)
+        return JobUpload.objects.create(**attributes)
+
+    @patch("zentral.contrib.turbo.tasks.complete_multipart_upload")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_a_completed_assembly_is_verified(self, list_parts, complete):
+        list_parts.return_value = PARTS
+        upload = self._upload()
+        result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "completed")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.VERIFIED)
+        self.assertIsNotNone(upload.verified_at)
+        # the part list is the STORAGE's, and the checksum is the one the agent declared at the mint
+        complete.assert_called_once()
+        args, kwargs = complete.call_args
+        self.assertEqual(args[2], PARTS)
+        self.assertEqual(args[3], CRC)
+        self.assertEqual(args[4], 200)
+
+    @patch("zentral.contrib.turbo.tasks.complete_multipart_upload")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_a_bad_digest_is_an_assembly_failure(self, list_parts, complete):
+        # the whole point of declaring the algorithm at create: S3 computes the assembled object's
+        # own checksum and refuses a mismatch
+        list_parts.return_value = PARTS
+        complete.side_effect = client_error("BadDigest")
+        upload = self._upload()
+        with self.assertLogs("zentral.contrib.turbo.tasks", level="ERROR"):
+            result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["error"], "BadDigest")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.ASSEMBLY_FAILED)
+        # and the first axis is untouched: the agent did upload, and the shot stays spent
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+
+    @patch("zentral.contrib.turbo.tasks.complete_multipart_upload")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_no_parts_at_all_is_an_assembly_failure(self, list_parts, complete):
+        # the agent said every part was up and the storage holds none: either they aged out on the
+        # lifecycle rule or they were never there
+        list_parts.return_value = []
+        upload = self._upload()
+        result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "no_parts")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.ASSEMBLY_FAILED)
+        complete.assert_not_called()
+
+    @patch("zentral.contrib.turbo.tasks.stat_object")
+    @patch("zentral.contrib.turbo.tasks.complete_multipart_upload")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_completing_an_already_completed_upload_is_success(self, list_parts, complete, stat):
+        # NoSuchUpload is what the storage says both for an upload that completed already and for one
+        # whose parts were aborted. The object is the only thing that tells them apart — and a retry
+        # of the agent's call is exactly how the first case arrives here.
+        list_parts.side_effect = client_error("NoSuchUpload", "ListParts")
+        stat.return_value = {"size": 200, "sha256": None, "crc64nvme": CRC}
+        upload = self._upload()
+        result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "already_completed")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.VERIFIED)
+
+    @patch("zentral.contrib.turbo.tasks.stat_object")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_parts_gone_with_no_object_is_an_assembly_failure(self, list_parts, stat):
+        list_parts.side_effect = client_error("NoSuchUpload", "ListParts")
+        stat.return_value = None
+        upload = self._upload()
+        result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "parts_gone")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.ASSEMBLY_FAILED)
+
+    @patch("zentral.contrib.turbo.tasks.stat_object")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_a_storage_that_cannot_be_asked_is_retried(self, list_parts, stat):
+        # the upload id is gone and the object is the only thing that says whether that means
+        # "completed" or "aborted". Without an answer there is nothing to record, so the row keeps
+        # waiting rather than being called either.
+        list_parts.side_effect = client_error("NoSuchUpload", "ListParts")
+        stat.side_effect = Exception("the storage is having a day")
+        upload = self._upload()
+        with patch.object(complete_multipart_upload_task, "retry",
+                          side_effect=RuntimeError("retried")) as retry:
+            with self.assertLogs("zentral.contrib.turbo.tasks", level="ERROR"):
+                with self.assertRaises(RuntimeError):
+                    complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(retry.call_count, 1)
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+
+    @patch("zentral.contrib.turbo.tasks.stat_object")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_an_object_of_the_wrong_size_is_not_an_already_completed_upload(self, list_parts, stat):
+        list_parts.side_effect = client_error("NoSuchUpload", "ListParts")
+        stat.return_value = {"size": 17, "sha256": None, "crc64nvme": None}
+        upload = self._upload()
+        result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "parts_gone")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.ASSEMBLY_FAILED)
+
+    @patch("zentral.contrib.turbo.tasks.stat_object")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_the_crc_settles_it_where_the_size_would_only_agree(self, list_parts, stat):
+        # the right size and somebody else's bytes: the HEAD reports the whole-object CRC the
+        # completion validated, and the row holds the one the agent declared, so the match is exact
+        list_parts.side_effect = client_error("NoSuchUpload", "ListParts")
+        stat.return_value = {"size": 200, "sha256": None, "crc64nvme": "AAAAAAAAAAA="}
+        upload = self._upload()
+        self.assertEqual(complete_multipart_upload_task(str(upload.pk))["status"], "parts_gone")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.ASSEMBLY_FAILED)
+
+    @patch("zentral.contrib.turbo.tasks.stat_object")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_a_matching_crc_is_the_completed_object(self, list_parts, stat):
+        list_parts.side_effect = client_error("NoSuchUpload", "ListParts")
+        stat.return_value = {"size": 999, "sha256": None, "crc64nvme": CRC}
+        upload = self._upload()
+        # the CRC decides, so a size that disagrees does not
+        self.assertEqual(complete_multipart_upload_task(str(upload.pk))["status"],
+                         "already_completed")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.VERIFIED)
+
+    @patch("zentral.contrib.turbo.tasks.complete_multipart_upload")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_a_transient_error_is_retried(self, list_parts, complete):
+        # a storage that is throttling or unreachable improves by asking again, with backoff. Nothing
+        # is recorded on the axis in the meantime — the row stays pending, which is honest.
+        # asserted on the task's own retry rather than on a result state: celery re-raises the
+        # original exception for a direct call and records eager retries as failures, so neither
+        # tells a retry from a give-up.
+        list_parts.return_value = PARTS
+        complete.side_effect = client_error("SlowDown")
+        upload = self._upload()
+        with patch.object(complete_multipart_upload_task, "retry",
+                          side_effect=RuntimeError("retried")) as retry:
+            with self.assertRaises(RuntimeError):
+                complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(retry.call_count, 1)
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+
+    @patch("zentral.contrib.turbo.tasks.complete_multipart_upload")
+    @patch("zentral.contrib.turbo.tasks.list_multipart_parts")
+    def test_a_result_that_lands_during_the_assembly_survives_it(self, list_parts, complete):
+        # the normal sequence, and the storage calls are given the window the docs allow: the task
+        # loads the row, the agent's result closes the status axis while ListParts and
+        # CompleteMultipartUpload run, and the task must not write its stale copy back over that. A
+        # full save here returned the row to pending for good — the agent was acknowledged and never
+        # resends — so it kept counting against MAX_PENDING_UPLOADS and read as a report that never
+        # came.
+        upload = self._upload(status=UploadStatus.PENDING)
+        list_parts.return_value = PARTS
+
+        def the_result_arrives(*args, **kwargs):
+            JobUpload.objects.filter(pk=upload.pk).update(
+                status=UploadStatus.UPLOADED, truncated=True, completed_at=timezone.now())
+            return {"ETag": '"final"'}
+
+        complete.side_effect = the_result_arrives
+        complete_multipart_upload_task(str(upload.pk))
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.VERIFIED)
+        # what the ingest wrote is still there
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        self.assertTrue(upload.truncated)
+        self.assertIsNotNone(upload.completed_at)
+
+    def test_an_already_verified_upload_is_left_alone(self):
+        upload = self._upload(verification=UploadVerification.VERIFIED)
+        result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "already_verified")
+
+    def test_a_single_put_is_not_assembled(self):
+        upload = self._upload(mode=UploadMode.PUT, upload_id="")
+        with self.assertLogs("zentral.contrib.turbo.tasks", level="ERROR"):
+            result = complete_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "not_multipart")
+        upload.refresh_from_db()
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+
+
+@override_settings(STORAGES=S3_STORAGE)
+class TurboAbortMultipartTaskTestCase(TurboPublicTestCase):
+    """Giving up frees the parts, which are stored and billed until something removes them."""
+
+    def _upload(self, **overrides):
+        attributes = {"schedule_pk": uuid.uuid4(), "schedule_mode": "one_time",
+                      "serial_number": "C02ZTEST", "run_id": uuid.uuid4(), "artifact": "archive",
+                      "key": "turbo/uploads/test/archive.tar.gz", "size": 200, "sha256": SHA256,
+                      "crc64nvme": CRC, "mode": UploadMode.MULTIPART, "upload_id": "mpu-1",
+                      "part_size": 100, "status": UploadStatus.FAILED}
+        attributes.update(overrides)
+        return JobUpload.objects.create(**attributes)
+
+    @patch("zentral.contrib.turbo.tasks.abort_multipart_upload")
+    def test_the_parts_are_dropped(self, abort):
+        upload = self._upload()
+        result = abort_multipart_upload_task(str(upload.pk))
+        self.assertEqual(result["status"], "aborted")
+        abort.assert_called_once()
+
+    @patch("zentral.contrib.turbo.tasks.abort_multipart_upload")
+    def test_an_upload_that_is_already_gone(self, abort):
+        abort.side_effect = client_error("NoSuchUpload", "AbortMultipartUpload")
+        upload = self._upload()
+        self.assertEqual(abort_multipart_upload_task(str(upload.pk))["status"], "aborted")
+
+    @patch("zentral.contrib.turbo.tasks.abort_multipart_upload")
+    def test_another_error_is_not_swallowed(self, abort):
+        abort.side_effect = client_error("AccessDenied", "AbortMultipartUpload")
+        upload = self._upload()
+        with self.assertRaises(ClientError):
+            abort_multipart_upload_task(str(upload.pk))
+
+    @patch("zentral.contrib.turbo.tasks.abort_multipart_upload")
+    def test_an_upload_that_is_not_failed_is_left_alone(self, abort):
+        # the row moved on between the enqueue and here: an abort now would drop the parts of an
+        # upload somebody is still counting on
+        upload = self._upload(status=UploadStatus.UPLOADED)
+        self.assertEqual(abort_multipart_upload_task(str(upload.pk))["status"], "not_failed")
+        abort.assert_not_called()
+
+    @patch("zentral.contrib.turbo.tasks.abort_multipart_upload")
+    def test_a_single_put_has_nothing_to_abort(self, abort):
+        upload = self._upload(mode=UploadMode.PUT, upload_id="")
+        self.assertEqual(abort_multipart_upload_task(str(upload.pk))["status"], "not_multipart")
+        abort.assert_not_called()
+
+
+@override_settings(STORAGES=S3_STORAGE)
+class TurboMultipartIngestTestCase(TurboPublicTestCase):
+    """What a result means for a multipart row, which does not get HEADed.
+
+    A multipart object is verified by its completion — the whole-object checksum validated against
+    the algorithm declared at create — so there is nothing left for the ingest to ask the storage.
+    What the ingest does instead is notice that a completion is still owed, or that the agent gave up.
+    """
+
+    def _minted(self, status=UploadStatus.PENDING, verification=UploadVerification.PENDING):
+        configuration = force_configuration()
+        _, serial_number, token = force_enrolled_machine(configuration=configuration,
+                                                         meta_business_unit=self.mbu)
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job,
+                                          serial_numbers=[serial_number])
+        upload = JobUpload.objects.create(
+            schedule_pk=one_time_job.pk, schedule_mode="one_time", serial_number=serial_number,
+            run_id=uuid.uuid4(), artifact="archive", key="turbo/uploads/test/archive.tar.gz",
+            size=200, sha256=SHA256, crc64nvme=CRC, mode=UploadMode.MULTIPART, upload_id="mpu-1",
+            part_size=100, status=status, verification=verification,
+        )
+        return token, one_time_job, upload
+
+    def _report(self, token, one_time_job, upload, entry):
+        body = {"results": [{"kind": one_time_job.job.kind, "pk": str(one_time_job.job.pk),
+                             "version": one_time_job.job.version,
+                             "run": {"at": "2026-09-03T10:00:00Z", "duration": 1.0,
+                                     "schedule_pk": str(one_time_job.pk),
+                                     "id": str(upload.run_id), "mode": "one_time"},
+                             "result": {"exit_code": 0, "uploads": [entry]}}]}
+        return self.client.post(
+            reverse("turbo_public:results"),
+            data=json.dumps(body),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"TurboEnrolledMachine {token}",
+        )
+
+    @staticmethod
+    def _uploads_ref(post_event):
+        from zentral.contrib.turbo.events import TurboResultEvent
+        event = [c.args[0] for c in post_event.call_args_list
+                 if isinstance(c.args[0], TurboResultEvent)][0]
+        return event.payload["result"]["uploads"][0]
+
+    @patch("zentral.contrib.turbo.public_views.results.complete_multipart_upload_task")
+    @patch("zentral.contrib.turbo.uploads.stat_object")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_completion_still_owed_is_enqueued_and_nothing_is_headed(self, post_event, stat, task):
+        # the agent's own call can have been lost, and a result is often the first thing to arrive
+        token, one_time_job, upload = self._minted()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._report(token, one_time_job, upload,
+                                    {"artifact": "archive", "key": upload.key, "size": 200,
+                                     "sha256": SHA256})
+        self.assertEqual(response.status_code, 200)
+        task.apply_async.assert_called_once_with((str(upload.pk),))
+        stat.assert_not_called()
+        upload.refresh_from_db()
+        self.assertEqual(upload.status, UploadStatus.UPLOADED)
+        self.assertEqual(upload.verification, UploadVerification.PENDING)
+
+    @patch("zentral.contrib.turbo.public_views.results.complete_multipart_upload_task")
+    @patch("zentral.contrib.turbo.uploads.stat_object")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_an_assembled_object_rides_the_event_as_verified(self, post_event, stat, task):
+        token, one_time_job, upload = self._minted(verification=UploadVerification.VERIFIED)
+        with self.captureOnCommitCallbacks(execute=True):
+            self._report(token, one_time_job, upload,
+                         {"artifact": "archive", "key": upload.key, "size": 200, "sha256": SHA256})
+        self.assertEqual(self._uploads_ref(post_event)["verification"],
+                         UploadVerification.VERIFIED)
+        # already answered, so there is nothing to enqueue and nothing to ask the storage
+        task.apply_async.assert_not_called()
+        stat.assert_not_called()
+
+    @patch("zentral.contrib.turbo.public_views.results.complete_multipart_upload_task")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_failed_assembly_rides_the_event_as_not_verified(self, post_event, task):
+        token, one_time_job, upload = self._minted(
+            verification=UploadVerification.ASSEMBLY_FAILED)
+        with self.captureOnCommitCallbacks(execute=True):
+            self._report(token, one_time_job, upload,
+                         {"artifact": "archive", "key": upload.key, "size": 200, "sha256": SHA256})
+        # the verdict and not a boolean: assembly_failed is its own answer, and a consumer that has
+        # to tell it from a mismatch cannot go to the database from an event
+        self.assertEqual(self._uploads_ref(post_event)["verification"],
+                         UploadVerification.ASSEMBLY_FAILED)
+        task.apply_async.assert_not_called()
+
+    @patch("zentral.contrib.turbo.public_views.results.abort_multipart_upload_task")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_reported_failure_frees_the_parts(self, post_event, task):
+        # parts of an abandoned multipart upload are stored, and billed, until something removes
+        # them. The lifecycle rule is the backstop; this is the fast path, for when the agent said so.
+        token, one_time_job, upload = self._minted()
+        with self.captureOnCommitCallbacks(execute=True):
+            self._report(token, one_time_job, upload,
+                         {"artifact": "archive", "error": {"reason": "network"}})
+        task.apply_async.assert_called_once_with((str(upload.pk),))
+        upload.refresh_from_db()
+        self.assertEqual(upload.status, UploadStatus.FAILED)
+
+    @patch("zentral.contrib.turbo.public_views.results.abort_multipart_upload_task")
+    @patch("zentral.contrib.turbo.public_views.results.complete_multipart_upload_task")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_mismatched_key_frees_the_parts_too(self, post_event, complete, abort):
+        # the echoed key does not match the minted one, so the row closes as failed — and a failed
+        # multipart row has parts nobody will ever assemble
+        token, one_time_job, upload = self._minted()
+        with self.captureOnCommitCallbacks(execute=True):
+            self._report(token, one_time_job, upload,
+                         {"artifact": "archive", "key": "somewhere/else", "size": 200})
+        abort.apply_async.assert_called_once_with((str(upload.pk),))
+        complete.apply_async.assert_not_called()

--- a/tests/turbo/test_public_uploads.py
+++ b/tests/turbo/test_public_uploads.py
@@ -6,15 +6,16 @@ from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from zentral.contrib.turbo.command_backends import CommandBackend
 from zentral.contrib.turbo.events import TurboRequestEvent, TurboResultEvent
-from zentral.contrib.turbo.models import (Job, JobUpload, OneTimeJobMachine, UploadStatus,
-                                          UploadVerification)
+from zentral.contrib.turbo.models import (Job, JobUpload, OneTimeJobMachine, UploadMode,
+                                          UploadStatus, UploadVerification)
 from zentral.contrib.turbo.uploads import (MAX_PENDING_UPLOADS, MAX_UPLOAD_ATTEMPTS,
+                                           MULTIPART_PART_SIZE, MULTIPART_THRESHOLD, part_lengths,
                                            sign_hosted_upload)
 
 from .utils import (TurboPublicTestCase, force_command, force_configuration, force_enrolled_machine,
@@ -291,7 +292,10 @@ class TurboUploadMintTestCase(TurboPublicTestCase):
     # requests the agent should abandon silently
 
     @override_settings(STORAGES=S3_STORAGE)
-    def test_the_kind_cap_applies_under_the_deployment_ceiling(self):
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload", return_value="mpu-1")
+    def test_the_kind_cap_applies_under_the_deployment_ceiling(self, create_multipart_upload):
+        # both sizes here are above the multipart threshold, so the accepted one starts a multipart
+        # upload. That is another test's subject; this one is about the ceiling.
         # file_export caps at 500 MiB, well under the 2 GiB an S3 deployment would take. Read off the
         # model with getattr() the cap was always None and only the deployment ceiling applied, so a
         # 600 MiB export minted fine — the old test used 10 GiB and could not see it.
@@ -1171,3 +1175,254 @@ class TurboUploadIngestTestCase(TurboPublicTestCase):
         )
         self.assertEqual(response.status_code, 410)
         self.assertEqual(response.json(), {"error": "gate_closed"})
+
+
+class TurboPartGeometryTestCase(SimpleTestCase):
+    """The slicing rule, which the mint response spells out so the agent never reproduces it."""
+
+    def test_an_exact_multiple_has_no_tail(self):
+        self.assertEqual(part_lengths(200, 100), [100, 100])
+
+    def test_a_remainder_is_the_last_part(self):
+        self.assertEqual(part_lengths(250, 100), [100, 100, 50])
+
+    def test_the_lengths_add_up_to_the_artifact(self):
+        for size in (MULTIPART_THRESHOLD, MULTIPART_THRESHOLD + 1, 5 * MULTIPART_PART_SIZE - 1):
+            with self.subTest(size=size):
+                lengths = part_lengths(size, MULTIPART_PART_SIZE)
+                self.assertEqual(sum(lengths), size)
+                # every part but the last is exactly the part size, which is what makes a resumed
+                # part line up with the object already in flight
+                self.assertTrue(all(length == MULTIPART_PART_SIZE for length in lengths[:-1]))
+                self.assertLessEqual(lengths[-1], MULTIPART_PART_SIZE)
+
+    def test_the_threshold_is_two_part_sizes(self):
+        # at one there is no resumability to buy: a part_size + 1 artifact would be a two-part upload
+        # whose second part is one byte, paying the whole multipart bill to protect a one-byte tail
+        self.assertEqual(MULTIPART_THRESHOLD, 2 * MULTIPART_PART_SIZE)
+        self.assertEqual(len(part_lengths(MULTIPART_THRESHOLD, MULTIPART_PART_SIZE)), 2)
+
+
+@override_settings(STORAGES=S3_STORAGE)
+class TurboMultipartMintTestCase(TurboPublicTestCase):
+    """The mint against a storage that can sign, where the mode is the server's business."""
+
+    CRC = "nD+hB17SSLE="
+
+    def _mint(self, token, body):
+        return self.client.post(
+            reverse("turbo_public:uploads"),
+            data=json.dumps(body),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"TurboEnrolledMachine {token}",
+        )
+
+    def _scheduled(self):
+        configuration = force_configuration()
+        _, serial_number, token = force_enrolled_machine(configuration=configuration,
+                                                         meta_business_unit=self.mbu)
+        command = force_command(backend=CommandBackend.SYSDIAGNOSE)
+        one_time_job = force_one_time_job(configuration=configuration, job=command.job,
+                                          serial_numbers=[serial_number])
+        return token, one_time_job
+
+    def _body(self, one_time_job, size, run_id=None, **extra):
+        return {"schedule_pk": str(one_time_job.pk), "run_id": str(run_id or uuid.uuid4()),
+                "artifact": "archive", "size": size, "sha256": SHA256,
+                "digests": {"crc64nvme": self.CRC}, **extra}
+
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_below_the_threshold_is_a_single_put(self, post_event, create):
+        token, one_time_job = self._scheduled()
+        response = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD - 1))
+        self.assertEqual(response.status_code, 200)
+        answer = response.json()
+        self.assertEqual(answer["mode"], "put")
+        self.assertIn("url", answer)
+        self.assertNotIn("parts", answer)
+        create.assert_not_called()
+
+    @patch("zentral.contrib.turbo.uploads.generate_presigned_part")
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_at_the_threshold_the_geometry_comes_back_with_the_urls(self, post_event, create, part):
+        # which is the whole reason it is not published in the config or cached anywhere
+        create.return_value = "mpu-1"
+        part.side_effect = lambda key, upload_id, n, size, expiry, storage=None: (
+            f"https://example.com/{n}", {"Content-Length": str(size)})
+        token, one_time_job = self._scheduled()
+        run_id = uuid.uuid4()
+        answer = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD,
+                                              run_id=run_id)).json()
+        self.assertEqual(answer["mode"], "multipart")
+        self.assertEqual(answer["upload_id"], "mpu-1")
+        self.assertEqual(answer["part_size"], MULTIPART_PART_SIZE)
+        self.assertEqual([p["n"] for p in answer["parts"]], [1, 2])
+        self.assertEqual([p["headers"]["Content-Length"] for p in answer["parts"]],
+                         [str(MULTIPART_PART_SIZE)] * 2)
+        # no url and no headers at the top level: the parts are the destination
+        self.assertNotIn("url", answer)
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.mode, UploadMode.MULTIPART)
+        self.assertEqual(upload.part_size, MULTIPART_PART_SIZE)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_multipart_without_the_whole_object_crc_is_refused(self, post_event):
+        # sha256 is composite-only on a multipart upload, so the CRC is the only thing that can
+        # validate the assembled object. Without it completion would accept whatever arrived.
+        token, one_time_job = self._scheduled()
+        body = self._body(one_time_job, MULTIPART_THRESHOLD)
+        del body["digests"]
+        response = self._mint(token, body)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "missing_digest"})
+        self.assertEqual(JobUpload.objects.count(), 0)
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_single_put_needs_no_crc(self, post_event):
+        # nothing uses it there: the PUT itself is a full-object checksum, and sha256 does the work
+        token, one_time_job = self._scheduled()
+        body = self._body(one_time_job, 1024)
+        del body["digests"]
+        self.assertEqual(self._mint(token, body).status_code, 200)
+
+    @patch("zentral.contrib.turbo.uploads.generate_presigned_part")
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_resume_signs_only_the_missing_parts(self, post_event, create, part):
+        create.return_value = "mpu-1"
+        part.side_effect = lambda key, upload_id, n, size, expiry, storage=None: (
+            f"https://example.com/{n}", {"Content-Length": str(size)})
+        token, one_time_job = self._scheduled()
+        run_id = uuid.uuid4()
+        size = 3 * MULTIPART_PART_SIZE
+        self._mint(token, self._body(one_time_job, size, run_id=run_id))
+        answer = self._mint(token, self._body(one_time_job, size, run_id=run_id,
+                                              upload_id="mpu-1", missing_parts=[2])).json()
+        self.assertEqual([p["n"] for p in answer["parts"]], [2])
+        # the SAME multipart upload: a resume must produce parts that line up with what is in flight
+        self.assertEqual(answer["upload_id"], "mpu-1")
+        self.assertEqual(create.call_count, 1)
+
+    @patch("zentral.contrib.turbo.uploads.generate_presigned_part")
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_resume_with_another_upload_id_is_refused(self, post_event, create, part):
+        # the presented id is checked against the row, never believed: parts signed against a
+        # different multipart upload would assemble somewhere nothing is looking
+        create.return_value = "mpu-1"
+        part.return_value = ("https://example.com/1", {"Content-Length": "1"})
+        token, one_time_job = self._scheduled()
+        run_id = uuid.uuid4()
+        size = 3 * MULTIPART_PART_SIZE
+        self._mint(token, self._body(one_time_job, size, run_id=run_id))
+        response = self._mint(token, self._body(one_time_job, size, run_id=run_id,
+                                                upload_id="mpu-somebody-else", missing_parts=[1]))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "unknown_upload_id"})
+
+    @patch("zentral.contrib.turbo.uploads.generate_presigned_part")
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_resume_cannot_ask_for_a_part_that_does_not_exist(self, post_event, create, part):
+        create.return_value = "mpu-1"
+        part.side_effect = lambda key, upload_id, n, size, expiry, storage=None: (
+            f"https://example.com/{n}", {"Content-Length": str(size)})
+        token, one_time_job = self._scheduled()
+        run_id = uuid.uuid4()
+        size = 2 * MULTIPART_PART_SIZE
+        self._mint(token, self._body(one_time_job, size, run_id=run_id))
+        answer = self._mint(token, self._body(one_time_job, size, run_id=run_id,
+                                              upload_id="mpu-1", missing_parts=[2, 99])).json()
+        self.assertEqual([p["n"] for p in answer["parts"]], [2])
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_missing_parts_must_be_part_numbers(self, post_event):
+        token, one_time_job = self._scheduled()
+        for value in ([], [0], ["1"], [True], 3, [1, -2]):
+            with self.subTest(missing_parts=value):
+                response = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD,
+                                                        upload_id="mpu-1", missing_parts=value))
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.json(), {"error": "invalid_missing_parts"})
+
+    @patch("zentral.contrib.turbo.uploads.generate_presigned_part")
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_resume_of_a_different_artifact_is_refused(self, post_event, create, part):
+        # the parts already up are the bytes the row describes, and the geometry was fixed against
+        # that size. Re-signing against a new one would hand out parts that cannot line up with what
+        # is already in flight.
+        create.return_value = "mpu-1"
+        part.side_effect = lambda key, upload_id, n, size, expiry, storage=None: (
+            f"https://example.com/{n}", {"Content-Length": str(size)})
+        token, one_time_job = self._scheduled()
+        run_id = uuid.uuid4()
+        self._mint(token, self._body(one_time_job, 3 * MULTIPART_PART_SIZE, run_id=run_id))
+        response = self._mint(token, self._body(one_time_job, 4 * MULTIPART_PART_SIZE, run_id=run_id,
+                                                upload_id="mpu-1", missing_parts=[2]))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "artifact_changed"})
+        # and the row still describes the upload that is in flight
+        upload = JobUpload.objects.get(run_id=run_id)
+        self.assertEqual(upload.size, 3 * MULTIPART_PART_SIZE)
+
+    @patch("zentral.contrib.turbo.uploads.generate_presigned_part")
+    @patch("zentral.contrib.turbo.uploads.create_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_resume_of_a_different_digest_is_refused(self, post_event, create, part):
+        create.return_value = "mpu-1"
+        part.side_effect = lambda key, upload_id, n, size, expiry, storage=None: (
+            f"https://example.com/{n}", {"Content-Length": str(size)})
+        token, one_time_job = self._scheduled()
+        run_id = uuid.uuid4()
+        size = 3 * MULTIPART_PART_SIZE
+        self._mint(token, self._body(one_time_job, size, run_id=run_id))
+        body = self._body(one_time_job, size, run_id=run_id, upload_id="mpu-1", missing_parts=[2])
+        body["sha256"] = "b" * 64
+        response = self._mint(token, body)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "artifact_changed"})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_missing_parts_without_an_upload_id(self, post_event):
+        # the resume shape is both keys: signing part 3 of an upload the agent has not started would
+        # hand it a URL for two thirds of an object it can never finish
+        token, one_time_job = self._scheduled()
+        response = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD,
+                                                missing_parts=[2]))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "missing_upload_id"})
+
+    @patch("zentral.contrib.turbo.public_views.uploads.start_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_storage_that_does_not_answer_is_a_retry_later(self, post_event, start):
+        # the one storage call this endpoint makes. Unhandled it is an HTML 500 on an endpoint whose
+        # contract is that it never serves one, and the agent has no parser for that and no reason to
+        # treat it as transient.
+        from botocore.exceptions import EndpointConnectionError
+        start.side_effect = EndpointConnectionError(endpoint_url="https://s3.example.com")
+        token, one_time_job = self._scheduled()
+        with self.assertLogs("zentral.contrib.turbo.public_views.uploads", level="ERROR"):
+            response = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD))
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"error": "storage_unavailable"})
+
+    @patch("zentral.contrib.turbo.public_views.uploads.start_multipart_upload")
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_a_storage_that_refuses_is_a_retry_later_too(self, post_event, start):
+        from botocore.exceptions import ClientError
+        start.side_effect = ClientError({"Error": {"Code": "SlowDown"}}, "CreateMultipartUpload")
+        token, one_time_job = self._scheduled()
+        with self.assertLogs("zentral.contrib.turbo.public_views.uploads", level="ERROR"):
+            response = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD))
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"error": "storage_unavailable"})
+
+    @patch("zentral.core.queues.backends.kombu.EventQueues.post_event")
+    def test_an_upload_id_that_is_not_a_string(self, post_event):
+        token, one_time_job = self._scheduled()
+        response = self._mint(token, self._body(one_time_job, MULTIPART_THRESHOLD, upload_id=17))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "invalid_upload_id"})

--- a/tests/utils/test_storage.py
+++ b/tests/utils/test_storage.py
@@ -2,14 +2,19 @@ import base64
 import hashlib
 from urllib.parse import parse_qs, urlparse
 
+from unittest.mock import patch
+
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages
 from django.test import SimpleTestCase, TestCase, override_settings
-from zentral.utils.storage import (_stat_client, file_storage_has_presigned_uploads,
-                                   file_storage_has_signed_urls, generate_presigned_put,
-                                   select_dist_storage, sha256_object, stat_object)
+from zentral.utils.storage import (_assembly_client, _request_client, abort_multipart_upload,
+                                   complete_multipart_upload, create_multipart_upload,
+                                   file_storage_has_presigned_uploads, file_storage_has_signed_urls,
+                                   generate_presigned_part, generate_presigned_put,
+                                   list_multipart_parts, select_dist_storage, sha256_object,
+                                   stat_object)
 
 
 S3_STORAGE = {"default": {"BACKEND": "storages.backends.s3.S3Storage",
@@ -109,18 +114,25 @@ class StatObjectS3TestCase(SimpleTestCase):
     """The S3 branch, stubbed against the real service model — so a parameter S3 does not have, or a
     response member that is not one, fails here instead of in production."""
 
-    def _stubbed(self):
+    def _stubbed(self, builder="_request_client"):
+        """A storage whose S3 client is a stub, by replacing the builder rather than its cache.
+
+        Priming the cached attribute worked until the attribute was renamed, and then the calls went
+        to the real endpoint and failed with a 403 — a test that reaches past the seam it is testing
+        breaks in a way that says nothing about what changed.
+        """
         storage = storages.create_storage(S3_STORAGE["default"])
-        # the client stat_object caches on the storage, primed with a stub before it can build one
         client = storage.connection.meta.client
-        storage._zentral_stat_client = client
+        patcher = patch(f"zentral.utils.storage.{builder}", return_value=client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
         return storage, Stubber(client)
 
-    def test_the_stat_client_carries_its_own_ceiling(self):
+    def test_the_request_client_carries_its_own_ceiling(self):
         # the only test that builds the real client: everything below primes the cache with a stub,
         # so a typo in these kwargs would surface in production as an exception verify_upload
         # swallows into "undecided", with one log line to find it by
-        client = _stat_client(storages.create_storage(S3_STORAGE["default"]))
+        client = _request_client(storages.create_storage(S3_STORAGE["default"]))
         self.assertEqual(client.meta.config.connect_timeout, 2)
         self.assertEqual(client.meta.config.read_timeout, 5)
         # botocore stores retries as a TOTAL: asking for max_attempts=1 would have meant two
@@ -136,7 +148,7 @@ class StatObjectS3TestCase(SimpleTestCase):
         storage = storages.create_storage(
             dict(S3_STORAGE["default"],
                  OPTIONS=dict(S3_STORAGE["default"]["OPTIONS"], location="zentral")))
-        storage._zentral_stat_client = storage.connection.meta.client
+        storage._zentral_request_client = storage.connection.meta.client
         stub = Stubber(storage.connection.meta.client)
         stub.add_response("head_object", {"ContentLength": 4},
                           {"Bucket": "zentral-tests", "Key": "zentral/turbo/uploads/test",
@@ -223,3 +235,123 @@ class StatObjectLocalTestCase(TestCase):
         storage = self._store("turbo/uploads/hash-test", b"yolo" * 1024)
         self.assertEqual(sha256_object("turbo/uploads/hash-test", storage=storage),
                          hashlib.sha256(b"yolo" * 1024).hexdigest())
+
+
+class MultipartUploadTestCase(SimpleTestCase):
+    """The multipart control plane, stubbed against the real service model.
+
+    Every expected parameter here is validated by the stub, which is the point: the declaration this
+    design rests on is one S3 accepts silently when it is absent, so the test that it is sent has to
+    be a test that S3 would recognise.
+    """
+
+    def _stubbed(self, builder):
+        storage = storages.create_storage(S3_STORAGE["default"])
+        client = storage.connection.meta.client
+        patcher = patch(f"zentral.utils.storage.{builder}", return_value=client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return storage, Stubber(client)
+
+    def test_create_declares_the_checksum_algorithm(self):
+        # the one line of the multipart design that must not be dropped. Without the declaration S3
+        # accepts a WRONG whole-object checksum at completion, and the object afterwards reports a
+        # perfectly correct one because S3 computed its own — it looks verified and is not.
+        storage, stub = self._stubbed("_request_client")
+        stub.add_response(
+            "create_multipart_upload", {"UploadId": "mpu-1"},
+            {"Bucket": "zentral-tests", "Key": "turbo/uploads/test",
+             "ContentType": "application/gzip",
+             "ChecksumAlgorithm": "CRC64NVME", "ChecksumType": "FULL_OBJECT"},
+        )
+        with stub:
+            upload_id = create_multipart_upload("turbo/uploads/test", "application/gzip",
+                                                storage=storage)
+        self.assertEqual(upload_id, "mpu-1")
+
+    def test_list_parts_paginates(self):
+        # a truncated first page read as the whole list would assemble a partial object and call it
+        # done
+        storage, stub = self._stubbed("_assembly_client")
+        stub.add_response(
+            "list_parts",
+            {"Parts": [{"PartNumber": 2, "ETag": '"e2"'}], "IsTruncated": True,
+             "NextPartNumberMarker": 2},
+            {"Bucket": "zentral-tests", "Key": "k", "UploadId": "mpu-1"},
+        )
+        stub.add_response(
+            "list_parts",
+            {"Parts": [{"PartNumber": 1, "ETag": '"e1"'}], "IsTruncated": False},
+            {"Bucket": "zentral-tests", "Key": "k", "UploadId": "mpu-1", "PartNumberMarker": 2},
+        )
+        with stub:
+            parts = list_multipart_parts("k", "mpu-1", storage=storage)
+        # both pages, and in part order whatever order they arrived in
+        self.assertEqual(parts, [{"PartNumber": 1, "ETag": '"e1"'},
+                                 {"PartNumber": 2, "ETag": '"e2"'}])
+
+    def test_complete_supplies_the_whole_object_checksum(self):
+        storage, stub = self._stubbed("_assembly_client")
+        parts = [{"PartNumber": 1, "ETag": '"e1"'}, {"PartNumber": 2, "ETag": '"e2"'}]
+        stub.add_response(
+            "complete_multipart_upload",
+            {"ETag": '"final"', "ChecksumCRC64NVME": "nD+hB17SSLE="},
+            {"Bucket": "zentral-tests", "Key": "k", "UploadId": "mpu-1",
+             "MultipartUpload": {"Parts": parts},
+             "ChecksumCRC64NVME": "nD+hB17SSLE=", "ChecksumType": "FULL_OBJECT",
+             "MpuObjectSize": 200},
+        )
+        with stub:
+            response = complete_multipart_upload("k", "mpu-1", parts, "nD+hB17SSLE=", 200,
+                                                 storage=storage)
+        self.assertEqual(response["ETag"], '"final"')
+
+    def test_abort(self):
+        storage, stub = self._stubbed("_request_client")
+        stub.add_response("abort_multipart_upload", {},
+                          {"Bucket": "zentral-tests", "Key": "k", "UploadId": "mpu-1"})
+        with stub:
+            abort_multipart_upload("k", "mpu-1", storage=storage)
+
+    @override_settings(STORAGES=S3_STORAGE)
+    def test_generate_presigned_part_signs_the_length_with_sigv4(self):
+        # the part carries no checksum on either storage, so the length is the entire contract — and
+        # the legacy V2 presign signs no header at all, which would leave a part free to be any size
+        url, headers = generate_presigned_part("k", "mpu-1", 3, 67108864, 900,
+                                               storages["default"])
+        self.assertEqual(headers, {"Content-Length": "67108864"})
+        query = parse_qs(urlparse(url).query)
+        self.assertEqual(query["X-Amz-Algorithm"], ["AWS4-HMAC-SHA256"])
+        self.assertEqual(query["partNumber"], ["3"])
+        self.assertEqual(query["uploadId"], ["mpu-1"])
+        self.assertIn("content-length", query["X-Amz-SignedHeaders"][0].split(";"))
+
+
+class AssemblyClientTestCase(SimpleTestCase):
+    """The second ceiling. The request client's is covered where it is built for real, above.
+
+    A call inside a device request holds a web worker and a database connection while it waits, so it
+    gets seconds. Assembling a multipart upload is documented as taking several minutes, which is why
+    it runs in a worker — and why the request ceiling there would abandon every large artifact.
+    """
+
+    def _storage(self):
+        return storages.create_storage(S3_STORAGE["default"])
+
+    def test_the_assembly_ceiling_is_minutes(self):
+        config = _assembly_client(self._storage()).meta.config
+        self.assertEqual(config.connect_timeout, 5)
+        self.assertEqual(config.read_timeout, 600)
+        # one attempt here too: the retrying is the completion task's, with backoff, and a second
+        # botocore attempt would sit for another ten minutes before the task ever heard about it
+        self.assertEqual(config.retries["total_max_attempts"], 1)
+
+    def test_each_client_is_built_once_and_the_two_are_not_the_same(self):
+        storage = self._storage()
+        self.assertIs(_assembly_client(storage), _assembly_client(storage))
+        self.assertIsNot(_request_client(storage), _assembly_client(storage))
+
+    def test_the_assembly_client_signs_with_sigv4(self):
+        # only the PRESIGN needed forcing; a real request resolves to v4 on its own. Asserted so a
+        # future change to the shared builder cannot quietly take that away.
+        self.assertEqual(_assembly_client(self._storage()).meta.config.signature_version, "s3v4")

--- a/zentral/contrib/turbo/public_urls.py
+++ b/zentral/contrib/turbo/public_urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
     path('status/', csrf_exempt(public_views.StatusView.as_view()), name='status'),
     path('inventory/', csrf_exempt(public_views.InventoryView.as_view()), name='inventory'),
     path('uploads/', csrf_exempt(public_views.UploadMintView.as_view()), name='uploads'),
+    path('uploads/complete/', csrf_exempt(public_views.UploadCompleteView.as_view()),
+         name='uploads_complete'),
     # the fallback destination when the storage cannot presign a PUT; the token names one row
     path('uploads/<str:token>/', csrf_exempt(public_views.HostedUploadView.as_view()),
          name='upload'),

--- a/zentral/contrib/turbo/public_views/base.py
+++ b/zentral/contrib/turbo/public_views/base.py
@@ -85,7 +85,10 @@ class BaseEnrolledMachineView(WireErrorMixin, View):
         self.user_agent, self.ip = user_agent_and_ip_address_from_request(request)
         self._stamp_last_seen()
         response = super().dispatch(request, *args, **kwargs)
-        if self.request_type and response.status_code == 200:
+        # any 2xx: the event records that the agent made the request and the server took it, and an
+        # endpoint that only accepts the work answers 202. A 4xx is a wire error, which logs instead —
+        # otherwise a machine hammering a malformed request would fill the event stream with it.
+        if self.request_type and 200 <= response.status_code < 300:
             post_turbo_request_event(request, self.serial_number, self.enrollment,
                                      {"request_type": self.request_type, **(self.request_event_payload or {})})
         return response
@@ -103,6 +106,11 @@ class BaseEnrolledMachineView(WireErrorMixin, View):
 class BaseEnrolledMachinePostView(BaseEnrolledMachineView):
     """Base for the agent's JSON POST endpoints: read (and optionally gunzip) the body, hand the
     decoded payload to do_post(), and wrap its dict in a JsonResponse."""
+
+    # 200 for an endpoint that did the work before answering. An endpoint that only accepted the work
+    # says so with a 202, which is part of its contract rather than a detail: the agent moves on
+    # instead of waiting for an answer it has no use for.
+    response_status = 200
 
     def get_json_data(self, request):
         # gzip is the one Content-Encoding the agent uses: standard, and available out of the box on
@@ -128,4 +136,4 @@ class BaseEnrolledMachinePostView(BaseEnrolledMachineView):
         return data
 
     def post(self, request, *args, **kwargs):
-        return JsonResponse(self.do_post(self.get_json_data(request)))
+        return JsonResponse(self.do_post(self.get_json_data(request)), status=self.response_status)

--- a/zentral/contrib/turbo/public_views/results.py
+++ b/zentral/contrib/turbo/public_views/results.py
@@ -1,11 +1,14 @@
 import logging
 
 from django.core.files.storage import storages
+from django.db import transaction
 from django.utils import timezone
 
 from ..events import post_turbo_result_events
-from ..models import JobUpload, UploadErrorReason, UploadStatus, resolve_machine_schedules
+from ..models import (JobUpload, UploadErrorReason, UploadMode, UploadStatus, UploadVerification,
+                      resolve_machine_schedules)
 from ..results import ParsedResult, ResultsBatch
+from ..tasks import abort_multipart_upload_task, complete_multipart_upload_task
 from ..uploads import verify_upload
 from ..wire import WireResultsSerializer
 from .base import BaseEnrolledMachinePostView, WireError
@@ -163,17 +166,43 @@ class ResultsView(BaseEnrolledMachinePostView):
                     row.status = UploadStatus.UPLOADED
                     row.truncated = bool(reported.get("truncated"))
             row.completed_at = timezone.now()
-            if row.status == UploadStatus.UPLOADED:
+            # the status axis, which is this path's to write
+            written = ["status", "error_reason", "truncated", "completed_at", "updated_at"]
+            if row.mode == UploadMode.MULTIPART:
+                # a multipart object is verified by its completion, which validates the whole-object
+                # checksum against the algorithm declared at create — there is nothing left to HEAD.
+                # The verdict may already be here, or the completion may still be owed: the agent's
+                # call can have been lost, and a result is often the first thing to arrive.
+                self._settle_multipart(row, uploads_ref)
+            elif row.status == UploadStatus.UPLOADED:
                 verification = verify_upload(row, reported, storage)
                 if verification is not None:
                     row.verification = verification
                     row.verified_at = timezone.now()
+                    written += ["verification", "verified_at"]
                     # the verdict, not a boolean: `missing` and `mismatch` both answer "no" and
                     # mean different things, and a consumer that has to tell them apart cannot go
                     # to the database from an event
                     uploads_ref[-1] = {**reported, "verification": verification}
-            row.save()
+            # named fields, so this never writes back a verification the completion task committed
+            # while this request was in flight — the multipart path above decides nothing itself
+            row.save(update_fields=written)
         return uploads_ref
+
+    def _settle_multipart(self, row, uploads_ref):
+        # on_commit, both of them: a task that read the row before this request committed would find
+        # it as it was, and the abort would drop the parts of an upload whose failure is not recorded
+        # yet
+        if row.status == UploadStatus.FAILED:
+            transaction.on_commit(lambda: abort_multipart_upload_task.apply_async((str(row.pk),)))
+            return
+        if row.verification == UploadVerification.PENDING:
+            transaction.on_commit(
+                lambda: complete_multipart_upload_task.apply_async((str(row.pk),)))
+            return
+        # the verdict, like the single-PUT path: assembly_failed is its own answer, and a consumer
+        # that has to tell it from a mismatch cannot go to the database from an event
+        uploads_ref[-1] = {**uploads_ref[-1], "verification": row.verification}
 
     @staticmethod
     def _wire_ref(job, kind, version, run, ran_at, outcome, uploads_ref=None):

--- a/zentral/contrib/turbo/public_views/uploads.py
+++ b/zentral/contrib/turbo/public_views/uploads.py
@@ -5,16 +5,19 @@ from datetime import timedelta
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages
+from django.db import transaction
+from botocore.exceptions import BotoCoreError, ClientError
 from django.core.exceptions import RequestDataTooBig
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.generic import View
 
-from ..models import (JobUpload, ScheduleMode, UploadStatus, get_machine_schedule,
-                      one_time_gate_closed)
+from ..models import (JobUpload, ScheduleMode, UploadMode, UploadStatus, UploadVerification,
+                      get_machine_schedule, one_time_gate_closed)
+from ..tasks import complete_multipart_upload_task
 from ..uploads import (MAX_PENDING_UPLOADS, MAX_UPLOAD_ATTEMPTS, UPLOAD_URL_EXPIRY,
                        build_upload_destination, build_upload_key, parse_digests, parse_sha256,
-                       unsign_hosted_upload, upload_max_size)
+                       start_multipart_upload, unsign_hosted_upload, upload_max_size, upload_mode)
 from .base import BaseEnrolledMachinePostView, WireError
 
 logger = logging.getLogger("zentral.contrib.turbo.public_views.uploads")
@@ -28,6 +31,24 @@ def _uuid(data, key):
         return uuid.UUID(value)
     except ValueError:
         raise WireError(f"invalid_{key}")
+
+
+def _part_numbers(value):
+    """The part numbers of a resume, or None when the request is not one.
+
+    A part number is what it says, so it is checked as one here rather than trusted into a range()
+    below. The geometry the row holds decides which of them exist.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, list) or not value:
+        raise WireError("invalid_missing_parts")
+    numbers = []
+    for number in value:
+        if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+            raise WireError("invalid_missing_parts")
+        numbers.append(number)
+    return sorted(set(numbers))
 
 
 class UploadMintView(BaseEnrolledMachinePostView):
@@ -56,6 +77,17 @@ class UploadMintView(BaseEnrolledMachinePostView):
         digests = parse_digests(data.get("digests"))
         if digests is None:
             raise WireError("invalid_digests")
+        # the resume block, both halves or neither: an upload_id names the multipart upload already in
+        # flight, and missing_parts says which parts of it still need a URL
+        upload_id = data.get("upload_id")
+        if upload_id is not None and not isinstance(upload_id, str):
+            raise WireError("invalid_upload_id")
+        missing_parts = _part_numbers(data.get("missing_parts"))
+        if missing_parts is not None and upload_id is None:
+            # the resume shape is both keys. Without the id there is nothing to resume, and signing
+            # part 3 of a multipart upload the agent has not started would hand it a URL for two
+            # thirds of an object it can never finish.
+            raise WireError("missing_upload_id")
 
         resolved = get_machine_schedule(self.configuration, self.serial_number, schedule_pk)
         if resolved is None:
@@ -77,12 +109,20 @@ class UploadMintView(BaseEnrolledMachinePostView):
             raise WireError("too_large", status=413)
         self._check_pending(schedule.pk, run_id, artifact_name)
 
+        mode = upload_mode(size, storage)
+        if mode == UploadMode.MULTIPART and not digests.get("crc64nvme"):
+            # a multipart object is validated by the whole-object CRC and by nothing else: sha256 is
+            # composite-only on a multipart upload, so without this there is no value to complete
+            # with and the assembled object would be accepted unchecked
+            raise WireError("missing_digest")
+
         upload, _ = JobUpload.objects.get_or_create(
             schedule_pk=schedule.pk, serial_number=self.serial_number,
             run_id=run_id, artifact=artifact_name,
             defaults={"schedule_mode": schedule.wire_mode, "size": size, "sha256": sha256,
                       "crc64nvme": digests.get("crc64nvme", ""),
                       "crc32c": digests.get("crc32c", ""),
+                      "mode": mode,
                       "key": ""},
         )
         if upload.status == UploadStatus.UPLOADED:
@@ -91,6 +131,18 @@ class UploadMintView(BaseEnrolledMachinePostView):
             raise WireError("already_uploaded", status=410)
         if upload.attempts >= MAX_UPLOAD_ATTEMPTS:
             raise WireError("attempts_exhausted")
+
+        if upload.mode == UploadMode.MULTIPART and upload.upload_id:
+            if upload_id is not None and upload_id != upload.upload_id:
+                # the presented id is checked against the row, never believed: parts signed against a
+                # different multipart upload would assemble somewhere nothing is looking
+                raise WireError("unknown_upload_id")
+            if (size, sha256) != (upload.size, upload.sha256):
+                # the parts already up are the bytes this row describes, and the geometry was fixed
+                # against that size when the multipart upload was created. A different artifact needs
+                # its own upload, not a resume of this one — re-signing against a new geometry would
+                # produce parts that cannot line up with what is already in flight.
+                raise WireError("artifact_changed")
 
         # a retry re-signs the SAME key, so it overwrites in place instead of leaving a twin
         if not upload.key:
@@ -102,14 +154,28 @@ class UploadMintView(BaseEnrolledMachinePostView):
         upload.sha256 = sha256
         upload.crc64nvme = digests.get("crc64nvme", "")
         upload.crc32c = digests.get("crc32c", "")
+        if upload.mode == UploadMode.MULTIPART and not upload.upload_id:
+            try:
+                start_multipart_upload(upload, artifact, storage)
+            except (BotoCoreError, ClientError):
+                # the one storage call this endpoint makes, and a storage that does not answer is not
+                # the agent's fault. Unhandled it would be an HTML 500 on an endpoint contracted never
+                # to serve one, and ATOMIC_REQUESTS would roll the row back while the storage may
+                # already hold the upload id — an orphan for the lifecycle rule to sweep. A retry-later
+                # answer instead: the agent mints again, which is the right thing to do about a
+                # storage that was busy.
+                logger.exception("Turbo upload mint from %s: could not start the multipart upload",
+                                 self.serial_number)
+                raise WireError("storage_unavailable", status=503)
         upload.attempts += 1
         upload.save()
 
-        url, headers = build_upload_destination(upload, artifact, storage)
+        destination = build_upload_destination(upload, artifact, storage, missing_parts)
         self.request_event_payload = {"artifact": artifact_name, "size": size,
-                                      "attempts": upload.attempts}
-        return {"mode": upload.mode, "url": url, "headers": headers, "key": upload.key,
-                "expires_at": (timezone.now() + timedelta(seconds=UPLOAD_URL_EXPIRY)).isoformat()}
+                                      "attempts": upload.attempts, "mode": upload.mode}
+        return {"mode": upload.mode, "key": upload.key,
+                "expires_at": (timezone.now() + timedelta(seconds=UPLOAD_URL_EXPIRY)).isoformat(),
+                **destination}
 
     def _max_size(self, job, storage):
         # the kind's ceiling under the deployment's, never above it. The definition is resolved: the
@@ -131,6 +197,46 @@ class UploadMintView(BaseEnrolledMachinePostView):
             logger.warning("Turbo upload mint from %s: %s pending rows on schedule %s",
                            self.serial_number, pending, schedule_pk)
             raise WireError("too_many_pending", status=429)
+
+
+class UploadCompleteView(BaseEnrolledMachinePostView):
+    """`POST /public/turbo/uploads/complete/` — every part is up; the server closes the upload.
+
+    There is no presigned complete and no presigned abort. Completing means collecting ETags,
+    building a CompleteMultipartUpload body and, on S3, parsing an error out of a 200 OK — the one
+    place the agent would have needed storage-specific knowledge, which is what "the agent is a plain
+    HTTP client" was supposed to mean.
+
+    202, because both storages document that assembling a multipart upload can take several minutes,
+    so it cannot sit in a device request. The agent has nothing to do with the answer either: it
+    uploaded the bytes, and whether the storage assembles them lands on the row's verification axis.
+    Idempotent, so the agent can retry the call freely.
+    """
+    request_type = "upload_complete"
+    response_status = 202
+
+    def do_post(self, data):
+        schedule_pk = _uuid(data, "schedule_pk")
+        run_id = _uuid(data, "run_id")
+        artifact_name = data.get("artifact")
+        if not isinstance(artifact_name, str) or not artifact_name:
+            raise WireError("missing_artifact")
+        try:
+            upload = JobUpload.objects.get(schedule_pk=schedule_pk, serial_number=self.serial_number,
+                                           run_id=run_id, artifact=artifact_name)
+        except JobUpload.DoesNotExist:
+            raise WireError("unknown_upload")
+        if upload.mode != UploadMode.MULTIPART or not upload.upload_id:
+            # a single PUT is finished when its PUT returns, and `mode` is how the agent knows which
+            # it has — asking for this one is a contract error, not a transient one
+            raise WireError("not_multipart")
+        self.request_event_payload = {"artifact": artifact_name}
+        if upload.verification != UploadVerification.VERIFIED:
+            # on_commit like every other enqueue here: ATOMIC_REQUESTS means a task started now could
+            # run against a transaction that never lands
+            transaction.on_commit(
+                lambda: complete_multipart_upload_task.apply_async((str(upload.pk),)))
+        return {}
 
 
 class HostedUploadView(View):

--- a/zentral/contrib/turbo/tasks.py
+++ b/zentral/contrib/turbo/tasks.py
@@ -1,0 +1,141 @@
+import logging
+
+from celery import shared_task
+from django.core.files.storage import storages
+from django.utils import timezone
+
+from zentral.utils.storage import (abort_multipart_upload, complete_multipart_upload,
+                                   list_multipart_parts, stat_object)
+
+from .models import JobUpload, UploadMode, UploadStatus, UploadVerification
+
+logger = logging.getLogger("zentral.contrib.turbo.tasks")
+
+
+# What the storage says when the upload cannot be assembled, ever. A checksum that does not match the
+# bytes, or a part list that cannot make an object — none of it improves by asking again, and a retry
+# would only keep the parts alive and billed. Everything else is transient by default: a storage that
+# is unreachable or throttling gets the backoff.
+TERMINAL_COMPLETION_ERRORS = {
+    "BadDigest",              # the whole-object checksum the agent declared is not what arrived
+    "EntityTooSmall",         # a part below the minimum, so the geometry never made an object
+    "InvalidPart",            # a part the storage does not have, or whose ETag moved
+    "InvalidPartOrder",
+    "InvalidRequest",
+}
+
+
+@shared_task(bind=True, max_retries=5)
+def complete_multipart_upload_task(self, upload_pk):
+    """Assemble a multipart upload, and record on the row whether the storage agreed.
+
+    This is the second axis for a multipart object, and the only place it is decided: the whole-object
+    checksum is validated by the completion itself, so there is nothing left for the ingest to HEAD.
+
+    Idempotent by design, because the agent may call the endpoint again after a timeout and the result
+    ingest re-enqueues any upload still waiting on one. Completing an upload that is already complete
+    is success, not an error.
+    """
+    from botocore.exceptions import ClientError
+
+    upload = JobUpload.objects.get(pk=upload_pk)
+    result = {"upload": {"pk": str(upload.pk), "key": upload.key}}
+    if upload.mode != UploadMode.MULTIPART or not upload.upload_id:
+        # nothing to assemble. Reachable through a re-enqueue that raced a row it does not describe.
+        logger.error("Turbo upload %s is not a multipart upload", upload.pk)
+        return {**result, "status": "not_multipart"}
+    if upload.verification == UploadVerification.VERIFIED:
+        return {**result, "status": "already_verified"}
+
+    storage = storages["default"]
+    try:
+        parts = list_multipart_parts(upload.key, upload.upload_id, storage=storage)
+    except ClientError as error:
+        return _settle(self, upload, result, error, storage)
+    if not parts:
+        # the agent said every part was up and the storage is holding none: either they aged out on
+        # the AbortIncompleteMultipartUpload rule, or they were never there. Nothing to wait for.
+        return _record(upload, {**result, "status": "no_parts"}, UploadVerification.ASSEMBLY_FAILED)
+
+    result["parts"] = len(parts)
+    try:
+        complete_multipart_upload(upload.key, upload.upload_id, parts, upload.crc64nvme, upload.size,
+                                  storage=storage)
+    except ClientError as error:
+        return _settle(self, upload, result, error, storage)
+    return _record(upload, {**result, "status": "completed"}, UploadVerification.VERIFIED)
+
+
+def _settle(task, upload, result, error, storage):
+    """What a failed storage call means: done already, done for, or worth another try."""
+    code = error.response.get("Error", {}).get("Code", "")
+    if code == "NoSuchUpload":
+        # the upload id is gone, which is what the storage says BOTH for one that completed already
+        # and for one whose parts were aborted. The object itself is the only thing that tells them
+        # apart, and a second completion call is exactly how the first case arrives here.
+        try:
+            stored = stat_object(upload.key, storage=storage)
+        except Exception:
+            logger.exception("Could not stat turbo upload %s", upload.pk)
+            raise task.retry(exc=error, countdown=60 * 2 ** task.request.retries)
+        if _is_the_completed_object(stored, upload):
+            return _record(upload, {**result, "status": "already_completed"},
+                           UploadVerification.VERIFIED)
+        return _record(upload, {**result, "status": "parts_gone"},
+                       UploadVerification.ASSEMBLY_FAILED)
+    if code in TERMINAL_COMPLETION_ERRORS:
+        logger.error("Turbo upload %s could not be assembled: %s", upload.pk, code)
+        return _record(upload, {**result, "status": "failed", "error": code},
+                       UploadVerification.ASSEMBLY_FAILED)
+    raise task.retry(exc=error, countdown=60 * 2 ** task.request.retries)
+
+
+def _is_the_completed_object(stored, upload):
+    # is the object at the key this upload, assembled? The CRC settles it: the HEAD reports the
+    # whole-object value the completion validated, and the row holds the one the agent declared, so a
+    # match is exact where a match on the size alone can be a coincidence. The size is the fallback
+    # for an object whose checksum the HEAD does not carry.
+    if stored is None:
+        return False
+    if stored["crc64nvme"] and upload.crc64nvme:
+        return stored["crc64nvme"] == upload.crc64nvme
+    return stored["size"] == upload.size
+
+
+def _record(upload, result, verification):
+    # the verification axis only, and update_fields so it is only that. This row was loaded before
+    # ListParts and CompleteMultipartUpload, which the storages document as taking MINUTES, and the
+    # result for the same run arrives in that window and closes the status axis. A full save here
+    # would write this stale copy back over it: the status would return to pending for good — the
+    # agent has been acknowledged and never resends — the row would count against MAX_PENDING_UPLOADS,
+    # and the console would show a report that did arrive as one that did not.
+    upload.verification = verification
+    upload.verified_at = timezone.now()
+    upload.save(update_fields=["verification", "verified_at", "updated_at"])
+    return {**result, "verification": verification}
+
+
+@shared_task
+def abort_multipart_upload_task(upload_pk):
+    """Drop the parts of an upload the agent has given up on.
+
+    The bucket's AbortIncompleteMultipartUpload rule is the backstop, and it has to be: a result can
+    be a day behind, so it is often the first thing to act. This is the fast path for the case where
+    the agent told us, so the parts stop being billed today rather than at the end of that window.
+    """
+    from botocore.exceptions import ClientError
+
+    upload = JobUpload.objects.get(pk=upload_pk)
+    if upload.mode != UploadMode.MULTIPART or not upload.upload_id:
+        return {"status": "not_multipart"}
+    if upload.status != UploadStatus.FAILED:
+        # the row moved on between the enqueue and here — an abort now would drop the parts of an
+        # upload somebody is still counting on
+        return {"status": "not_failed"}
+    try:
+        abort_multipart_upload(upload.key, upload.upload_id, storage=storages["default"])
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code", "") != "NoSuchUpload":
+            raise
+        # already gone, which is the outcome we wanted
+    return {"upload": {"pk": str(upload.pk), "key": upload.key}, "status": "aborted"}

--- a/zentral/contrib/turbo/uploads.py
+++ b/zentral/contrib/turbo/uploads.py
@@ -7,10 +7,11 @@ from django.urls import reverse
 from django.utils import timezone
 
 from zentral.conf import api_base_url
-from zentral.utils.storage import (file_storage_has_presigned_uploads, generate_presigned_put,
-                                   sha256_object, stat_object)
+from zentral.utils.storage import (create_multipart_upload, file_storage_has_presigned_uploads,
+                                   generate_presigned_part, generate_presigned_put, sha256_object,
+                                   stat_object)
 
-from .models import UploadVerification
+from .models import UploadMode, UploadVerification
 
 
 logger = logging.getLogger("zentral.contrib.turbo.uploads")
@@ -65,6 +66,18 @@ MAX_UPLOAD_ATTEMPTS = 5
 # version bump re-arms a one-time job, so more than one open run is legitimate; a dozen is not.
 MAX_PENDING_UPLOADS = 12
 
+# The slicing rule for a multipart upload. Server-side only — the agent reads the geometry off the
+# mint response, so retuning this needs no protocol change and no agent release.
+MULTIPART_PART_SIZE = 64 * 2**20
+# TWO part sizes and not one. Resumability is the entire point, and at one there is none to buy: a
+# part_size + 1 artifact is a two-part upload whose second part is one byte, so losing the first part
+# costs the same retransmission that restarting a single PUT would have. The whole multipart bill —
+# an upload id on the row, N signed URLs, a device-facing completion call, a queue task and a
+# lifecycle obligation for parts that never complete — would be paid to protect a one-byte tail. At
+# two, the first failure loses at most half the transfer, so a resume saves at least one whole part.
+# That is the line: multipart starts paying when a resume can save a full part.
+MULTIPART_THRESHOLD = 2 * MULTIPART_PART_SIZE
+
 _UNSAFE_KEY_CHARS = re.compile(r"[^A-Za-z0-9._-]")
 # a length check is not a format check: a 64-character non-hex digest passes one and reaches the
 # encoder, which cannot unhexlify it — on a device endpoint that is a 500 instead of a 400 the agent
@@ -80,6 +93,32 @@ _hosted_upload_signer = TimestampSigner(salt="zentral.contrib.turbo.uploads")
 
 def upload_max_size(storage=None):
     return PRESIGNED_UPLOAD_MAX_SIZE if file_storage_has_presigned_uploads(storage) else hosted_upload_max_size()
+
+
+def upload_mode(size, storage):
+    """Single PUT or multipart, and entirely the server's business.
+
+    The agent sends the same mint body either way and reads the mode off the response, so there is
+    nothing for it to predict, no part size to cache, and no stale-configuration two-step. Nothing
+    forces the choice either: S3's single-PUT ceiling is 5 GiB against a 2 GiB upload_max_size, so a
+    single PUT is legal for every artifact Zentral accepts and multipart is purely an optimisation.
+    """
+    if size >= MULTIPART_THRESHOLD and file_storage_has_presigned_uploads(storage):
+        return UploadMode.MULTIPART
+    return UploadMode.PUT
+
+
+def part_lengths(size, part_size):
+    """The exact length of every part, in order.
+
+    Returned rather than computed at the call site so the slicing falls out of the mint response —
+    the agent reads a Content-Length per part instead of reproducing this division.
+    """
+    full, tail = divmod(size, part_size)
+    lengths = [part_size] * full
+    if tail:
+        lengths.append(tail)
+    return lengths
 
 
 def upload_digests(storage=None):
@@ -222,14 +261,22 @@ def _report_agrees_with_the_mint(upload, reported):
     return True
 
 
-def build_upload_destination(upload, artifact, storage):
-    """Where to PUT the artifact, and the headers to send with it.
+def build_upload_destination(upload, artifact, storage, missing_parts=None):
+    """Where to send the artifact, as the mode-specific half of the mint response.
 
-    The two branches produce the same contract on the wire — one `mode: "put"` shape — so the agent
-    has no storage to detect. What differs is who validates the body: a presigned PUT signs the
-    length and the digest as headers, so the storage rejects a mismatch and Zentral never reads a
-    byte; the hosted fallback has to read it, which is exactly why its ceiling is small.
+    A single PUT is one url and the headers to send with it, and the two single-PUT branches produce
+    the same shape on the wire so the agent has no storage to detect. What differs is who validates
+    the body: a presigned PUT signs the length and the digest as headers, so the storage rejects a
+    mismatch and Zentral never reads a byte; the hosted fallback has to read it, which is exactly why
+    its ceiling is small.
+
+    A multipart upload is the geometry plus one presigned URL per part. The geometry comes back WITH
+    the URLs, which is the whole reason it is not published or cached anywhere.
     """
+    if upload.mode == UploadMode.MULTIPART:
+        return {"upload_id": upload.upload_id,
+                "part_size": upload.part_size,
+                "parts": _presigned_parts(upload, storage, missing_parts)}
     if file_storage_has_presigned_uploads(storage):
         url, headers = generate_presigned_put(
             upload.key, upload.size, artifact.content_type, upload.sha256, UPLOAD_URL_EXPIRY,
@@ -239,4 +286,32 @@ def build_upload_destination(upload, artifact, storage):
         url = "{}{}".format(api_base_url(),
                             reverse("turbo_public:upload", args=(sign_hosted_upload(upload),)))
         headers = {"Content-Type": artifact.content_type, "Content-Length": str(upload.size)}
-    return url, headers
+    return {"url": url, "headers": headers}
+
+
+def _presigned_parts(upload, storage, missing_parts):
+    # against the row's OWN part_size, fixed when the multipart upload was created: a resume has to
+    # produce parts that line up with the object already in flight, so a change to the deployment's
+    # default in the meantime must not reach it
+    lengths = part_lengths(upload.size, upload.part_size)
+    wanted = range(1, len(lengths) + 1)
+    if missing_parts is not None:
+        # a resume signs only what is still needed, and only numbers this geometry actually has
+        wanted = [n for n in missing_parts if 1 <= n <= len(lengths)]
+    parts = []
+    for number in wanted:
+        url, headers = generate_presigned_part(
+            upload.key, upload.upload_id, number, lengths[number - 1], UPLOAD_URL_EXPIRY, storage,
+        )
+        parts.append({"n": number, "url": url, "headers": headers})
+    return parts
+
+
+def start_multipart_upload(upload, artifact, storage):
+    """Create the multipart upload the row will hold for the rest of its life.
+
+    Once, on the first mint that chose multipart: the upload id and the part size are then the row's,
+    and every resume re-signs against them.
+    """
+    upload.upload_id = create_multipart_upload(upload.key, artifact.content_type, storage)
+    upload.part_size = MULTIPART_PART_SIZE

--- a/zentral/utils/storage.py
+++ b/zentral/utils/storage.py
@@ -5,18 +5,34 @@ import hashlib
 from django.core.files.storage import storages, InvalidStorageError
 
 
-# One HEAD is a single small round trip — tens of milliseconds — but it happens on a device endpoint,
-# inside the request transaction, so it gets an explicit ceiling instead of botocore's minute-scale
-# defaults: an unbounded call to a storage that has gone quiet holds a web worker AND a database
-# connection. One attempt, deliberately: a retry would double how long that transaction stays open to
-# buy an answer that was never urgent, and the caller treats "could not tell" as a normal outcome it
-# can ask about again later.
-_STAT_CONNECT_TIMEOUT = 2
-_STAT_READ_TIMEOUT = 5
+# A HEAD, or starting a multipart upload, is a single small round trip — tens of milliseconds — but it
+# happens on a device endpoint, inside the request transaction, so it gets an explicit ceiling instead
+# of botocore's minute-scale defaults: an unbounded call to a storage that has gone quiet holds a web
+# worker AND a database connection.
+_REQUEST_CONNECT_TIMEOUT = 2
+_REQUEST_READ_TIMEOUT = 5
+
+# Assembling a multipart upload is the exception: both storages document that it can take several
+# MINUTES, which is why it runs in a worker and not in a request. The ceiling is there to bound a
+# connection that died rather than to bound the operation, and the retrying is the task's, with
+# backoff, rather than botocore's.
+_ASSEMBLY_CONNECT_TIMEOUT = 5
+_ASSEMBLY_READ_TIMEOUT = 600
+
 # total, not retries: botocore reads `max_attempts` as the number of RETRIES and stores
-# max_attempts + 1, so the obvious spelling of "once" asks for twice and doubles the worst case this
-# ceiling exists to bound. total_max_attempts is the key it keeps, and it means what it says.
-_STAT_TOTAL_ATTEMPTS = 1
+# max_attempts + 1, so the obvious spelling of "once" asks for twice and doubles the worst case these
+# ceilings exist to bound. total_max_attempts is the key it keeps, and it means what it says. One
+# attempt for both: the caller of a request-path call treats "could not tell" as a normal outcome it
+# can ask about again later, and the assembly is retried by its task, with backoff.
+_ONE_ATTEMPT = {"mode": "standard", "total_max_attempts": 1}
+
+# The one line of the multipart design that must not be dropped. Declaring the algorithm at
+# CreateMultipartUpload is what makes the checksum supplied at completion actually validate: without
+# it S3 accepts a WRONG whole-object checksum silently, and HeadObject afterwards reports a perfectly
+# correct one, because S3 computed its own — the object looks verified and is not. CRC64NVME and not
+# SHA-256 because S3 offers a full-object checksum on a multipart upload only for the CRC algorithms:
+# only those compose from part checksums into a checksum of the whole object.
+MULTIPART_CHECKSUM_ALGORITHM = "CRC64NVME"
 
 
 def file_storage_has_signed_urls(storage=None):
@@ -84,19 +100,28 @@ def _presigning_client(storage):
     return _s3_client(storage, "_zentral_presigning_client", signature_version="s3v4")
 
 
-def _stat_client(storage):
-    """A client for the verification HEAD, with a ceiling the deployment's config cannot lift.
+def _request_client(storage):
+    """A client for the storage calls made inside a device request, with a ceiling the deployment's
+    config cannot lift.
 
-    Unlike the presigning client this one talks to the network, on a device endpoint, inside the
-    request transaction — so an unbounded call to a storage that has gone quiet would hold a web
-    worker AND a database connection. One attempt, deliberately: a retry would double how long that
-    transaction stays open to buy an answer that was never urgent, and the caller treats "could not
-    tell" as a normal outcome it can ask about again later.
+    Unlike the presigning client these talk to the network, on a device endpoint, inside the request
+    transaction — so an unbounded call to a storage that has gone quiet would hold a web worker AND a
+    database connection. One attempt, deliberately: a retry would double how long that transaction
+    stays open to buy an answer that was never urgent, and the callers treat "could not tell" as a
+    normal outcome they can ask about again later.
     """
-    return _s3_client(storage, "_zentral_stat_client",
-                      connect_timeout=_STAT_CONNECT_TIMEOUT,
-                      read_timeout=_STAT_READ_TIMEOUT,
-                      retries={"mode": "standard", "total_max_attempts": _STAT_TOTAL_ATTEMPTS})
+    return _s3_client(storage, "_zentral_request_client",
+                      connect_timeout=_REQUEST_CONNECT_TIMEOUT,
+                      read_timeout=_REQUEST_READ_TIMEOUT,
+                      retries=_ONE_ATTEMPT)
+
+
+def _assembly_client(storage):
+    """The one client allowed to wait minutes, for the one call that takes them, in a worker."""
+    return _s3_client(storage, "_zentral_assembly_client",
+                      connect_timeout=_ASSEMBLY_CONNECT_TIMEOUT,
+                      read_timeout=_ASSEMBLY_READ_TIMEOUT,
+                      retries=_ONE_ATTEMPT)
 
 
 def _object_key(storage, key):
@@ -169,7 +194,7 @@ def stat_object(key, storage=None):
         storage = storages["default"]
     if file_storage_has_presigned_uploads(storage):
         from botocore.exceptions import ClientError
-        client = _stat_client(storage)
+        client = _request_client(storage)
         try:
             response = client.head_object(Bucket=storage.bucket_name, Key=_object_key(storage, key),
                                           ChecksumMode="ENABLED")
@@ -200,6 +225,90 @@ def sha256_object(key, storage=None):
         for chunk in stored.chunks():
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def create_multipart_upload(key, content_type, storage):
+    """Start a multipart upload, and DECLARE the checksum algorithm.
+
+    Every call of this plane names the object through _object_key: with a `location` set, a bare key
+    would start the upload, sign its parts, list them and complete them outside the namespace the
+    rest of the storage reads, and the object would land where nothing looks for it.
+
+    The declaration is what makes the value supplied at completion validate anything — see
+    MULTIPART_CHECKSUM_ALGORITHM. ChecksumType and the object size at completion are genuinely
+    optional (CRC64NVME defaults to full-object), and are sent for clarity; the algorithm is not
+    optional, and its optionality elsewhere must not be read as license to drop it.
+    """
+    response = _request_client(storage).create_multipart_upload(
+        Bucket=storage.bucket_name,
+        Key=_object_key(storage, key),
+        ContentType=content_type,
+        ChecksumAlgorithm=MULTIPART_CHECKSUM_ALGORITHM,
+        ChecksumType="FULL_OBJECT",
+    )
+    return response["UploadId"]
+
+
+def generate_presigned_part(key, upload_id, part_number, size, expires_in, storage):
+    """A presigned UploadPart, and the one header that goes with it.
+
+    Geometry only: a part carries no checksum on either storage, so the length is the entire contract
+    — and it is a SIGNED header, which is why this goes through the SigV4 client like every other
+    presign here. The legacy V2 presign signs no header at all, and a part could then be any size.
+    """
+    url = _presigning_client(storage).generate_presigned_url(
+        "upload_part",
+        Params={"Bucket": storage.bucket_name, "Key": _object_key(storage, key),
+                "UploadId": upload_id, "PartNumber": part_number, "ContentLength": size},
+        ExpiresIn=expires_in,
+    )
+    return url, {"Content-Length": str(size)}
+
+
+def list_multipart_parts(key, upload_id, storage):
+    """The parts the storage is holding, as CompletedPart entries in part order.
+
+    Paginated, because reading a truncated first page as the whole list would assemble a partial
+    object and call it done. Zentral's own geometry cannot fill a page — which is exactly why a
+    truncated answer must not be mistaken for a complete one.
+    """
+    paginator = _assembly_client(storage).get_paginator("list_parts")
+    parts = []
+    for page in paginator.paginate(Bucket=storage.bucket_name, Key=_object_key(storage, key),
+                                   UploadId=upload_id):
+        for part in page.get("Parts", ()):
+            parts.append({"PartNumber": part["PartNumber"], "ETag": part["ETag"]})
+    parts.sort(key=lambda part: part["PartNumber"])
+    return parts
+
+
+def complete_multipart_upload(key, upload_id, parts, crc64nvme, object_size, storage):
+    """Assemble the object, and let the storage refuse it if the bytes are not what was declared.
+
+    The part list comes from the storage, never from a client. The whole-object checksum is the one
+    the agent declared before it sent a byte, and S3 computes the assembled object's own and answers
+    BadDigest on a mismatch — because the algorithm was declared at create.
+    """
+    return _assembly_client(storage).complete_multipart_upload(
+        Bucket=storage.bucket_name,
+        Key=_object_key(storage, key),
+        UploadId=upload_id,
+        MultipartUpload={"Parts": parts},
+        ChecksumCRC64NVME=crc64nvme,
+        ChecksumType="FULL_OBJECT",
+        MpuObjectSize=object_size,
+    )
+
+
+def abort_multipart_upload(key, upload_id, storage):
+    """Drop the parts of an upload that will never complete.
+
+    Parts of an abandoned multipart upload are stored, and billed, until something removes them. The
+    bucket's AbortIncompleteMultipartUpload rule is the backstop; this is the fast path, for the
+    cases where the agent told us it gave up.
+    """
+    _request_client(storage).abort_multipart_upload(
+        Bucket=storage.bucket_name, Key=_object_key(storage, key), UploadId=upload_id)
 
 
 def select_dist_storage():


### PR DESCRIPTION
Stacked on #1685 — review that one first. A large artifact goes up in parts now, and Zentral closes the upload rather than the agent.

## `storage: the multipart control plane, and the declaration it rests on`

`create_multipart_upload()` declares `ChecksumAlgorithm: CRC64NVME`, and **that declaration is the one line of this design that must not be dropped.** Without it S3 accepts a *wrong* whole-object checksum at completion, and `HeadObject` afterwards reports a perfectly correct one because S3 computed its own — the object looks verified and is not. `ChecksumType: FULL_OBJECT` and `MpuObjectSize` genuinely are optional; do not read their optionality as license to drop the algorithm.

CRC-64/NVME rather than SHA-256 because S3 offers a full-object checksum on a multipart upload only for the CRC algorithms: only those compose from part checksums into a checksum of the whole object.

`ListParts` paginates. Reading a truncated first page as the whole list would assemble a partial object and call it done — and Zentral's own geometry cannot fill a page, which is exactly why a truncated answer must not be mistaken for a complete one.

The presigned part goes through the SigV4 client, like every presign here. A part carries no checksum on either storage, so its length is the entire contract, and the legacy V2 presign signs no header at all. Measured again while writing this: a raw client presigns V2 in `us-east-1`, so this is not hypothetical.

**Two client ceilings, and a correction to #1685's.** A call inside a device request keeps seconds; the assembly gets ten minutes, since both storages document that it can take several. And `max_attempts` in botocore counts **retries**, not attempts:

```
max_attempts=0 -> {'mode': 'standard', 'total_max_attempts': 1}
max_attempts=1 -> {'mode': 'standard', 'total_max_attempts': 2}
```

#1685's review had already fixed its stat client, with the better spelling: `total_max_attempts: 1`, the key botocore actually keeps, which cannot be misread the way `max_attempts` can. This PR adopts it for the assembly client too, and the tests assert that key. The client is renamed `_request_client`, because this PR gives it two more callers — starting and aborting a multipart upload — and `_stat_client` would have named only one of the three.

## `turbo: multipart, and the server closes it`

The mint answers `mode: "multipart"` with the geometry and one signed URL per part. **The geometry comes back with the URLs**, which is the whole reason it is not published or cached anywhere: the agent sends the same body either way and reads the mode off the answer, so there is nothing to predict, no part size to cache, and no stale-configuration two-step.

**The threshold is two part sizes**, 128 MB. At one there is no resumability to buy: a `part_size + 1` artifact is a two-part upload whose second part is one byte, so losing the first part costs the retransmission that restarting a single `PUT` would have — the whole multipart bill paid to protect a one-byte tail. At two, the first failure loses at most half the transfer.

**A multipart artifact is refused without `crc64nvme`.** `sha256` is composite-only on a multipart upload, so the whole-object CRC is the only thing that can validate the assembled object; without it completion would accept whatever arrived. Nothing uses the CRC on a single `PUT`, and a single `PUT` is not refused for want of it.

**Completion is the server's.** The agent posts the three keys that identify the upload and gets a `202`; Zentral lists the parts from the storage — never from the wire — and completes with its own credentials. That is the one place the agent would have needed storage-specific knowledge: collecting `ETag`s, building a completion body, and on S3 finding an error inside a `200 OK`. It runs in Celery because completion is documented as taking minutes, and the agent has no use for the answer anyway. Idempotent, so the call can be retried freely.

The task maps each answer onto the verification axis. A checksum that does not match the bytes is terminal — `assembly_failed` — because no retry improves it and retrying keeps the parts alive and billed. `NoSuchUpload` is ambiguous: the storage says it both for an upload that completed already and for one whose parts were aborted, and the object itself is the only thing that tells them apart. Everything else is transient and gets backoff.

**Result ingest does not HEAD a multipart row** — completion already validated the whole object. What it does instead is notice that a completion is still owed (the agent's call can have been lost, and a result is often the first thing to arrive) and drop the parts when the agent reports giving up.

A resume re-signs only the parts the agent names, against the row's **own** part size, fixed when the upload was created. It is refused when it declares a different `size` or `sha256`: those parts are the bytes the row describes, and re-signing against a new geometry would hand out parts that cannot line up with what is already in flight. I found that one reviewing my own first pass, which had no such check. The presented `upload_id` is checked against the row rather than believed.

Two small changes to shared code the `202` needed: the base POST view grows a `response_status`, and the `turbo_request` event posts on any 2xx rather than a literal `200` — otherwise an endpoint that only accepts the work would emit no event at all.

## Deployment

**The `AbortIncompleteMultipartUpload` lifecycle rule on the bucket is now load-bearing.** Zentral drops the parts when an agent reports giving up, but nothing else removes the parts of an upload the agent never reports, and parts are stored and billed until something does. It is in the docs and the changelog, but it is a deployment step and not only code.

## Not in this PR

**A sweep for multipart rows still `pending`** — raised in review, and a real gap. Only two things ask for a completion: the agent's `uploads/complete/` call and the result ingest. After the task's five retries are spent, or if both enqueues are lost, nothing asks again: the row stays `pending` for ever, counts against `MAX_PENDING_UPLOADS`, and its parts age out on the lifecycle rule leaving no object. The fix is a periodic re-enqueue and not a verdict on timeout — a storage that was unavailable is not a failed assembly, which #1685 settled — and this app already has the shape for it in `cleanup_turbo_machine_job_statuses`. Recorded in the plan as its own piece of work.

GCS multipart — its XML API is documented as compatible and the design accommodates it, but it is a second server-side implementation through a different client. And the console views to list and download an artifact.

## Tests

Full suite green — 8704 tests. 100% coverage on every line of the three modules this touches (`zentral/utils/storage.py`, `zentral/contrib/turbo/uploads.py`, the new `tasks.py`), verified from `coverage json` rather than from the diff, since a new file does not show up in a diff-hunk intersection. 71 new tests, `mkdocs build --strict` clean, all in-page anchors resolve.

Every S3 call is stubbed with `botocore.stub.Stubber` against the real service model, so a parameter S3 does not have — or a response member that is not one — fails here rather than in production. That matters more than usual for this PR: the declaration everything rests on is one S3 accepts silently when it is absent.

