### PR TITLE
inventory: pick the tables of the full export, and describe it with a manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The documentation is published at https://www.zentral.com/docs/zentral/ now, and
 
 The inventory JMESPath compliance check publishes the same `zentral_audit` events as the other objects now, from the web console and from the API.
 
+The full inventory export can be limited to a list of tables, with the `tables` attribute of the API request or the `--table` option of the `export_full_inventory` command. The task result carries a manifest with the tables, their row counts and their columns, and the files of the archive with their size and SHA-256 digest. The archive contains the manifest as `manifest.json`.
+
 
 #### MDM
 
@@ -125,6 +127,10 @@ An import of a standard Osquery pack fails if one of its queries has SQL that Ze
 #### 🧨 Inventory full export
 
 The full inventory export contains the current snapshot of each machine and source, and the objects that these snapshots reference. A snapshot that a newer snapshot replaced, and an object that only such a snapshot references, are not exported anymore. All the tables of an export are read in one transaction, so they are consistent with each other.
+
+The `zentral_machine_disks_<index>.jsonl` files of the archive are named `zentral_machine_disk_<index>.jsonl` now, like the files of the other link tables.
+
+The export archive has a new name: `full_inventory_export-20260911T100000Z-3f9c1a2b.zip`, and not `full_inventory_export-2026-09-11_10-00-00.zip`. The last part of the name is random, so two exports started in the same second do not have the same name.
 
 
 #### 🧨 Inventory JMESPath compliance check events

--- a/docs/content/apps/inventory.md
+++ b/docs/content/apps/inventory.md
@@ -806,13 +806,40 @@ Response:
 * PBAC actions:
 	* `Inventory::Action::"viewMachineSnapshot"`
 
-Use this endpoint to start a full inventory export. The export is a ZIP archive of `.jsonl` files, with one set of files per table. It contains the current snapshot of each machine and source, and the objects that these snapshots reference: operating system versions, applications, certificates, profiles, disks, … A snapshot that a newer snapshot replaced, and an object that only such a snapshot references, are not exported. All the tables are read in one transaction, so they are consistent with each other.
+Use this endpoint to start a full inventory export. The export is a ZIP archive of `.jsonl` files, with one set of files per table, and a `manifest.json` file. It contains the current snapshot of each machine and source, and the objects that these snapshots reference: operating system versions, applications, certificates, profiles, disks, … A snapshot that a newer snapshot replaced, and an object that only such a snapshot references, are not exported. All the tables are read in one transaction, so they are consistent with each other.
+
+The optional `tables` attribute limits the export to a list of tables. An unknown table, or an empty list, gives a `400` response that lists the valid tables.
+
+| Tables | Content |
+|---|---|
+| `machine` | The current snapshot of each machine and source. `ms_id` is the identifier of the snapshot. |
+| `business_unit`, `meta_business_unit` | The business units of the snapshots, and their meta business units. |
+| `source` | The inventory sources of the snapshots and of the business units. |
+| `os_version`, `system_info`, `principal_user` | The operating system versions, the system information and the principal users of the snapshots. |
+| `disk`, `machine_disk` | The disks, and their link to the snapshots. |
+| `network_interface`, `machine_network_interface` | The network interfaces, and their link to the snapshots. |
+| `certificate`, `machine_certificate` | The certificates of the snapshots, the signers of the applications and of the profiles, with their chains, and the link of the certificates to the snapshots. |
+| `profile`, `machine_profile` | The configuration profiles, and their link to the snapshots. |
+| `macos_app`, `macos_app_instance`, `machine_macos_app_instance` | The macOS applications, their instances, and the link of the instances to the snapshots. |
+| `android_app`, `machine_android_app` | The Android applications, and their link to the snapshots. |
+| `deb_package`, `machine_deb_package` | The Debian packages, and their link to the snapshots. |
+| `ec2_instance_metadata`, `ec2_instance_tag`, `machine_ec2_instance_tag` | The EC2 instance metadata of the snapshots, the EC2 instance tags, and their link to the snapshots. |
+| `ios_app`, `machine_ios_app` | The iOS applications, and their link to the snapshots. |
+| `program`, `program_instance`, `machine_program_instance` | The Windows programs, their instances, and the link of the instances to the snapshots. |
+
+A `machine_*` table links the snapshots to the rows of another table: `ms_id` is the identifier of the snapshot, and the other column is the identifier of the row. The files of a table are named `zentral_<table>_<index>.jsonl`. The index starts at `0001`, and a table with many rows has more than one file. A table without a row has no file.
+
+The task result carries a manifest, also present in the archive as `manifest.json`. The manifest gives the tables, with their row counts, their columns and their files, and the files, with their table, row count, size and SHA-256 digest. The keys of `files` are the names of the `.jsonl` files in the archive.
+
+Zentral does not delete the exports. The retention of the files under `exports/` in the storage is a responsibility of the deployment, for example with a lifecycle policy on the bucket.
 
 Example:
 
 ```bash
 curl -XPOST \
   -H "Authorization: Token $ZTL_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"tables": ["machine", "os_version"]}' \
   https://$ZTL_FQDN/api/inventory/full_export/\
   |python3 -m json.tool
 ```
@@ -826,3 +853,42 @@ Response:
 }
 ```
 
+Task result, when the task is done (see [`/api/task_result/<uuid:task_id>/`](core.md#apitask_resultuuidtask_id)):
+
+```json
+{
+  "name": "zentral.contrib.inventory.tasks.export_full_inventory",
+  "id": "5ecb057b-57cc-41e4-a07e-fcc357d7a5c7",
+  "status": "SUCCESS",
+  "unready": false,
+  "download_url": "/api/task_result/5ecb057b-57cc-41e4-a07e-fcc357d7a5c7/download/",
+  "result": {
+    "headers": {
+      "Content-Type": "application/zip",
+      "Content-Disposition": "attachment; filename=\"full_inventory_export-20260911T100000Z-3f9c1a2b.zip\""
+    },
+    "manifest": {
+      "version": 1,
+      "export_id": "20260911T100000Z-3f9c1a2b",
+      "exported_at": "2026-09-11T10:00:00Z",
+      "format": "JSONL",
+      "tables": {
+        "machine": {
+          "rows": 4213,
+          "columns": [{"name": "serial_number"}, {"name": "last_seen"}, {"name": "ms_id"}, "…"],
+          "files": ["zentral_machine_0001.jsonl"]
+        },
+        "os_version": {
+          "rows": 17,
+          "columns": [{"name": "id"}, {"name": "mt_hash"}, {"name": "mt_created_at"}, "…"],
+          "files": ["zentral_os_version_0001.jsonl"]
+        }
+      },
+      "files": {
+        "zentral_machine_0001.jsonl": {"table": "machine", "rows": 4213, "size": 5312876, "sha256": "…"},
+        "zentral_os_version_0001.jsonl": {"table": "os_version", "rows": 17, "size": 3021, "sha256": "…"}
+      }
+    }
+  }
+}
+```

--- a/tests/inventory/test_api.py
+++ b/tests/inventory/test_api.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import uuid
 from django_celery_results.models import TaskResult
 from django.contrib.auth.models import Group
 from django.test import TestCase
@@ -13,6 +14,7 @@ from zentral.contrib.inventory.models import (CurrentMachineSnapshot, MachineSna
                                               MachineSnapshotCommit, MachineTag,
                                               MetaBusinessUnit, Tag, Taxonomy)
 from zentral.core.events.base import AuditEvent
+from zentral.contrib.inventory.utils import FULL_EXPORT_TABLE_NAMES
 
 
 class InventoryAPITests(TestCase, LoginCase, RequestCase):
@@ -412,6 +414,41 @@ class InventoryAPITests(TestCase, LoginCase, RequestCase):
         # the export produces a file, and its download button lives on the task page
         user_task = UserTask.objects.get(task_result__task_id=response.data["task_id"])
         self.assertEqual(user_task.user, self.user)
+
+    @patch("zentral.contrib.inventory.api_views.export_full_inventory.apply_async")
+    def test_full_export_tables(self, apply_async):
+        apply_async.return_value.id = str(uuid.uuid4())
+        self.set_permissions("inventory.view_machinesnapshot")
+        response = self.post(reverse('inventory_api:full_export'), {"tables": ["os_version", "machine", "machine"]})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # canonical order, no duplicates
+        apply_async.assert_called_once_with(kwargs={"tables": ["machine", "os_version"], "task_user": self.user.id})
+
+    @patch("zentral.contrib.inventory.api_views.export_full_inventory.apply_async")
+    def test_full_export_null_tables(self, apply_async):
+        apply_async.return_value.id = str(uuid.uuid4())
+        self.set_permissions("inventory.view_machinesnapshot")
+        response = self.post(reverse('inventory_api:full_export'), {"tables": None})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        apply_async.assert_called_once_with(kwargs={"tables": None, "task_user": self.user.id})
+
+    def test_full_export_unknown_table(self):
+        self.set_permissions("inventory.view_machinesnapshot")
+        response = self.post(reverse('inventory_api:full_export'), {"tables": ["machine", "yolo"]})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"tables": {"1": [f'"yolo" is not a valid table. Valid tables: {", ".join(FULL_EXPORT_TABLE_NAMES)}.']}}
+        )
+
+    def test_full_export_empty_tables(self):
+        self.set_permissions("inventory.view_machinesnapshot")
+        response = self.post(reverse('inventory_api:full_export'), {"tables": []})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"tables": [f"This list may not be empty. Valid tables: {', '.join(FULL_EXPORT_TABLE_NAMES)}."]}
+        )
 
     # create meta business unit
 

--- a/tests/inventory/test_exports.py
+++ b/tests/inventory/test_exports.py
@@ -10,7 +10,8 @@ from zentral.contrib.inventory.models import MachineSnapshot, MachineSnapshotCom
 from zentral.contrib.inventory.utils import (do_full_export,
                                              export_machine_macos_app_instances,
                                              export_machine_snapshots)
-from zentral.contrib.inventory.utils.full_export import FULL_EXPORT_QUERIES, export_transaction
+from zentral.contrib.inventory.utils.full_export import (FULL_EXPORT_QUERIES, FULL_EXPORT_TABLE_NAMES,
+                                                         export_transaction, iter_tables)
 
 
 # The *_id columns of the export that the naming rule (<table>_id → <table>.id) does not resolve, with the reason.
@@ -103,10 +104,11 @@ class InventoryExportsTests(TestCase):
             with zipfile.ZipFile(f) as zf:
                 self.assertEqual(
                     sorted(zf.namelist()),
-                    ['zentral_business_unit_0001.jsonl',
+                    ['manifest.json',
+                     'zentral_business_unit_0001.jsonl',
                      'zentral_disk_0001.jsonl',
                      'zentral_machine_0001.jsonl',
-                     'zentral_machine_disks_0001.jsonl',
+                     'zentral_machine_disk_0001.jsonl',
                      'zentral_machine_macos_app_instance_0001.jsonl',
                      'zentral_machine_network_interface_0001.jsonl',
                      'zentral_macos_app_0001.jsonl',
@@ -128,7 +130,7 @@ class InventoryExportsTests(TestCase):
                     disk_d = json.loads(content[0])
                     self.assertEqual(disk_d["filevault_status"], "on")
                     d_id = disk_d["id"]
-                with zf.open("zentral_machine_disks_0001.jsonl") as jl:
+                with zf.open("zentral_machine_disk_0001.jsonl") as jl:
                     content = jl.read().decode("utf-8").splitlines()
                     self.assertEqual(len(content), 1)
                     mdi_d = json.loads(content[0])
@@ -223,6 +225,8 @@ class InventoryExportsTests(TestCase):
         with default_storage.open(result["filepath"]) as f:
             with zipfile.ZipFile(f) as zf:
                 for name in zf.namelist():
+                    if not name.startswith("zentral_"):
+                        continue
                     # zentral_<table>_<index>.jsonl
                     table = name[len("zentral_"):].rsplit("_", 1)[0]
                     with zf.open(name) as jl:
@@ -249,7 +253,7 @@ class InventoryExportsTests(TestCase):
             return {row[column] for row in tables[table]}
 
         self.assertEqual(values("machine", "ms_id"), {ms2.pk})
-        for table in ("machine_disks", "machine_network_interface", "machine_certificate", "machine_profile",
+        for table in ("machine_disk", "machine_network_interface", "machine_certificate", "machine_profile",
                       "machine_macos_app_instance", "machine_android_app", "machine_deb_package",
                       "machine_ec2_instance_tag", "machine_ios_app", "machine_program_instance"):
             self.assertEqual(values(table, "ms_id"), {ms2.pk}, table)
@@ -289,6 +293,87 @@ class InventoryExportsTests(TestCase):
                         self.assertEqual(len(jl.read().decode("utf-8").splitlines()), 1)
         tables = self.read_export(result)
         self.assertEqual(len(tables["machine"]), 2)
+
+    def test_iter_tables_window_size(self):
+        self.commit_machine_snapshot()
+        self.commit_machine_snapshot()
+        for table, columns, batches in iter_tables(["machine"], window_size=1):
+            self.assertEqual(table, "machine")
+            self.assertIn("serial_number", columns)
+            # one fetch per row
+            self.assertEqual([len(batch) for batch in batches], [1, 1])
+
+    def test_full_export_manifest(self):
+        self.commit_full_tree(get_random_string(12), 1)
+        self.commit_full_tree(get_random_string(12), 2)
+        result = do_full_export(max_temp_file_size=1)
+        manifest = result["manifest"]
+        self.assertEqual(manifest["version"], 1)
+        self.assertRegex(manifest["export_id"], r"^\d{8}T\d{6}Z-[0-9a-f]{8}$")
+        self.assertRegex(manifest["exported_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+        self.assertEqual(manifest["format"], "JSONL")
+        self.assertEqual(list(manifest["tables"]), FULL_EXPORT_TABLE_NAMES)
+        self.assertEqual(result["filepath"], f"exports/full_inventory_export-{manifest['export_id']}.zip")
+        self.assertEqual(result["headers"]["Content-Disposition"],
+                         f'attachment; filename="full_inventory_export-{manifest["export_id"]}.zip"')
+        with default_storage.open(result["filepath"]) as f:
+            with zipfile.ZipFile(f) as zf:
+                self.assertEqual(json.loads(zf.read("manifest.json")), manifest)
+                self.assertNotIn("manifest.json", manifest["files"])
+                self.assertEqual(set(manifest["files"]), set(zf.namelist()) - {"manifest.json"})
+                for name, file_manifest in manifest["files"].items():
+                    content = zf.read(name)
+                    self.assertEqual(file_manifest["size"], len(content))
+                    self.assertEqual(file_manifest["sha256"], hashlib.sha256(content).hexdigest())
+                    lines = content.decode("utf-8").splitlines()
+                    # max_temp_file_size=1: one row per file
+                    self.assertEqual(len(lines), 1)
+                    self.assertEqual(file_manifest["rows"], 1)
+                    table_manifest = manifest["tables"][file_manifest["table"]]
+                    self.assertIn(name, table_manifest["files"])
+                    self.assertEqual([c["name"] for c in table_manifest["columns"]], list(json.loads(lines[0])))
+        for table, table_manifest in manifest["tables"].items():
+            self.assertTrue(table_manifest["rows"] > 0, table)
+            self.assertEqual(table_manifest["rows"], len(table_manifest["files"]))
+        default_storage.delete(result["filepath"])
+
+    def test_full_export_tables(self):
+        self.commit_machine_snapshot()
+        result = do_full_export(tables=["machine_disk", "machine", "machine"])
+        # canonical order, no duplicates
+        self.assertEqual(list(result["manifest"]["tables"]), ["machine", "machine_disk"])
+        with default_storage.open(result["filepath"]) as f:
+            with zipfile.ZipFile(f) as zf:
+                self.assertEqual(sorted(zf.namelist()),
+                                 ["manifest.json", "zentral_machine_0001.jsonl", "zentral_machine_disk_0001.jsonl"])
+        default_storage.delete(result["filepath"])
+
+    def test_full_export_unknown_tables(self):
+        with self.assertRaises(ValueError) as cm:
+            do_full_export(tables=["machine", "yolo", "fomo"])
+        self.assertEqual(cm.exception.args[0], "Unknown tables: fomo, yolo")
+
+    def test_full_export_no_tables(self):
+        with self.assertRaises(ValueError) as cm:
+            do_full_export(tables=[])
+        self.assertEqual(cm.exception.args[0], "At least one table is required")
+
+    def test_full_export_empty_table(self):
+        # no Debian packages in this tree
+        self.commit_machine_snapshot()
+        result = do_full_export(tables=["deb_package", "machine_deb_package"])
+        manifest = result["manifest"]
+        self.assertEqual(manifest["files"], {})
+        self.assertEqual(manifest["tables"]["deb_package"]["rows"], 0)
+        self.assertEqual(manifest["tables"]["deb_package"]["files"], [])
+        # the columns are known without a row
+        self.assertIn({"name": "name"}, manifest["tables"]["deb_package"]["columns"])
+        self.assertEqual(manifest["tables"]["machine_deb_package"]["columns"],
+                         [{"name": "ms_id"}, {"name": "deb_package_id"}])
+        with default_storage.open(result["filepath"]) as f:
+            with zipfile.ZipFile(f) as zf:
+                self.assertEqual(zf.namelist(), ["manifest.json"])
+        default_storage.delete(result["filepath"])
 
     def test_full_export_referential_closure(self):
         serial_number = get_random_string(12)

--- a/tests/inventory/test_management_commands.py
+++ b/tests/inventory/test_management_commands.py
@@ -2,6 +2,7 @@ from io import StringIO
 from unittest import mock
 from unittest.mock import patch, MagicMock
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 from zentral.contrib.inventory.models import MACAddressBlockAssignment
 
@@ -54,6 +55,19 @@ class InventoryManagementCommandsTest(TestCase):
         result = out.getvalue()
         self.assertTrue(result.startswith("Download URL:"))
         self.assertTrue(result.endswith(".zip\n"))
+
+    @patch("zentral.contrib.inventory.management.commands.export_full_inventory.do_full_export")
+    def test_export_full_inventory_tables(self, do_full_export):
+        do_full_export.return_value = {"filepath": "exports/yolo.zip"}
+        out = StringIO()
+        call_command('export_full_inventory', '--table', 'machine', '--table', 'os_version', stdout=out)
+        do_full_export.assert_called_once_with(tables=["machine", "os_version"])
+        self.assertEqual(out.getvalue(), "File: exports/yolo.zip\n")
+
+    def test_export_full_inventory_unknown_table(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command('export_full_inventory', '--table', 'yolo')
+        self.assertIn("argument --table: invalid choice: 'yolo'", cm.exception.args[0])
 
     # import mac assigment
 

--- a/tests/inventory/test_tasks.py
+++ b/tests/inventory/test_tasks.py
@@ -74,6 +74,10 @@ class InventoryTasksTest(TestCase):
         result = export_full_inventory()
         self.assertTrue(result["filepath"].startswith("exports/full_inventory_export-2"))
 
+    def test_export_full_inventory_tables(self):
+        result = export_full_inventory(tables=["machine"])
+        self.assertEqual(list(result["manifest"]["tables"]), ["machine"])
+
     # apps
 
     def test_export_android_apps(self):

--- a/zentral/contrib/inventory/api_views.py
+++ b/zentral/contrib/inventory/api_views.py
@@ -22,6 +22,7 @@ from .models import (CurrentMachineSnapshot,
                      MetaMachine,
                      Tag, Taxonomy)
 from .serializers import (CleanupInventorySerializer,
+                          FullExportSerializer,
                           JMESPathCheckSerializer,
                           MachineSerialNumbersSerializer,
                           MachineTagsUpdateSerializer,
@@ -397,14 +398,19 @@ class CleanupInventory(APIView):
 class FullExport(APIView):
     permission_required = "inventory.view_machinesnapshot"
     permission_classes = [DjangoPermissionRequired]
+    parser_classes = [FormParser, JSONParser, MultiPartParser]
 
     def post(self, request, *args, **kwargs):
-        result = export_full_inventory.apply_async(
-            kwargs={"task_user": request.user.id}
-        )
-        return Response({"task_id": result.id,
-                         "task_result_url": reverse("base_api:task_result", args=(result.id,))},
-                        status=status.HTTP_201_CREATED)
+        serializer = FullExportSerializer(data=request.data)
+        if serializer.is_valid():
+            result = export_full_inventory.apply_async(
+                kwargs={"tables": serializer.validated_data.get("tables"), "task_user": request.user.id}
+            )
+            return Response({"task_id": result.id,
+                             "task_result_url": reverse("base_api:task_result", args=(result.id,))},
+                            status=status.HTTP_201_CREATED)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 # Standard DRF views

--- a/zentral/contrib/inventory/management/commands/export_full_inventory.py
+++ b/zentral/contrib/inventory/management/commands/export_full_inventory.py
@@ -1,7 +1,7 @@
 import logging
 from django.core.files.storage import default_storage
 from django.core.management.base import BaseCommand
-from zentral.contrib.inventory.utils import do_full_export
+from zentral.contrib.inventory.utils import FULL_EXPORT_TABLE_NAMES, do_full_export
 from zentral.utils.storage import file_storage_has_signed_urls
 
 
@@ -9,10 +9,16 @@ logger = logging.getLogger("zentral.contrib.inventory.management.commands.export
 
 
 class Command(BaseCommand):
-    help = "Export full inventory as a ZIP archive of .ndjson files"
+    help = "Export the full inventory as a ZIP archive of .jsonl files"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--table", action="append", dest="tables", metavar="TABLE",
+                            choices=FULL_EXPORT_TABLE_NAMES,
+                            help="Export this table only. Repeat the option to export more than one table. "
+                                 "Without the option, all the tables are exported.")
 
     def handle(self, *args, **kwargs):
-        result = do_full_export()
+        result = do_full_export(tables=kwargs["tables"])
         filepath = result["filepath"]
         if file_storage_has_signed_urls(default_storage):
             url = default_storage.url(filepath)

--- a/zentral/contrib/inventory/serializers.py
+++ b/zentral/contrib/inventory/serializers.py
@@ -1,7 +1,7 @@
 from django.db.models import F
 from rest_framework import serializers
 from zentral.core.compliance_checks.models import ComplianceCheck
-from .utils import get_default_snapshot_retention_days
+from .utils import FULL_EXPORT_TABLE_NAMES, get_default_snapshot_retention_days
 from .compliance_checks import InventoryJMESPathCheck
 from .models import EnrollmentSecret, JMESPathCheck, MetaBusinessUnit, Tag, Taxonomy
 
@@ -95,6 +95,26 @@ class MachineSerialNumbersSerializer(serializers.Serializer):
 
 class CleanupInventorySerializer(serializers.Serializer):
     days = serializers.IntegerField(min_value=1, max_value=3660, default=get_default_snapshot_retention_days)
+
+
+class FullExportSerializer(serializers.Serializer):
+    tables = serializers.ListField(
+        child=serializers.ChoiceField(
+            choices=FULL_EXPORT_TABLE_NAMES,
+            error_messages={"invalid_choice": '"{input}" is not a valid table. '
+                                              f"Valid tables: {', '.join(FULL_EXPORT_TABLE_NAMES)}."},
+        ),
+        required=False,
+        allow_null=True,
+        allow_empty=False,
+        error_messages={"empty": f"This list may not be empty. Valid tables: {', '.join(FULL_EXPORT_TABLE_NAMES)}."},
+    )
+
+    def validate_tables(self, value):
+        if value is None:
+            return value
+        # canonical order, no duplicates
+        return [name for name in FULL_EXPORT_TABLE_NAMES if name in value]
 
 
 # Standard model serializers

--- a/zentral/contrib/inventory/tasks.py
+++ b/zentral/contrib/inventory/tasks.py
@@ -41,9 +41,9 @@ def cleanup_inventory(days, serialized_event_request, **kwargs):
 
 
 @shared_task
-def export_full_inventory(**kwargs):
+def export_full_inventory(tables=None, **kwargs):
     # kwargs absorbs task_user, added by the API view for the UserTask created in the celery signal
-    return do_full_export()
+    return do_full_export(tables=tables)
 
 
 @shared_task

--- a/zentral/contrib/inventory/utils/full_export.py
+++ b/zentral/contrib/inventory/utils/full_export.py
@@ -1,6 +1,8 @@
+import hashlib
 import json
 import logging
 import os.path
+import secrets
 import tempfile
 import zipfile
 from contextlib import contextmanager
@@ -13,7 +15,8 @@ from zentral.utils.db import get_read_only_database
 from zentral.utils.time import naive_utcnow
 
 __all__ = [
-    "do_full_export"
+    "FULL_EXPORT_TABLE_NAMES",
+    "do_full_export",
 ]
 
 
@@ -90,7 +93,7 @@ FULL_EXPORT_QUERIES = [
     ("system_info", rows("inventory_systeminfo", ms_fk_ids("system_info_id"))),
     # disks
     ("disk", rows("inventory_disk", m2m_ids("inventory_machinesnapshot_disks", "disk_id"))),
-    ("machine_disks", link_rows("inventory_machinesnapshot_disks", "disk_id")),
+    ("machine_disk", link_rows("inventory_machinesnapshot_disks", "disk_id")),
     # network interfaces
     ("network_interface",
      rows("inventory_networkinterface",
@@ -137,6 +140,20 @@ FULL_EXPORT_QUERIES = [
 ]
 
 
+FULL_EXPORT_TABLE_NAMES = [name for name, _ in FULL_EXPORT_QUERIES]
+
+
+def normalize_tables(tables):
+    if tables is None:
+        return FULL_EXPORT_TABLE_NAMES
+    if not tables:
+        raise ValueError("At least one table is required")
+    unknown = sorted(set(tables) - set(FULL_EXPORT_TABLE_NAMES))
+    if unknown:
+        raise ValueError(f"Unknown tables: {', '.join(unknown)}")
+    return [name for name in FULL_EXPORT_TABLE_NAMES if name in tables]
+
+
 @contextmanager
 def export_transaction():
     connection = connections[get_read_only_database()]
@@ -150,51 +167,106 @@ def export_transaction():
         yield connection
 
 
-def iter_model_exports(max_temp_file_size, window_size):
-    # for each model
-    # - execute the query
-    # - write the results in a temporary file
+def iter_batches(cursor, batch, window_size):
+    while batch:
+        yield batch
+        batch = cursor.fetchmany(window_size)
+
+
+def iter_tables(tables, window_size):
     with export_transaction() as connection:
-        for model_name, query in FULL_EXPORT_QUERIES:
-            model_export_f = model_export_p = None
-            file_index = 0
+        for table, query in FULL_EXPORT_QUERIES:
+            if table not in tables:
+                continue
             with connection.chunked_cursor() as cursor:
-                cursor.itersize = window_size
                 cursor.execute(query)
-                columns = None
-                for row in cursor:
-                    if columns is None:
-                        columns = [c.name for c in cursor.description]
-                    if model_export_f is None or model_export_f.tell() > max_temp_file_size:
-                        if model_export_f:
-                            model_export_f.close()
-                            yield model_name, file_index, model_export_p
-                        file_index += 1
-                        model_export_fh, model_export_p = tempfile.mkstemp()
-                        model_export_f = os.fdopen(model_export_fh, mode="w", newline="")
-                    obj = dict(zip(columns, row))
-                    json.dump(obj, model_export_f, cls=DjangoJSONEncoder)
-                    model_export_f.write("\n")
-            if model_export_f:
-                model_export_f.close()
-                yield model_name, file_index, model_export_p
+                # the description of a server-side cursor is only known after the first fetch
+                batch = cursor.fetchmany(window_size)
+                columns = [c.name for c in cursor.description]
+                yield table, columns, iter_batches(cursor, batch, window_size)
 
 
-def do_full_export(max_temp_file_size=2**30, window_size=5000):
+class HashingFile:
+    def __init__(self, f):
+        self._f = f
+        self._hash = hashlib.sha256()
+        self.size = 0
+
+    def write(self, data):
+        self._f.write(data)
+        self._hash.update(data)
+        self.size += len(data)
+
+    def close(self):
+        self._f.close()
+
+    def hexdigest(self):
+        return self._hash.hexdigest()
+
+
+class JSONLPart:
+    def __init__(self, table, index):
+        self.name = f"zentral_{table}_{index:04d}.jsonl"
+        fh, self.path = tempfile.mkstemp()
+        self.file = HashingFile(os.fdopen(fh, mode="wb"))
+        self.rows = 0
+
+    def write_row(self, obj):
+        self.file.write(json.dumps(obj, cls=DjangoJSONEncoder).encode("utf-8") + b"\n")
+        self.rows += 1
+
+    def close(self):
+        self.file.close()
+        return {"rows": self.rows, "size": self.file.size, "sha256": self.file.hexdigest()}
+
+
+def iter_jsonl_parts(table, columns, batches, max_temp_file_size):
+    part = None
+    part_index = 0
+    for batch in batches:
+        for row in batch:
+            if part is None or part.file.size > max_temp_file_size:
+                if part:
+                    yield part
+                part_index += 1
+                part = JSONLPart(table, part_index)
+            part.write_row(dict(zip(columns, row)))
+    if part:
+        yield part
+
+
+def do_full_export(tables=None, max_temp_file_size=2**30, window_size=5000):
+    tables = normalize_tables(tables)
     export_dt = naive_utcnow()
+    export_id = f"{export_dt:%Y%m%dT%H%M%SZ}-{secrets.token_hex(4)}"
+    manifest = {
+        "version": 1,
+        "export_id": export_id,
+        "exported_at": f"{export_dt:%Y-%m-%dT%H:%M:%SZ}",
+        "format": "JSONL",
+        "tables": {},
+        "files": {},
+    }
 
     # create ZIP archive
     zip_fh, zip_p = tempfile.mkstemp()
     with zipfile.ZipFile(zip_p, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_a:
-        for model_name, file_index, file_p in iter_model_exports(max_temp_file_size, window_size):
-            zip_a.write(file_p, f"zentral_{model_name}_{file_index:04d}.jsonl")
-            os.unlink(file_p)
+        for table, columns, batches in iter_tables(tables, window_size):
+            table_manifest = {"rows": 0, "columns": [{"name": column} for column in columns], "files": []}
+            for part in iter_jsonl_parts(table, columns, batches, max_temp_file_size):
+                file_manifest = part.close()
+                zip_a.write(part.path, part.name)
+                os.unlink(part.path)
+                table_manifest["rows"] += file_manifest["rows"]
+                table_manifest["files"].append(part.name)
+                manifest["files"][part.name] = {"table": table, **file_manifest}
+            manifest["tables"][table] = table_manifest
+        zip_a.writestr("manifest.json", json.dumps(manifest, indent=2))
 
     # copy ZIP archive to default storage
-    filename = f"full_inventory_export-{export_dt:%Y-%m-%d_%H-%M-%S}.zip"
-    filepath = os.path.join("exports", filename)
     with os.fdopen(zip_fh, "rb") as zip_f:
-        default_storage.save(filepath, zip_f)
+        filepath = default_storage.save(os.path.join("exports", f"full_inventory_export-{export_id}.zip"), zip_f)
+    filename = os.path.basename(filepath)
 
     # cleanup local ZIP archive
     os.unlink(zip_p)
@@ -205,5 +277,6 @@ def do_full_export(max_temp_file_size=2**30, window_size=5000):
         "headers": {
             "Content-Type": "application/zip",
             "Content-Disposition": f'attachment; filename="{filename}"',
-        }
+        },
+        "manifest": manifest,
     }


### PR DESCRIPTION
## What

- `POST /api/inventory/full_export/` takes an optional `tables` list, and the `export_full_inventory` command takes a repeatable `--table` option. The tables are exported in their canonical order, one time each. An unknown table, or an empty list, gives a `400` that lists the valid tables.
- The task result carries a manifest: the tables, with their row counts, their columns and their files, and the files of the archive, with their table, row count, size and SHA-256 digest. The archive contains the same manifest as `manifest.json`. The manifest is the contract of the multi-file downloads and of the Parquet export that come next.
- The `zentral_machine_disks_<index>.jsonl` files are named `zentral_machine_disk_<index>.jsonl`, like the files of the other link tables.

## Fix on the way

The archive was named after a timestamp with a one second resolution, and `do_full_export` returned the name it asked for, not the name the storage used. Two exports started in the same second got the same name, and the second task result pointed at the file of the first export. The archive is named after the export id now, `full_inventory_export-<timestamp>-<random suffix>.zip`, and the task result carries the name the storage used.

## How

- The export loop is split into a table iterator, which runs the selected queries in the one transaction, and a JSONL writer, which hashes and counts what it writes. The columns of a table are read from the description of the server-side cursor after the first fetch, so they are known for a table without a row.
- `FullExportSerializer` validates `tables`. The view, the task and the command pass the list through.

## Tests

- The manifest against the archive: the size, digest and row count of every file, the columns against the rows, `manifest.json` equal to the task result manifest, the file name with the export id.
- The `tables` option: canonical order and duplicates, unknown table, empty list, `null`, at the export, the API, the task and the command.
- A table without a row: no file, columns known.
- Each new test was checked against a broken version of the code.

CHANGELOG: a feature entry under *Inventory*, and the rename under *Backward incompatibilities*. Docs: the table list, the manifest, the retention sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
