### PR TITLE
Bump PyJWT to 2.14.0, and do not use the HMAC algorithms an OpenID Connect issuer advertises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,8 @@ The probe caches expire after 300 seconds now. A notifier notification was the o
 
 A store worker verifies the configuration of its store every 300 seconds now. Before, only a notifier notification made the worker apply a change, and the notifier does not guarantee delivery. A worker that did not receive the notification kept the event filters and the credentials from its start, and an operator had to restart it. The worker now stops when it finds a change to its store, and starts again with the configuration in the database.
 
+Zentral does not use the HMAC algorithms that an OpenID Connect issuer advertises anymore. It verifies an ID token with a key from the issuer JWKS, and the HMAC algorithms use the client secret. An ID token signed with one of them gives an invalid token error now, and not a 500 error.
+
 Fixed the `zentral_audit` events of the Santa enrollments and the Santa enrolled machines, which were not linked to the object they report. A model that declares the parents of an object replaced the link to the object itself, and the events of that object did not reach its page. A model keeps control of its own key when it declares one, because the MDM commands are linked by UUID and not by primary key.
 
 Fixed the version of an Osquery query in the events published when a user changed the query from the web console. The version was a database expression, and not a number.

--- a/requirements_constraints.txt
+++ b/requirements_constraints.txt
@@ -125,7 +125,7 @@ pyasn1_modules==0.4.2
 pycparser==3.0
 pycurl==7.46.0
 Pygments==2.20.0
-PyJWT==2.13.0
+PyJWT==2.14.0
 pyOpenSSL==26.4.0
 pyotp==2.9.0
 pyparsing==3.2.5

--- a/tests/utils/test_oidc.py
+++ b/tests/utils/test_oidc.py
@@ -1,3 +1,6 @@
+import base64
+import hashlib
+import hmac
 import json
 import time
 from unittest.mock import patch
@@ -38,6 +41,10 @@ class OIDCUtilsTestCase(TestCase):
             encryption_algorithm=serialization.NoEncryption(),
         )
         public_key = private_key.public_key()
+        cls.public_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
         jwk_json = RSAAlgorithm.to_jwk(public_key)
         jwk = json.loads(jwk_json)
         jwk["kid"] = "test-kid"
@@ -49,11 +56,11 @@ class OIDCUtilsTestCase(TestCase):
     # utils
 
     @staticmethod
-    def _make_oid_config(issuer):
+    def _make_oid_config(issuer, algorithms=None):
         return {
             "issuer": issuer,
             "jwks_uri": f"{issuer}/jwks",
-            "id_token_signing_alg_values_supported": ["RS256"],
+            "id_token_signing_alg_values_supported": algorithms or ["RS256"],
         }
 
     def _make_token(self, iss, aud, exp=None, iat=None, sub="user-123", kid="test-kid", none_alg=False):
@@ -85,6 +92,23 @@ class OIDCUtilsTestCase(TestCase):
             },
             **kwargs,
         )
+
+    # jwt.encode refuses the public key as an HMAC secret, so the forged token is assembled here
+    def _make_hs256_token_signed_with_the_public_key(self, iss, aud, kid="test-kid"):
+        now = int(time.time())
+        segments = [
+            self._b64encode({"alg": "HS256", "typ": "JWT", "kid": kid}),
+            self._b64encode({"iss": iss, "aud": aud, "sub": "user-123", "iat": now, "exp": now + 300}),
+        ]
+        signing_input = b".".join(segments)
+        segments.append(
+            base64.urlsafe_b64encode(hmac.new(self.public_pem, signing_input, hashlib.sha256).digest()).rstrip(b"=")
+        )
+        return b".".join(segments).decode("utf-8")
+
+    @staticmethod
+    def _b64encode(payload):
+        return base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=")
 
     # test get_openid_configuration
 
@@ -240,4 +264,39 @@ class OIDCUtilsTestCase(TestCase):
                 issuer=issuer,
                 audience=audience,
                 openid_configuration=self._make_oid_config(issuer),
+            )
+
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_hmac_alg_not_supported(self, build_opener):
+        build_opener.return_value.open.return_value = FakeHTTPResponse(self.jwks_payload)
+
+        issuer = "https://issuer.zentral.com"
+        audience = "my-client"
+
+        token = self._make_hs256_token_signed_with_the_public_key(iss=issuer, aud=audience)
+
+        with self.assertRaisesRegex(jwt.InvalidAlgorithmError, r"The specified alg value is not allowed"):
+            verify_jws(
+                token=token,
+                issuer=issuer,
+                audience=audience,
+                openid_configuration=self._make_oid_config(issuer, ["RS256", "HS256"]),
+            )
+
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_only_hmac_algs_supported(self, build_opener):
+        build_opener.return_value.open.return_value = FakeHTTPResponse(self.jwks_payload)
+
+        issuer = "https://issuer.zentral.com"
+        audience = "my-client"
+
+        token = self._make_hs256_token_signed_with_the_public_key(iss=issuer, aud=audience)
+
+        with self.assertRaisesRegex(ValueError, r"Invalid token"):
+            verify_jws(
+                token=token,
+                issuer=issuer,
+                audience=audience,
+                openid_configuration=self._make_oid_config(issuer, ["HS256"]),
+                exception_class=ValueError,
             )

--- a/tests/utils/test_oidc.py
+++ b/tests/utils/test_oidc.py
@@ -13,7 +13,7 @@ from django.utils.crypto import get_random_string
 from zentral.utils.oidc import get_openid_configuration, verify_jws
 
 
-# see https://github.com/jpadilla/pyjwt/blob/b85050f1d444c6828bb4618ee764443b0a3f5d18/jwt/jwks_client.py#L108
+# see https://github.com/jpadilla/pyjwt/blob/2.14.0/jwt/jwks_client.py#L162
 class FakeHTTPResponse:
     def __init__(self, bytes):
         self.bytes = bytes
@@ -112,9 +112,9 @@ class OIDCUtilsTestCase(TestCase):
 
     # test verify_jws
 
-    @patch("jwt.jwks_client.urllib.request.urlopen")
-    def test_verify_jws_success(self, jwt_urlopen):
-        jwt_urlopen.return_value = FakeHTTPResponse(self.jwks_payload)
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_success(self, build_opener):
+        build_opener.return_value.open.return_value = FakeHTTPResponse(self.jwks_payload)
 
         issuer = "https://issuer.zentral.com"
         audience = "my-client"
@@ -154,9 +154,9 @@ class OIDCUtilsTestCase(TestCase):
                 openid_configuration=self._make_oid_config(issuer),
             )
 
-    @patch("jwt.jwks_client.urllib.request.urlopen")
-    def test_verify_jws_wrong_kid(self, jwt_urlopen):
-        jwt_urlopen.return_value = FakeHTTPResponse(self.jwks_payload)
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_wrong_kid(self, build_opener):
+        build_opener.return_value.open.return_value = FakeHTTPResponse(self.jwks_payload)
 
         issuer = "https://issuer.zentral.com"
         audience = "my-client"
@@ -178,9 +178,9 @@ class OIDCUtilsTestCase(TestCase):
                 openid_configuration=self._make_oid_config(issuer),
             )
 
-    @patch("jwt.jwks_client.urllib.request.urlopen")
-    def test_verify_jws_keys_not_found(self, jwt_urlopen):
-        jwt_urlopen.side_effect = HTTPError("Boom!", 404, "Not found", {}, None)
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_keys_not_found(self, build_opener):
+        build_opener.return_value.open.side_effect = HTTPError("Boom!", 404, "Not found", {}, None)
 
         issuer = "https://issuer.zentral.com"
         audience = "my-client"
@@ -201,9 +201,9 @@ class OIDCUtilsTestCase(TestCase):
                 openid_configuration=self._make_oid_config(issuer),
             )
 
-    @patch("jwt.jwks_client.urllib.request.urlopen")
-    def test_verify_jws_invalid_audience(self, jwt_urlopen):
-        jwt_urlopen.return_value = FakeHTTPResponse(self.jwks_payload)
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_invalid_audience(self, build_opener):
+        build_opener.return_value.open.return_value = FakeHTTPResponse(self.jwks_payload)
 
         issuer = "https://issuer.zentral.com"
         audience = "my-client"
@@ -221,9 +221,9 @@ class OIDCUtilsTestCase(TestCase):
                 openid_configuration=self._make_oid_config(issuer),
             )
 
-    @patch("jwt.jwks_client.urllib.request.urlopen")
-    def test_verify_jws_expired_token(self, jwt_urlopen):
-        jwt_urlopen.return_value = FakeHTTPResponse(self.jwks_payload)
+    @patch("jwt.jwks_client.urllib.request.build_opener")
+    def test_verify_jws_expired_token(self, build_opener):
+        build_opener.return_value.open.return_value = FakeHTTPResponse(self.jwks_payload)
 
         issuer = "https://issuer.zentral.com"
         audience = "my-client"

--- a/zentral/utils/oidc.py
+++ b/zentral/utils/oidc.py
@@ -9,6 +9,10 @@ logger = logging.getLogger("zentral.utils.oidc")
 
 TIMESTAMP_LEEWAY = 60
 
+# an ID token is verified with a key from the issuer JWKS, and the HMAC algorithms
+# use the client secret
+UNSUPPORTED_ALGORITHMS = {"NONE", "HS256", "HS384", "HS512"}
+
 
 def get_discovery_uri_from_issuer_uri(issuer_uri):
     return issuer_uri.rstrip("/") + "/.well-known/openid-configuration"
@@ -36,7 +40,7 @@ def get_openid_configuration_from_issuer_uri(issuer_uri):
 def verify_jws(token, issuer, audience, openid_configuration, exception_class=None):
     supported_algorithms = [
         alg for alg in openid_configuration["id_token_signing_alg_values_supported"]
-        if alg.upper() != "NONE"
+        if alg.upper() not in UNSUPPORTED_ALGORITHMS
     ]
     try:
         header = jwt.get_unverified_header(token)


### PR DESCRIPTION
Two commits.

### Bump PyJWT to 2.14.0

A security release. It closes twelve advisories against 2.13.0, one of them critical (GHSA-ffc3-869f-jxw9): a public key with modified PEM armour, with different whitespace or CRLF line endings, moves past the guard in `HMACAlgorithm.prepare_key`. The key is accepted as an HMAC secret, and an attacker can forge an HS256 token. The release also hardens the other variants of the same attack (DER, BOM prefix, JWK and JWKS containers, arrays, encoded material), and the empty HMAC key that an `oct` JWK supplied.

That family of attacks is not possible here: `verify_jws` gives `jwt.decode` the key object from the JWK, and not bytes.

These fixes apply to Zentral, because the token and the JWKS come from outside:

- `PyJWKClient` does not follow a redirect to a different key source anymore (GHSA-9v7f-9g4p-ffgj).
- A header with many levels does not cause an uncaught `RecursionError` in `jwt.decode` anymore (GHSA-8wjv-2p76-3863).
- One incorrect RSA key does not stop the parsing of the full JWK Set anymore (GHSA-w6j9-cwv2-h6wq).

`PyJWKClient.fetch_data` gets the JWKS with its own opener now, to install the handler that refuses the redirects, and not with `urllib.request.urlopen`. The OIDC tests replace the opener.

The dependency metadata of 2.13.0 and 2.14.0 is the same, so no other pin moves.

### Do not use the HMAC algorithms an OpenID Connect issuer advertises

`verify_jws` made its list of permitted algorithms from `id_token_signing_alg_values_supported`, and removed only `none`. Some issuers advertise HS256 with RS256.

The key given to `jwt.decode` is the key that `PyJWKClient` reads from the issuer JWKS, a cryptography key object. A token with `alg=HS256` and a `kid` for such a key went to `HMACAlgorithm.prepare_key`, where `force_bytes` raises `TypeError`, because the key is not a string and not bytes. `TypeError` is not a `PyJWTError`, so it moved past the `except` block: the realm login callback and the OIDC API token issuer gave a 500 error, and did not report an invalid token.

An ID token signed with an HMAC algorithm uses the client secret, so a key from the JWKS cannot verify it. The HMAC algorithms are removed from the list with `none` now, and PyJWT refuses the token before it prepares the key. An issuer that advertises only HMAC algorithms leaves an empty list, and all of its tokens are invalid. Zentral could not verify those tokens with a JWKS key.

Two tests use a forged HS256 token signed with the RSA public key, against a configuration that advertises `["RS256", "HS256"]`, and against one that advertises only `["HS256"]`. With the filter removed, the two tests give the `TypeError`.

### Tests

The full suite is green (8406 tests). flake8 and ruff are clean. The added lines in `zentral/utils/oidc.py` are fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
