### PR TITLE
inventory: export only the objects the current snapshots reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,11 @@ An import of a standard Osquery pack fails if one of its queries has SQL that Ze
 
 `PATCH` gives a `405 Method Not Allowed` on the Monolith catalog, condition, enrollment and manifest enrollment package endpoints. Use `PUT`, and send all the attributes of the object.
 
+#### 🧨 Inventory full export
+
+The full inventory export contains the current snapshot of each machine and source, and the objects that these snapshots reference. A snapshot that a newer snapshot replaced, and an object that only such a snapshot references, are not exported anymore. All the tables of an export are read in one transaction, so they are consistent with each other.
+
+
 #### 🧨 Inventory JMESPath compliance check events
 
 The `inventory_jmespath_check_created`, `inventory_jmespath_check_updated` and `inventory_jmespath_check_deleted` events do not exist anymore. The JMESPath compliance checks publish `zentral_audit` events, like the other objects. A probe or a query on the three event types must use `zentral_audit` with the `inventory.jmespathcheck` model. The events are still linked to the compliance check and to the JMESPath check, so the events page of a check does not change. The `inventory_jmespath_check_status_updated` event does not change.

--- a/docs/content/apps/inventory.md
+++ b/docs/content/apps/inventory.md
@@ -806,7 +806,7 @@ Response:
 * PBAC actions:
 	* `Inventory::Action::"viewMachineSnapshot"`
 
-Use this endpoint to trigger a full inventory export (ZIP archive of `.jsonl`. files).
+Use this endpoint to start a full inventory export. The export is a ZIP archive of `.jsonl` files, with one set of files per table. It contains the current snapshot of each machine and source, and the objects that these snapshots reference: operating system versions, applications, certificates, profiles, disks, … A snapshot that a newer snapshot replaced, and an object that only such a snapshot references, are not exported. All the tables are read in one transaction, so they are consistent with each other.
 
 Example:
 

--- a/tests/inventory/test_exports.py
+++ b/tests/inventory/test_exports.py
@@ -1,14 +1,44 @@
 import csv
 from datetime import datetime
+import hashlib
 import json
 import zipfile
 from django.core.files.storage import default_storage
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils.crypto import get_random_string
-from zentral.contrib.inventory.models import MachineSnapshotCommit
+from zentral.contrib.inventory.models import MachineSnapshot, MachineSnapshotCommit, MetaBusinessUnit, Source
 from zentral.contrib.inventory.utils import (do_full_export,
                                              export_machine_macos_app_instances,
                                              export_machine_snapshots)
+from zentral.contrib.inventory.utils.full_export import FULL_EXPORT_QUERIES, export_transaction
+
+
+# The *_id columns of the export that the naming rule (<table>_id → <table>.id) does not resolve, with the reason.
+NOT_FOREIGN_KEYS = {
+    ("ec2_instance_metadata", "account_id"): "an AWS account ID",
+    ("ec2_instance_metadata", "ami_id"): "an AMI ID",
+    ("ec2_instance_metadata", "instance_id"): "an EC2 instance ID",
+    ("ec2_instance_metadata", "reservation_id"): "an EC2 reservation ID",
+    ("macos_app", "bundle_id"): "a bundle identifier",
+    ("macos_app_instance", "team_id"): "an Apple team ID",
+    ("principal_user", "unique_id"): "the identifier of the user at its source",
+}
+RENAMED_FOREIGN_KEYS = {
+    ("certificate", "signed_by_id"): "certificate",
+    ("macos_app_instance", "signed_by_id"): "certificate",
+    ("profile", "signed_by_id"): "certificate",
+}
+NOT_EXPORTED_TARGETS = {
+    ("principal_user", "source_id"): "inventory_principalusersource is not exported",
+}
+
+
+def sha_256(*parts):
+    return hashlib.sha256(" ".join(parts).encode("utf-8")).hexdigest()
+
+
+def root_certificate():
+    return {"common_name": "Apple Root CA", "sha_256": sha_256("root")}
 
 
 class InventoryExportsTests(TestCase):
@@ -131,6 +161,171 @@ class InventoryExportsTests(TestCase):
                                                     "com.apple.security.network.client": True})
         default_storage.delete(result["filepath"])
 
+    def commit_full_tree(self, serial_number, index, source_name="Zentral Tests"):
+        marker = f"V{index}"
+        source = {"module": "tests.zentral.io", "name": source_name}
+        tree = {
+            "source": source,
+            "serial_number": serial_number,
+            "business_unit": {"name": f"BU {marker}", "reference": f"bu-{marker}", "source": source},
+            "os_version": {"name": "macOS", "major": 26, "minor": 0, "patch": 0, "build": f"26A{index}"},
+            "system_info": {"computer_name": f"computer {marker}", "hardware_model": "Mac16,10"},
+            "principal_user": {"source": {"type": "LOGGED_IN_USER", "properties": {"marker": marker}},
+                               "unique_id": f"uid-{marker}",
+                               "principal_name": f"user-{marker}",
+                               "display_name": f"User {marker}"},
+            "ec2_instance_metadata": {"instance_id": f"i-{marker}",
+                                      "instance_type": "t4g.small",
+                                      "architecture": "arm64",
+                                      "region": "eu-central-1",
+                                      "availability_zone": "eu-central-1a",
+                                      "local_hostname": f"ip-{marker}",
+                                      "mac": "0a:0b:0c:0d:0e:0f",
+                                      "ami_id": f"ami-{marker}",
+                                      "reservation_id": f"r-{marker}",
+                                      "account_id": "123456789012"},
+            "ec2_instance_tags": [{"key": "Name", "value": f"tag {marker}"}],
+            "disks": [{"name": f"/dev/disk-{marker}", "size": 62826479616}],
+            "network_interfaces": [{"interface": "en0",
+                                    "mac": "b0:be:00:00:00:00",
+                                    "address": f"10.0.0.{index}",
+                                    "mask": "255.255.255.0"}],
+            "certificates": [{"common_name": f"Zentral CA {marker}", "sha_256": sha_256(marker, "ca")}],
+            "profiles": [{"uuid": f"e6dd0e0b-0f92-4a58-9d41-3a4c04a1b7d{index}",
+                          "display_name": f"Profile {marker}",
+                          "signed_by": {"common_name": f"Profile signer {marker}",
+                                        "sha_256": sha_256(marker, "profile")}}],
+            "osx_app_instances": [
+                {"app": {"bundle_id": f"io.zentral.app{index}",
+                         "bundle_name": f"App {marker}.app",
+                         "bundle_version": str(index),
+                         "bundle_version_str": f"{index}.0"},
+                 "bundle_path": f"/Applications/App {marker}.app",
+                 "team_id": "ABCDE12345",
+                 "signed_by": {"common_name": f"Developer ID Application: {marker}",
+                               "sha_256": sha_256(marker, "leaf"),
+                               "signed_by": {"common_name": f"Developer ID CA {marker}",
+                                             "sha_256": sha_256(marker, "intermediate"),
+                                             "signed_by": root_certificate()}}},
+            ],
+            "android_apps": [{"display_name": f"Android {marker}", "version_name": f"{index}.0"}],
+            "deb_packages": [{"name": f"deb-{marker}", "version": f"{index}.0"}],
+            "ios_apps": [{"name": f"iOS {marker}", "version": f"{index}.0"}],
+            "program_instances": [{"program": {"name": f"Program {marker}", "version": f"{index}.0"},
+                                   "install_location": f"C:\\Program Files\\{marker}"}],
+            "extra_facts": {"marker": marker},
+        }
+        _, ms, _ = MachineSnapshotCommit.objects.commit_machine_snapshot_tree(tree)
+        return ms
+
+    def read_export(self, result):
+        tables = {}
+        with default_storage.open(result["filepath"]) as f:
+            with zipfile.ZipFile(f) as zf:
+                for name in zf.namelist():
+                    # zentral_<table>_<index>.jsonl
+                    table = name[len("zentral_"):].rsplit("_", 1)[0]
+                    with zf.open(name) as jl:
+                        tables.setdefault(table, []).extend(
+                            json.loads(line) for line in jl.read().decode("utf-8").splitlines()
+                        )
+        default_storage.delete(result["filepath"])
+        return tables
+
+    def test_full_export_current_snapshots_only(self):
+        serial_number = get_random_string(12)
+        ms1 = self.commit_full_tree(serial_number, 1)
+        ms2 = self.commit_full_tree(serial_number, 2)
+        self.assertNotEqual(ms1.pk, ms2.pk)
+        # the replaced snapshot is kept in the inventory
+        self.assertTrue(MachineSnapshot.objects.filter(pk=ms1.pk).exists())
+        # objects without a current snapshot
+        MetaBusinessUnit.objects.create(name="Orphan MBU")
+        Source.objects.commit({"module": "tests.zentral.io", "name": "Orphan Source"})
+
+        tables = self.read_export(do_full_export())
+
+        def values(table, column):
+            return {row[column] for row in tables[table]}
+
+        self.assertEqual(values("machine", "ms_id"), {ms2.pk})
+        for table in ("machine_disks", "machine_network_interface", "machine_certificate", "machine_profile",
+                      "machine_macos_app_instance", "machine_android_app", "machine_deb_package",
+                      "machine_ec2_instance_tag", "machine_ios_app", "machine_program_instance"):
+            self.assertEqual(values(table, "ms_id"), {ms2.pk}, table)
+        self.assertEqual(values("business_unit", "name"), {"BU V2"})
+        self.assertEqual(values("meta_business_unit", "name"), {"BU V2"})
+        self.assertEqual(values("os_version", "build"), {"26A2"})
+        self.assertEqual(values("principal_user", "unique_id"), {"uid-V2"})
+        self.assertEqual(values("source", "name"), {"Zentral Tests"})
+        self.assertEqual(values("system_info", "computer_name"), {"computer V2"})
+        self.assertEqual(values("disk", "name"), {"/dev/disk-V2"})
+        self.assertEqual(values("network_interface", "address"), {"10.0.0.2"})
+        # the certificates of the snapshot, the signers of the app instances and of the profiles, and their chains
+        self.assertEqual(values("certificate", "common_name"),
+                         {"Zentral CA V2", "Profile signer V2",
+                          "Developer ID Application: V2", "Developer ID CA V2", "Apple Root CA"})
+        self.assertEqual(values("profile", "display_name"), {"Profile V2"})
+        self.assertEqual(values("macos_app", "bundle_name"), {"App V2.app"})
+        self.assertEqual(values("macos_app_instance", "bundle_path"), {"/Applications/App V2.app"})
+        self.assertEqual(values("android_app", "display_name"), {"Android V2"})
+        self.assertEqual(values("deb_package", "name"), {"deb-V2"})
+        self.assertEqual(values("ec2_instance_metadata", "instance_id"), {"i-V2"})
+        self.assertEqual(values("ec2_instance_tag", "value"), {"tag V2"})
+        self.assertEqual(values("ios_app", "name"), {"iOS V2"})
+        self.assertEqual(values("program", "name"), {"Program V2"})
+        self.assertEqual(values("program_instance", "install_location"), {"C:\\Program Files\\V2"})
+
+    def test_full_export_rolls_the_parts(self):
+        self.commit_full_tree(get_random_string(12), 1)
+        self.commit_full_tree(get_random_string(12), 2)
+        result = do_full_export(max_temp_file_size=1)
+        with default_storage.open(result["filepath"]) as f:
+            with zipfile.ZipFile(f) as zf:
+                machine_parts = sorted(n for n in zf.namelist() if n.startswith("zentral_machine_0"))
+                self.assertEqual(machine_parts, ["zentral_machine_0001.jsonl", "zentral_machine_0002.jsonl"])
+                for name in machine_parts:
+                    with zf.open(name) as jl:
+                        self.assertEqual(len(jl.read().decode("utf-8").splitlines()), 1)
+        tables = self.read_export(result)
+        self.assertEqual(len(tables["machine"]), 2)
+
+    def test_full_export_referential_closure(self):
+        serial_number = get_random_string(12)
+        self.commit_full_tree(serial_number, 1)
+        self.commit_full_tree(serial_number, 2)
+        self.commit_full_tree(get_random_string(12), 3, source_name="Zentral Tests Bis")
+
+        tables = self.read_export(do_full_export())
+        self.assertEqual(set(tables), {name for name, _ in FULL_EXPORT_QUERIES})
+
+        checked = set()
+        for table, table_rows in tables.items():
+            columns = set().union(*(row.keys() for row in table_rows))
+            for column in sorted(columns):
+                if column == "id" or not column.endswith("_id") or (table, column) == ("machine", "ms_id"):
+                    continue
+                if (table, column) in NOT_FOREIGN_KEYS or (table, column) in NOT_EXPORTED_TARGETS:
+                    continue
+                target = RENAMED_FOREIGN_KEYS.get((table, column), "machine" if column == "ms_id" else column[:-3])
+                self.assertIn(target, tables,
+                              f"{table}.{column} is not a known foreign key of the export: "
+                              "add it to RENAMED_FOREIGN_KEYS, NOT_FOREIGN_KEYS or NOT_EXPORTED_TARGETS")
+                target_ids = {row["ms_id" if target == "machine" else "id"] for row in tables[target]}
+                values = {row[column] for row in table_rows if row[column] is not None}
+                self.assertTrue(values, f"{table}.{column} has no value in the fixture")
+                self.assertTrue(values <= target_ids, f"{table}.{column} has dangling references")
+                checked.add((table, column))
+        self.assertIn(("certificate", "signed_by_id"), checked)
+        self.assertIn(("machine_macos_app_instance", "macos_app_instance_id"), checked)
+
+    def test_export_transaction_inside_an_outer_transaction(self):
+        # the test runs in a transaction: the export must not change its isolation level
+        with export_transaction() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("show transaction_isolation")
+                self.assertEqual(cursor.fetchone()[0], "read committed")
+
     def test_export_machine_snapshots(self):
         serial_number = self.commit_machine_snapshot()
         result = export_machine_snapshots(source_name="ZENTRAL TESTS")
@@ -180,3 +375,11 @@ class InventoryExportsTests(TestCase):
                  'source_name': 'Zentral Tests'}
             )
         default_storage.delete(result["filepath"])
+
+
+class InventoryExportTransactionTests(TransactionTestCase):
+    def test_export_transaction_repeatable_read(self):
+        with export_transaction() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("show transaction_isolation")
+                self.assertEqual(cursor.fetchone()[0], "repeatable read")

--- a/zentral/contrib/inventory/utils/full_export.py
+++ b/zentral/contrib/inventory/utils/full_export.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import tempfile
 import zipfile
+from contextlib import contextmanager
 
 from django.core.files.storage import default_storage
 from django.core.serializers.json import DjangoJSONEncoder
@@ -19,6 +20,52 @@ __all__ = [
 logger = logging.getLogger("zentral.contrib.inventory.utils.full_export")
 
 
+# A table holds the rows a current machine snapshot reaches, directly or through the rows of another
+# exported table.
+
+CURRENT_MS_IDS = "select machine_snapshot_id from inventory_currentmachinesnapshot"
+
+
+def ms_fk_ids(column):
+    return f"select {column} from inventory_machinesnapshot where id in ({CURRENT_MS_IDS})"
+
+
+def m2m_ids(through_table, column):
+    return f"select {column} from {through_table} where machinesnapshot_id in ({CURRENT_MS_IDS})"
+
+
+def fk_ids(column, table, ids):
+    return f"select {column} from {table} where id in ({ids})"
+
+
+def rows(table, ids, columns="*"):
+    return f"select {columns} from {table} where id in ({ids})"
+
+
+def link_rows(through_table, columns):
+    return (f"select machinesnapshot_id ms_id, {columns} from {through_table} "
+            f"where machinesnapshot_id in ({CURRENT_MS_IDS})")
+
+
+BUSINESS_UNIT_IDS = ms_fk_ids("business_unit_id")
+OSX_APP_INSTANCE_IDS = m2m_ids("inventory_machinesnapshot_osx_app_instances", "osxappinstance_id")
+PROFILE_IDS = m2m_ids("inventory_machinesnapshot_profiles", "profile_id")
+PROGRAM_INSTANCE_IDS = m2m_ids("inventory_machinesnapshot_program_instances", "programinstance_id")
+
+# the certificates of the snapshots, the signers of the app instances and of the profiles, and the chains above them
+CERTIFICATE_QUERY = (
+    "with recursive reachable_certificate as ("
+    "select id, signed_by_id from inventory_certificate where id in ("
+    f"{m2m_ids('inventory_machinesnapshot_certificates', 'certificate_id')} "
+    f"union {fk_ids('signed_by_id', 'inventory_osxappinstance', OSX_APP_INSTANCE_IDS)} "
+    f"union {fk_ids('signed_by_id', 'inventory_profile', PROFILE_IDS)}) "
+    "union "
+    "select c.id, c.signed_by_id from inventory_certificate c join reachable_certificate r on (c.id = r.signed_by_id)"
+    ") "
+    "select * from inventory_certificate where id in (select id from reachable_certificate)"
+)
+
+
 FULL_EXPORT_QUERIES = [
     # first the current snapshots
     ("machine",
@@ -30,103 +77,107 @@ FULL_EXPORT_QUERIES = [
      "from inventory_currentmachinesnapshot cms "
      "join inventory_machinesnapshot ms on (cms.machine_snapshot_id = ms.id)"),
     # meta/business units
-    ("business_unit", "select * from inventory_businessunit"),
-    ("meta_business_unit", "select * from inventory_metabusinessunit"),
+    ("business_unit", rows("inventory_businessunit", BUSINESS_UNIT_IDS)),
+    ("meta_business_unit",
+     rows("inventory_metabusinessunit", fk_ids("meta_business_unit_id", "inventory_businessunit", BUSINESS_UNIT_IDS))),
     # extra many to one tables
-    ("os_version", "select * from inventory_osversion"),
-    ("principal_user", "select * from inventory_principaluser"),
-    ("source", "select id, mt_hash, mt_created_at, module, name from inventory_source"),
-    ("system_info", "select * from inventory_systeminfo"),
+    ("os_version", rows("inventory_osversion", ms_fk_ids("os_version_id"))),
+    ("principal_user", rows("inventory_principaluser", ms_fk_ids("principal_user_id"))),
+    ("source",
+     rows("inventory_source",
+          f"{ms_fk_ids('source_id')} union {fk_ids('source_id', 'inventory_businessunit', BUSINESS_UNIT_IDS)}",
+          columns="id, mt_hash, mt_created_at, module, name")),
+    ("system_info", rows("inventory_systeminfo", ms_fk_ids("system_info_id"))),
     # disks
-    ("disk", "select * from inventory_disk"),
-    ("machine_disks",
-     "select machinesnapshot_id ms_id, disk_id "
-     "from inventory_machinesnapshot_disks"),
+    ("disk", rows("inventory_disk", m2m_ids("inventory_machinesnapshot_disks", "disk_id"))),
+    ("machine_disks", link_rows("inventory_machinesnapshot_disks", "disk_id")),
     # network interfaces
-    ("network_interface", "select * from inventory_networkinterface"),
+    ("network_interface",
+     rows("inventory_networkinterface",
+          m2m_ids("inventory_machinesnapshot_network_interfaces", "networkinterface_id"))),
     ("machine_network_interface",
-     "select machinesnapshot_id ms_id, networkinterface_id network_interface_id "
-     "from inventory_machinesnapshot_network_interfaces"),
+     link_rows("inventory_machinesnapshot_network_interfaces", "networkinterface_id network_interface_id")),
     # certificates
-    ("certificate", "select * from inventory_certificate"),
-    ("machine_certificate",
-     "select machinesnapshot_id ms_id, certificate_id "
-     "from inventory_machinesnapshot_certificates"),
+    ("certificate", CERTIFICATE_QUERY),
+    ("machine_certificate", link_rows("inventory_machinesnapshot_certificates", "certificate_id")),
     # profiles
-    ("profile", "select * from inventory_profile"),
-    ("machine_profile",
-     "select machinesnapshot_id ms_id, profile_id "
-     "from inventory_machinesnapshot_profiles"),
+    ("profile", rows("inventory_profile", PROFILE_IDS)),
+    ("machine_profile", link_rows("inventory_machinesnapshot_profiles", "profile_id")),
     # macOS apps
-    ("macos_app", "select * from inventory_osxapp"),
+    ("macos_app", rows("inventory_osxapp", fk_ids("app_id", "inventory_osxappinstance", OSX_APP_INSTANCE_IDS))),
     ("macos_app_instance",
-     "select id, mt_hash, mt_created_at,"
-     "bundle_path, executable_path, path, sha_1, sha_256, type, app_id macos_app_id, signed_by_id,"
-     "team_id, cd_hash, entitlements, signing_time, secure_signing_time "
-     "from inventory_osxappinstance"),
+     rows("inventory_osxappinstance", OSX_APP_INSTANCE_IDS,
+          columns="id, mt_hash, mt_created_at,"
+                  "bundle_path, executable_path, path, sha_1, sha_256, type, app_id macos_app_id, signed_by_id,"
+                  "team_id, cd_hash, entitlements, signing_time, secure_signing_time")),
     ("machine_macos_app_instance",
-     "select machinesnapshot_id ms_id, osxappinstance_id macos_app_instance_id "
-     "from inventory_machinesnapshot_osx_app_instances"),
+     link_rows("inventory_machinesnapshot_osx_app_instances", "osxappinstance_id macos_app_instance_id")),
     # Android apps
-    ("android_app", "select * from inventory_androidapp"),
-    ("machine_android_app",
-     "select machinesnapshot_id ms_id, androidapp_id android_app_id "
-     "from inventory_machinesnapshot_android_apps"),
+    ("android_app", rows("inventory_androidapp", m2m_ids("inventory_machinesnapshot_android_apps", "androidapp_id"))),
+    ("machine_android_app", link_rows("inventory_machinesnapshot_android_apps", "androidapp_id android_app_id")),
     # Debian packages
-    ("deb_package", "select * from inventory_debpackage"),
-    ("machine_deb_package",
-     "select machinesnapshot_id ms_id, debpackage_id deb_package_id "
-     "from inventory_machinesnapshot_deb_packages"),
+    ("deb_package", rows("inventory_debpackage", m2m_ids("inventory_machinesnapshot_deb_packages", "debpackage_id"))),
+    ("machine_deb_package", link_rows("inventory_machinesnapshot_deb_packages", "debpackage_id deb_package_id")),
     # EC2
-    ("ec2_instance_metadata", "select * from inventory_ec2instancemetadata"),
-    ("ec2_instance_tag", "select * from inventory_ec2instancetag"),
+    ("ec2_instance_metadata", rows("inventory_ec2instancemetadata", ms_fk_ids("ec2_instance_metadata_id"))),
+    ("ec2_instance_tag",
+     rows("inventory_ec2instancetag", m2m_ids("inventory_machinesnapshot_ec2_instance_tags", "ec2instancetag_id"))),
     ("machine_ec2_instance_tag",
-     "select machinesnapshot_id ms_id, ec2instancetag_id ec2_instance_tag_id "
-     "from inventory_machinesnapshot_ec2_instance_tags"),
+     link_rows("inventory_machinesnapshot_ec2_instance_tags", "ec2instancetag_id ec2_instance_tag_id")),
     # iOS apps
-    ("ios_app", "select * from inventory_iosapp"),
-    ("machine_ios_app",
-     "select machinesnapshot_id ms_id, iosapp_id ios_app_id "
-     "from inventory_machinesnapshot_ios_apps"),
+    ("ios_app", rows("inventory_iosapp", m2m_ids("inventory_machinesnapshot_ios_apps", "iosapp_id"))),
+    ("machine_ios_app", link_rows("inventory_machinesnapshot_ios_apps", "iosapp_id ios_app_id")),
     # Programs
-    ("program", "select * from inventory_program"),
-    ("program_instance", "select * from inventory_programinstance"),
+    ("program", rows("inventory_program", fk_ids("program_id", "inventory_programinstance", PROGRAM_INSTANCE_IDS))),
+    ("program_instance", rows("inventory_programinstance", PROGRAM_INSTANCE_IDS)),
     ("machine_program_instance",
-     "select machinesnapshot_id ms_id, programinstance_id program_instance_id "
-     "from inventory_machinesnapshot_program_instances"),
+     link_rows("inventory_machinesnapshot_program_instances", "programinstance_id program_instance_id")),
     # TODO: compliance checks
     # TODO: blueprints
 ]
 
 
-def iter_model_exports(export_dt, max_temp_file_size, window_size):
+@contextmanager
+def export_transaction():
+    connection = connections[get_read_only_database()]
+    # SET TRANSACTION must be the first statement of a transaction. The isolation level can only be raised
+    # when the export opens the transaction, not when it runs inside an outer one.
+    set_isolation_level = not connection.in_atomic_block
+    with transaction.atomic(using=connection.alias):
+        if set_isolation_level:
+            with connection.cursor() as cursor:
+                cursor.execute("set transaction isolation level repeatable read")
+        yield connection
+
+
+def iter_model_exports(max_temp_file_size, window_size):
     # for each model
     # - execute the query
     # - write the results in a temporary file
-    database = get_read_only_database()
-    for model_name, query in FULL_EXPORT_QUERIES:
-        model_export_f = model_export_p = None
-        file_index = 0
-        with transaction.atomic(), connections[database].chunked_cursor() as cursor:
-            cursor.itersize = window_size
-            cursor.execute(query, [export_dt])
-            columns = None
-            for row in cursor:
-                if columns is None:
-                    columns = [c.name for c in cursor.description]
-                if model_export_f is None or model_export_f.tell() > max_temp_file_size:
-                    if model_export_f:
-                        model_export_f.close()
-                        yield model_name, file_index, model_export_p
-                    file_index += 1
-                    model_export_fh, model_export_p = tempfile.mkstemp()
-                    model_export_f = os.fdopen(model_export_fh, mode="w", newline="")
-                obj = dict(zip(columns, row))
-                json.dump(obj, model_export_f, cls=DjangoJSONEncoder)
-                model_export_f.write("\n")
-        if model_export_f:
-            model_export_f.close()
-            yield model_name, file_index, model_export_p
+    with export_transaction() as connection:
+        for model_name, query in FULL_EXPORT_QUERIES:
+            model_export_f = model_export_p = None
+            file_index = 0
+            with connection.chunked_cursor() as cursor:
+                cursor.itersize = window_size
+                cursor.execute(query)
+                columns = None
+                for row in cursor:
+                    if columns is None:
+                        columns = [c.name for c in cursor.description]
+                    if model_export_f is None or model_export_f.tell() > max_temp_file_size:
+                        if model_export_f:
+                            model_export_f.close()
+                            yield model_name, file_index, model_export_p
+                        file_index += 1
+                        model_export_fh, model_export_p = tempfile.mkstemp()
+                        model_export_f = os.fdopen(model_export_fh, mode="w", newline="")
+                    obj = dict(zip(columns, row))
+                    json.dump(obj, model_export_f, cls=DjangoJSONEncoder)
+                    model_export_f.write("\n")
+            if model_export_f:
+                model_export_f.close()
+                yield model_name, file_index, model_export_p
 
 
 def do_full_export(max_temp_file_size=2**30, window_size=5000):
@@ -135,9 +186,7 @@ def do_full_export(max_temp_file_size=2**30, window_size=5000):
     # create ZIP archive
     zip_fh, zip_p = tempfile.mkstemp()
     with zipfile.ZipFile(zip_p, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_a:
-        for model_name, file_index, file_p in iter_model_exports(
-            export_dt, max_temp_file_size, window_size
-        ):
+        for model_name, file_index, file_p in iter_model_exports(max_temp_file_size, window_size):
             zip_a.write(file_p, f"zentral_{model_name}_{file_index:04d}.jsonl")
             os.unlink(file_p)
 


### PR DESCRIPTION
## What

The full inventory export (`POST /api/inventory/full_export/`, `export_full_inventory` command) contains the current snapshot of each machine and source, and the objects that these snapshots reference. A snapshot that a newer snapshot replaced, and an object that only such a snapshot references, are not exported anymore.

Before this change, the `machine` table had the current snapshots only, but every other table was dumped whole. The link tables carried the rows of every retained snapshot.

## How

- Each entry of the query list declares how its rows connect to the current snapshots, and the SQL is built from that: a filter on the current snapshot ids for the link tables, on the ids the current snapshots carry for the tables behind a foreign key, on the ids the current link rows carry for the tables behind a link table, and one more level for the apps, the programs and the meta business units.
- The certificates use a recursive query: the certificates of the snapshots, the signers of the app instances and of the profiles, and the chains above them.
- All the tables are read in one `REPEATABLE READ` transaction on the read-only database, so they see the same snapshots. The isolation level is only set when the export opens the transaction itself.
- The unused execute argument is removed. The queries have no placeholder, so psycopg2 never merged it.

## Tests

- A machine with two commits: only the rows of the second snapshot are exported, for every table. The certificate chain of the first snapshot is gone, and the shared root certificate stays.
- A referential closure test: every `*_id` column that points at an exported table resolves inside the export. The columns that are not foreign keys, and the one that points at a table that is not exported, are listed with a reason. A new `*_id` column fails the test until it is classified.
- The isolation level, in a `TransactionTestCase`, and the part rolling.
- Each new test was checked against a broken version of the code.

CHANGELOG entry under *Backward incompatibilities*. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
