### PR TITLE
accounts: show the items per page setting to remote users on the profile page

### DIFF
--- a/server/templates/accounts/profile.html
+++ b/server/templates/accounts/profile.html
@@ -60,6 +60,7 @@
             <a href="{% url 'accounts:verification_devices' %}">Manage your verification devices</a>
         </td>
         </tr>
+        {% endif %}
         <tr>
             <th>
                 Global items per page
@@ -68,7 +69,6 @@
                 {{ user.items_per_page }}
             </td>
         </tr>
-        {% endif %}
     </tbody>
     </table>
 </div>

--- a/tests/server_accounts/views/test_users_views.py
+++ b/tests/server_accounts/views/test_users_views.py
@@ -362,6 +362,18 @@ class AccountUsersViewsTestCase(TestCase, LoginCase, EventAssertions):
         self.assertTemplateUsed(response, "accounts/profile.html")
         self.assertNotContains(response, self.user.username)
         self.assertContains(response, self.ui_user.username)
+        self.assertContains(response, ">Change password</a>")
+        self.assertContains(response, ">Manage your verification devices</a>")
+        self.assertContains(response, "Global items per page")
+
+    def test_profile_remote_user(self):
+        self.client.force_login(self.remote_user)
+        response = self.client.get(reverse("accounts:profile"))
+        self.assertTemplateUsed(response, "accounts/profile.html")
+        self.assertContains(response, self.remote_user.username)
+        self.assertNotContains(response, ">Change password</a>")
+        self.assertNotContains(response, ">Manage your verification devices</a>")
+        self.assertContains(response, "Global items per page")
 
     def test_update_profile_login_redirect(self):
         self.login_redirect("update_profile")


### PR DESCRIPTION
## Summary

- The "Global items per page" row on the profile page was inside the block hidden for remote users, together with the password and verification device links, although remote users can update the setting and it applies to their lists too. Move it out of the block.
- The verification devices link stays hidden for remote users: the second factor is only checked on the local password login, which remote users cannot use, and the admin user detail page already hides them the same way.

## Test plan

- [x] `tests.server_accounts.views.test_users_views` passes (108 tests). The profile test now asserts the password, verification devices and items per page rows for a local user, and a new test asserts a remote user sees only the items per page row.
- [x] `ruff check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)