### PR TITLE
incidents: fix the machine incident pagination on the incident detail…

### DIFF
--- a/tests/core_incidents/test_views.py
+++ b/tests/core_incidents/test_views.py
@@ -158,6 +158,8 @@ class InventoryViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Machine incidents (23)")
         self.assertContains(response, "page 1 of 3")
+        self.assertContains(response, '<a class="page-link" href="?page=2">Next')
+        self.assertContains(response, '<a class="page-link" href=""><i class="bi bi-caret-left"></i> Previous')
 
     def test_incident_detail_machine_incidents_second_page(self):
         incident = self._force_incident()
@@ -168,6 +170,31 @@ class InventoryViewsTestCase(TestCase, LoginCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Machine incidents (23)")
         self.assertContains(response, "page 2 of 3")
+        self.assertContains(response, '<a class="page-link" href="?page=3">Next')
+        self.assertContains(response, '<a class="page-link" href="?page=1"><i class="bi bi-caret-left"></i> Previous')
+        self.assertContains(response, '<a href="?">{}</a>'.format(incident.name))
+
+    def test_incident_detail_machine_incidents_last_page(self):
+        incident = self._force_incident()
+        for i in range(23):
+            self._force_machine_incident(incident)
+        self.login("incidents.view_incident", "incidents.view_machineincident")
+        response = self.client.get(reverse("incidents:incident", args=(incident.pk,)) + "?page=3")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "page 3 of 3")
+        self.assertContains(response, '<a class="page-link" href="">Next')
+        self.assertContains(response, '<a class="page-link" href="?page=2"><i class="bi bi-caret-left"></i> Previous')
+
+    def test_incident_detail_machine_incidents_single_page(self):
+        incident = self._force_incident()
+        for i in range(3):
+            self._force_machine_incident(incident)
+        self.login("incidents.view_incident", "incidents.view_machineincident")
+        response = self.client.get(reverse("incidents:incident", args=(incident.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Machine incidents (3)")
+        self.assertNotContains(response, "page 1 of 1")
+        self.assertNotContains(response, "Page navigation")
 
     def test_incident_detail_no_perm_no_machine_incidents(self):
         incident = self._force_incident()

--- a/zentral/core/incidents/views.py
+++ b/zentral/core/incidents/views.py
@@ -79,6 +79,16 @@ class IncidentView(PermissionRequiredMixin, UserPaginationMixin, DetailView):
         except InvalidPage:
             raise Http404("Invalid page number")
         ctx["machine_incidents"] = page.object_list
+        if page.has_next():
+            qd = self.request.GET.copy()
+            qd["page"] = page.next_page_number()
+            ctx["next_url"] = "?{}".format(qd.urlencode())
+        if page.has_previous():
+            qd = self.request.GET.copy()
+            qd["page"] = page.previous_page_number()
+            ctx["previous_url"] = "?{}".format(qd.urlencode())
+            qd.pop("page", None)
+            ctx["reset_link"] = "?{}".format(qd.urlencode())
 
         # events links
         if self.request.user.has_perms(EventsMixin.permission_required):


### PR DESCRIPTION
## Summary

- On the incident detail page, the list of machine incidents is paginated by the user's "Global items per page", but the Previous/Next links never rendered. The template calls the `pagination` tag with `next_url` and `previous_url`, and the view never put them in the context, so only the first page was reachable without editing the URL by hand.
- The view now adds `next_url`, `previous_url` and the breadcrumb `reset_link` to the context, the same way `UserPaginationListView` does it for the list views. The view structure and template are otherwise unchanged.

## Test plan

- [x] `tests.core_incidents` passes (60 tests), with new assertions on the rendered Previous/Next links for the first, middle and last page, and a single-page case with no navigation.
- [x] `ruff check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)