### PR TITLE
base: serve the files of a task result that has a manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 The PBAC Schema browser documents each action now. It shows what the action authorizes, the context attributes a `when` clause can read, and the values an attribute accepts when the set is closed — for example the artifact types of `MDM::Action::"forceInstallArtifact"`. An optional attribute carries a `?` after its name, which tells you if a `has` guard is necessary. The principals and the resources show the types they are members of, so you can see what a `resource in` clause can name: a `forceCleanSync` policy can be scoped to a machine, or to one of its meta business units.
 
+A task that produces several files has a manifest in its result. The download endpoint of the task gives the manifest with a download URL for each file, and the `file` parameter downloads one file. With an S3 or GCS storage, the manifest also gives the URL of each file in the storage, and the expiration time of the URL when it expires. The tasks pages list the files.
+
 
 #### Documentation
 

--- a/docs/content/apps/core.md
+++ b/docs/content/apps/core.md
@@ -118,6 +118,8 @@ Issuers can also be managed over the API, at `/api/accounts/token_issuers/oidc/`
 
 Use this endpoint to get the status of a task. If the task generates a file, a `download_url` attribute will be included. The `download_url` will redirect to the exported file (for example, a signed S3 URL if Zentral is configured with a S3 bucket). A process should wait for a task if `unready` is true.
 
+If the task generates several files, its result carries a `manifest` that lists them, and the `download_url` attribute is present too. It gives the manifest with a download URL for each file, see [below](#apitask_resultuuidtask_iddownload).
+
 A task belongs to the user or the service account that launched it. Only that principal can read its status, and a superuser can read the status of all the tasks. The endpoint gives the `UNKNOWN` status for the task of a different principal, like it does for a task that does not exist. A task that a device launched, and a task that Zentral launched before version 2025.11, has no user: only a superuser can read it.
 
 Example:
@@ -160,6 +162,48 @@ Example:
 curl -H "Authorization: Token $ZTL_API_TOKEN" \
      -L -o inventory_export_2025-03-12_10-21-12.xlsx \
      https://$ZTL_FQDN/api/task_result/d40e9320-8c0c-459b-bfdb-001a9f73619f/download/
+```
+
+A task that generates several files puts them in one directory of the storage. Its result carries a manifest with the `files` of the directory, keyed by their name in the directory. For such a task, this endpoint gives the manifest, with a `download_url` for each file. If the storage is an S3 or a GCS bucket, each file also has its `url` in the storage, and the `expires_at` time of the URL when the URL expires. The `file` parameter downloads one file: `?file=<name>`, where the name is a key of `files`. An unknown name gives a `404`.
+
+Example:
+
+```
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     https://$ZTL_FQDN/api/task_result/5ecb057b-57cc-41e4-a07e-fcc357d7a5c7/download/
+```
+
+Result:
+
+```json
+{
+    "version": 1,
+    "export_id": "20260911T100000Z-3f9c1a2b",
+    "exported_at": "2026-09-11T10:00:00Z",
+    "format": "PARQUET",
+    "tables": {
+        "machine": {"rows": 4213, "columns": ["…"], "files": ["machine/machine-00001.parquet"]}
+    },
+    "files": {
+        "machine/machine-00001.parquet": {
+            "table": "machine",
+            "rows": 4213,
+            "size": 1284906,
+            "sha256": "…",
+            "download_url": "/api/task_result/5ecb057b-57cc-41e4-a07e-fcc357d7a5c7/download/?file=machine%2Fmachine-00001.parquet",
+            "url": "https://acme-zentral.s3.amazonaws.com/exports/inventory/20260911T100000Z-3f9c1a2b/machine/machine-00001.parquet?X-Amz-…",
+            "expires_at": "2026-09-11T11:05:12Z"
+        }
+    }
+}
+```
+
+One file:
+
+```
+curl -H "Authorization: Token $ZTL_API_TOKEN" \
+     -L -o machine-00001.parquet \
+     "https://$ZTL_FQDN/api/task_result/5ecb057b-57cc-41e4-a07e-fcc357d7a5c7/download/?file=machine%2Fmachine-00001.parquet"
 ```
 
 ### `/api/accounts/token_issuers/oidc/<uuid:issuer_id>/auth/`

--- a/server/base/api_views.py
+++ b/server/base/api_views.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import os.path
+from urllib.parse import urlencode
 import celery.states
 from django_celery_results.models import TaskResult
 from django.core.files.storage import default_storage
@@ -12,10 +14,19 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from accounts.api_authentication import APITokenAuthentication
 from accounts.models import task_results_for_user
-from zentral.utils.storage import file_storage_has_signed_urls
+from zentral.utils.storage import file_storage_has_signed_urls, file_storage_signed_url_expiration
+from zentral.utils.time import naive_utcnow
 
 
 logger = logging.getLogger("server.base.api_views")
+
+
+def get_manifest_location(result):
+    manifest = result.get("manifest")
+    if isinstance(manifest, dict):
+        location = manifest.get("location")
+        if isinstance(location, str) and location:
+            return location
 
 
 class BaseTaskResultView(APIView):
@@ -46,7 +57,10 @@ class TaskResultView(BaseTaskResultView):
                     logger.exception("Could not load task result")
                 else:
                     filepath = result.pop("filepath", None)
-                    if filepath:
+                    location = get_manifest_location(result)
+                    if location:
+                        del result["manifest"]["location"]
+                    if filepath or location:
                         response["download_url"] = reverse("base_api:task_result_file_download", args=(task_id,))
                     response["result"] = result
         return Response(response)
@@ -64,18 +78,45 @@ class TaskResultFileDownloadView(BaseTaskResultView):
         except (TypeError, ValueError):
             logger.exception("Could not load task result")
             raise Http404
-        try:
-            filepath = result["filepath"]
-            assert isinstance(filepath, str) and len(filepath) > 0
-        except (AssertionError, KeyError):
-            logger.error("No file found in task %s result", task_result.task_id)
-            raise Http404
+        location = get_manifest_location(result)
+        file_key = request.GET.get("file")
+        if file_key is not None:
+            # the key is checked against the manifest before it reaches the storage
+            if not location or file_key not in result["manifest"].get("files", {}):
+                raise Http404
+            return self._file_response(location + file_key, filename=os.path.basename(file_key))
+        filepath = result.get("filepath")
+        if isinstance(filepath, str) and filepath:
+            return self._file_response(filepath, headers=result.get("headers"))
+        if location:
+            return Response(self._manifest_with_urls(task_result.task_id, result["manifest"]))
+        logger.error("No file found in task %s result", task_result.task_id)
+        raise Http404
+
+    def _file_response(self, filepath, headers=None, filename=None):
         if self._redirect_to_files:
             return redirect(default_storage.url(filepath))
-        else:
-            if not default_storage.exists(filepath):
-                raise Http404
-            response = FileResponse(default_storage.open(filepath))
-            for k, v in result.get("headers").items():
-                response[k] = v
-            return response
+        if not default_storage.exists(filepath):
+            raise Http404
+        response = FileResponse(default_storage.open(filepath), as_attachment=bool(filename), filename=filename or "")
+        for k, v in (headers or {}).items():
+            response[k] = v
+        return response
+
+    def _manifest_with_urls(self, task_id, manifest):
+        manifest = dict(manifest)
+        location = manifest.pop("location")
+        download_url = reverse("base_api:task_result_file_download", args=(task_id,))
+        expiration = file_storage_signed_url_expiration() if self._redirect_to_files else None
+        files = {}
+        for key, file_info in manifest.get("files", {}).items():
+            file_info = dict(file_info)
+            file_info["download_url"] = f"{download_url}?{urlencode({'file': key})}"
+            if self._redirect_to_files:
+                signed_at = naive_utcnow()
+                file_info["url"] = default_storage.url(location + key)
+                if expiration:
+                    file_info["expires_at"] = f"{signed_at + expiration:%Y-%m-%dT%H:%M:%SZ}"
+            files[key] = file_info
+        manifest["files"] = files
+        return manifest

--- a/server/templates/accounts/tasks/_result.html
+++ b/server/templates/accounts/tasks/_result.html
@@ -2,6 +2,40 @@
 {% if task.result %}
 {% if result_json.filepath %}
 <a class="btn btn-default border" href="/api/task_result/{{ task.task_id }}/download/"><i class="bi bi-download"></i></a>
+{% elif result_json.manifest.location %}
+{% if show_result %}
+<table class="table table-sm align-middle mb-0">
+    <thead>
+        <tr>
+            <th>File</th>
+            <th>Table</th>
+            <th class="text-end">Rows</th>
+            <th class="text-end">Size</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for key, file in result_json.manifest.files.items %}
+        <tr>
+            <td><code>{{ key }}</code></td>
+            <td>{{ file.table|default:"-" }}</td>
+            <td class="text-end">{{ file.rows|default_if_none:"-" }}</td>
+            <td class="text-end">{{ file.size|filesizeformat }}</td>
+            <td class="text-end"><a class="btn btn-default border btn-sm" href="/api/task_result/{{ task.task_id }}/download/?file={{ key|urlencode:"" }}"><i class="bi bi-download"></i></a></td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<div class="dropdown">
+    <button class="btn btn-default border dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-download"></i></button>
+    <ul class="dropdown-menu dropdown-menu-end">
+        {% for key, file in result_json.manifest.files.items %}
+        <li><a class="dropdown-item" href="/api/task_result/{{ task.task_id }}/download/?file={{ key|urlencode:"" }}">{{ key }}</a></li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
 {% else %}
 {% if show_result %}
 <code>

--- a/tests/server_accounts/views/test_tasks_views.py
+++ b/tests/server_accounts/views/test_tasks_views.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from datetime import timedelta
 
@@ -56,6 +57,18 @@ class AccountTasksViewsTestCase(TestCase):
             date_created=naive_utcnow() - timedelta(days=1, seconds=10),
             date_done=naive_utcnow() - timedelta(days=1)
         )
+        cls.task_with_files = TaskResult.objects.create(
+            task_name='zentral.test.files_task',
+            task_id=str(uuid.uuid4()),
+            result=json.dumps({"manifest": {"location": "exports/inventory/yolo/",
+                                            "files": {"machine/machine-00001.parquet": {"table": "machine",
+                                                                                        "rows": 2,
+                                                                                        "size": 4096,
+                                                                                        "sha256": "…"}}}}),
+            date_created=naive_utcnow() - timedelta(days=1, seconds=10),
+            date_done=naive_utcnow() - timedelta(days=1)
+        )
+        UserTask.objects.create(user=cls.ui_user, task_result=cls.task_with_files)
 
     # auth utils
 
@@ -91,15 +104,25 @@ class AccountTasksViewsTestCase(TestCase):
         self.login(self.ui_user)
         response = self.client.get(reverse("accounts:tasks"))
         self.assertTemplateUsed(response, "accounts/task_list.html")
-        self.assertEqual(response.context["object_list"].count(), 1)
+        self.assertEqual(response.context["object_list"].count(), 2)
         self.assertContains(response, 'User Task')
 
     def test_task_list_admin(self):
         self.login(self.admin_user)
         response = self.client.get(reverse("accounts:tasks"))
         self.assertTemplateUsed(response, "accounts/task_list.html")
-        self.assertEqual(response.context["object_list"].count(), 3)
+        self.assertEqual(response.context["object_list"].count(), 4)
         self.assertContains(response, 'Admin Task')
+
+    def test_task_list_files(self):
+        self.login(self.ui_user)
+        response = self.client.get(reverse("accounts:tasks"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "dropdown-menu")
+        self.assertContains(
+            response,
+            f"/api/task_result/{self.task_with_files.task_id}/download/?file=machine%2Fmachine-00001.parquet"
+        )
 
     # task detail
 
@@ -146,3 +169,15 @@ class AccountTasksViewsTestCase(TestCase):
         self.assertContains(response, self.ui_user.username)
         # check for result display
         self.assertContains(response, "result_error")
+
+    def test_view_task_files(self):
+        self.login(self.ui_user)
+        response = self.client.get(reverse("accounts:task", args=(self.task_with_files.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/task_detail.html")
+        self.assertContains(response, "<code>machine/machine-00001.parquet</code>")
+        self.assertContains(response, "4.0\xa0KB")
+        self.assertContains(
+            response,
+            f"/api/task_result/{self.task_with_files.task_id}/download/?file=machine%2Fmachine-00001.parquet"
+        )

--- a/tests/server_base/test_api_views.py
+++ b/tests/server_base/test_api_views.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timedelta
 from unittest.mock import patch
 import uuid
 
 from django.contrib.auth.models import Group
+from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.urls import reverse
 from django.utils.crypto import get_random_string
@@ -10,6 +12,7 @@ from django.test import TestCase
 from accounts.models import APIToken, User
 from tests.zentral_test_utils.login_case import LoginCase
 from tests.zentral_test_utils.request_case import RequestCase
+from zentral.utils.time import naive_utcnow
 from .utils import force_task_result
 
 
@@ -51,6 +54,21 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
 
     def _get_api_key(self):
         return self.api_key
+
+    # utils
+
+    def force_manifest_task_result(self, user=None, location=True):
+        location_path = f"exports/inventory/{get_random_string(12)}/"
+        manifest = {
+            "version": 1,
+            "format": "PARQUET",
+            "tables": {"machine": {"rows": 2, "files": ["machine/machine-00001.parquet"]}},
+            "files": {"machine/machine-00001.parquet": {"table": "machine", "rows": 2, "size": 4, "sha256": "…"}},
+        }
+        if location:
+            manifest["location"] = location_path
+        tr, _, _ = force_task_result(result={"manifest": manifest}, user=user)
+        return tr, manifest, location_path
 
     # task result
 
@@ -161,6 +179,43 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"id": tr.task_id, "status": "UNKNOWN", "unready": True})
 
+    # task result, manifest
+
+    def test_task_result_manifest(self):
+        tr, manifest, _ = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        expected_manifest = {k: v for k, v in manifest.items() if k != "location"}
+        self.assertEqual(
+            response.json(),
+            {"id": tr.task_id,
+             "name": "zentral.contrib.santa.tasks.export_targets",
+             "status": "SUCCESS",
+             "unready": False,
+             "result": {"manifest": expected_manifest},
+             "download_url": f"/api/task_result/{tr.task_id}/download/"}
+        )
+
+    def test_task_result_manifest_without_location(self):
+        tr, manifest, _ = self.force_manifest_task_result(user=self.service_account, location=False)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"id": tr.task_id,
+             "name": "zentral.contrib.santa.tasks.export_targets",
+             "status": "SUCCESS",
+             "unready": False,
+             "result": {"manifest": manifest}}
+        )
+
+    def test_task_result_manifest_not_a_dict(self):
+        tr, _, _ = force_task_result(result={"manifest": ["yolo"]}, user=self.service_account)
+        response = self.get(reverse("base_api:task_result", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("download_url", response.json())
+        self.assertEqual(response.json()["result"], {"manifest": ["yolo"]})
+
     # task result file download
 
     def test_result_file_download_unauthorized(self):
@@ -244,3 +299,112 @@ class BaseAPIViewsTestCase(TestCase, LoginCase, RequestCase):
         response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)),
                             include_token=False)
         self.assertRedirects(response, f"/{filepath}", fetch_redirect_response=False)
+
+    # task result manifest download
+
+    def test_result_download_manifest(self):
+        tr, manifest, _ = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        key = "machine/machine-00001.parquet"
+        expected = {k: v for k, v in manifest.items() if k != "location"}
+        expected["files"] = {
+            key: {**manifest["files"][key],
+                  "download_url": f"/api/task_result/{tr.task_id}/download/?file=machine%2Fmachine-00001.parquet"}
+        }
+        self.assertEqual(response.json(), expected)
+
+    def test_result_download_manifest_login(self):
+        tr, manifest, _ = self.force_manifest_task_result(user=self.user)
+        self.login()
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)),
+                            include_token=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(set(response.json()["files"]), {"machine/machine-00001.parquet"})
+
+    def test_result_download_manifest_other_user_404(self):
+        tr, _, _ = self.force_manifest_task_result(user=self.other_user)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 404)
+
+    @patch("base.api_views.file_storage_signed_url_expiration")
+    @patch("base.api_views.file_storage_has_signed_urls")
+    def test_result_download_manifest_signed_urls(self, file_storage_has_signed_urls,
+                                                  file_storage_signed_url_expiration):
+        file_storage_has_signed_urls.return_value = True
+        file_storage_signed_url_expiration.return_value = timedelta(hours=1)
+        tr, manifest, location = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        file_info = response.json()["files"]["machine/machine-00001.parquet"]
+        self.assertEqual(file_info["download_url"],
+                         f"/api/task_result/{tr.task_id}/download/?file=machine%2Fmachine-00001.parquet")
+        self.assertEqual(file_info["url"], f"/{location}machine/machine-00001.parquet")
+        expires_at = datetime.strptime(file_info["expires_at"], "%Y-%m-%dT%H:%M:%SZ")
+        self.assertLess(abs(expires_at - naive_utcnow() - timedelta(hours=1)), timedelta(minutes=1))
+
+    @patch("base.api_views.file_storage_signed_url_expiration")
+    @patch("base.api_views.file_storage_has_signed_urls")
+    def test_result_download_manifest_signed_urls_without_expiration(self, file_storage_has_signed_urls,
+                                                                     file_storage_signed_url_expiration):
+        file_storage_has_signed_urls.return_value = True
+        file_storage_signed_url_expiration.return_value = None
+        tr, manifest, location = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)))
+        self.assertEqual(response.status_code, 200)
+        file_info = response.json()["files"]["machine/machine-00001.parquet"]
+        self.assertEqual(file_info["url"], f"/{location}machine/machine-00001.parquet")
+        self.assertNotIn("expires_at", file_info)
+
+    # task result manifest file download
+
+    def test_result_download_file(self):
+        tr, _, location = self.force_manifest_task_result(user=self.service_account)
+        default_storage.save(f"{location}machine/machine-00001.parquet", ContentFile(b"yolo"))
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,))
+                            + "?file=machine%2Fmachine-00001.parquet")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/octet-stream")
+        self.assertEqual(response.headers["Content-Disposition"], 'attachment; filename="machine-00001.parquet"')
+        self.assertEqual(b"".join(response.streaming_content), b"yolo")
+
+    @patch("base.api_views.file_storage_has_signed_urls")
+    def test_result_download_file_redirect(self, file_storage_has_signed_urls):
+        file_storage_has_signed_urls.return_value = True
+        tr, _, location = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,))
+                            + "?file=machine/machine-00001.parquet")
+        self.assertRedirects(response, f"/{location}machine/machine-00001.parquet", fetch_redirect_response=False)
+
+    def test_result_download_file_unknown_key_404(self):
+        tr, _, location = self.force_manifest_task_result(user=self.service_account)
+        # the object exists in the storage, but the manifest does not list it
+        default_storage.save(f"{location}other.parquet", ContentFile(b"yolo"))
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)) + "?file=other.parquet")
+        self.assertEqual(response.status_code, 404)
+
+    @patch("base.api_views.file_storage_has_signed_urls")
+    def test_result_download_file_unknown_key_no_redirect(self, file_storage_has_signed_urls):
+        file_storage_has_signed_urls.return_value = True
+        tr, _, _ = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)) + "?file=other.parquet")
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_download_file_missing_object_404(self):
+        tr, _, _ = self.force_manifest_task_result(user=self.service_account)
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,))
+                            + "?file=machine%2Fmachine-00001.parquet")
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_download_file_single_file_result_404(self):
+        tr, _, filepath = force_task_result(user=self.service_account)
+        default_storage.save(filepath, ContentFile(b"yolo"))
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,)) + "?file=yolo")
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_download_file_other_user_404(self):
+        tr, _, location = self.force_manifest_task_result(user=self.other_user)
+        default_storage.save(f"{location}machine/machine-00001.parquet", ContentFile(b"yolo"))
+        response = self.get(reverse("base_api:task_result_file_download", args=(tr.task_id,))
+                            + "?file=machine%2Fmachine-00001.parquet")
+        self.assertEqual(response.status_code, 404)

--- a/tests/utils/test_storage.py
+++ b/tests/utils/test_storage.py
@@ -1,5 +1,8 @@
+from datetime import timedelta
 from django.test import SimpleTestCase, override_settings
-from zentral.utils.storage import file_storage_has_signed_urls, select_dist_storage
+from zentral.utils.storage import (file_storage_has_signed_urls,
+                                   file_storage_signed_url_expiration,
+                                   select_dist_storage)
 
 
 class StorageTestCase(SimpleTestCase):
@@ -21,3 +24,28 @@ class StorageTestCase(SimpleTestCase):
     def test_select_dist_storage_fallback(self):
         storage = select_dist_storage()
         self.assertEqual(storage.__class__.__name__, "S3Storage")
+
+    # signed URL expiration
+
+    def test_file_storage_signed_url_expiration_default(self):
+        self.assertIsNone(file_storage_signed_url_expiration())
+
+    @override_settings(STORAGES={"default": {"BACKEND": "storages.backends.s3.S3Storage",
+                                             "OPTIONS": {"querystring_expire": 600}}})
+    def test_file_storage_signed_url_expiration_s3(self):
+        self.assertEqual(file_storage_signed_url_expiration(), timedelta(seconds=600))
+
+    @override_settings(STORAGES={"default": {"BACKEND": "storages.backends.s3.S3Storage",
+                                             "OPTIONS": {"querystring_auth": False}}})
+    def test_file_storage_signed_url_expiration_s3_public_urls(self):
+        self.assertIsNone(file_storage_signed_url_expiration())
+
+    @override_settings(STORAGES={"default": {"BACKEND": "storages.backends.s3.S3Storage",
+                                             "OPTIONS": {"querystring_expire": 0}}})
+    def test_file_storage_signed_url_expiration_s3_no_expire(self):
+        self.assertIsNone(file_storage_signed_url_expiration())
+
+    @override_settings(STORAGES={"default": {"BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+                                             "OPTIONS": {"expiration": timedelta(hours=2)}}})
+    def test_file_storage_signed_url_expiration_gcs(self):
+        self.assertEqual(file_storage_signed_url_expiration(), timedelta(hours=2))

--- a/zentral/utils/storage.py
+++ b/zentral/utils/storage.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from django.core.files.storage import storages, InvalidStorageError
 
 
@@ -7,6 +8,22 @@ def file_storage_has_signed_urls(storage=None):
     # TODO better detection!
     storage_class_name = storage.__class__.__name__
     return storage_class_name in ('S3Storage', 'S3Boto3Storage', 'GoogleCloudStorage', 'ZentralGoogleCloudStorage')
+
+
+def file_storage_signed_url_expiration(storage=None):
+    if storage is None:
+        storage = storages["default"]
+    if not file_storage_has_signed_urls(storage) or not getattr(storage, "querystring_auth", True):
+        return None
+    # GCS
+    expiration = getattr(storage, "expiration", None)
+    if isinstance(expiration, timedelta):
+        return expiration
+    # S3
+    querystring_expire = getattr(storage, "querystring_expire", None)
+    if querystring_expire:
+        return timedelta(seconds=int(querystring_expire))
+    return None
 
 
 def select_dist_storage():


### PR DESCRIPTION
## What

The base app can serve a task result with several files. Such a result carries a manifest with the `location` of the directory of the files in the storage, and the `files` of the directory, keyed by their name in the directory.

- `GET /api/task_result/<task_id>/`: the `download_url` attribute is present for such a result too. The manifest is echoed without the `location`.
- `GET /api/task_result/<task_id>/download/`: the manifest, with a `download_url` for each file. With an S3 or GCS storage, each file also has its `url` in the storage, and the `expires_at` time of the URL when the URL expires.
- `GET /api/task_result/<task_id>/download/?file=<key>`: one file. The key is looked up in the manifest first, then the object is resolved as `location + key`, then the response is a redirect to the signed URL, or the file itself. An unknown key, or a result without a `location`, gives a `404`. Nothing from the query string reaches the storage without the check.
- The tasks pages list the files, each with a download link.

A result with a `filepath` is served as before. A result with a manifest but without a `location` has no download, which is the case of the JSONL full export of #1695.

No task produces such a result yet. The Parquet inventory export, next in the series, is the first one. The contract is written down in the planning doc of the series.

## How

- `zentral/utils/storage.py`: `file_storage_signed_url_expiration` gives the validity of a signed URL, from the S3 `querystring_expire` seconds or the GCS `expiration`, and `None` when the storage does not sign its URLs.
- `server/base/api_views.py`: the two branches of the download view, and one file response helper shared with the single-file case.
- `server/templates/accounts/tasks/_result.html`: a table of the files on the task page, a dropdown on the tasks list.

## Tests

- The status response with a manifest, with and without a `location`.
- The manifest response: the download URLs, the signed URLs with and without an expiration time, the ownership rules.
- One file: served, redirected, unknown key with an object that exists but is not in the manifest, unknown key with a signing storage, missing object, `file` on a single-file result, other user.
- The expiration helper for the default storage, S3 with and without `querystring_auth`, S3 without an expiration, GCS.
- The two tasks pages.
- Each new test was checked against a broken version of the code, and one test was strengthened by that check: the unknown-key test passed for the wrong reason until the object existed in the storage.

Docs: the two task result sections of the core page. CHANGELOG: one entry under *Core*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
