### PR TITLE
inventory: read the machine exports with an explicit fetch, on the read-only database

### DIFF
--- a/tests/inventory/test_exports.py
+++ b/tests/inventory/test_exports.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import zipfile
 import pyarrow.parquet as pq
 from django.core.files.storage import default_storage
-from django.db import connection
+from django.db import connection, connections
 from django.test import TestCase, TransactionTestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MachineSnapshot, MachineSnapshotCommit, MetaBusinessUnit, Source
@@ -18,6 +18,7 @@ from zentral.contrib.inventory.utils import (do_full_export,
                                              export_machine_macos_app_instances,
                                              export_machine_snapshots)
 from zentral.contrib.inventory.utils.app_exports import _export_machine_csv_zip
+from zentral.contrib.inventory.utils.db import chunked_query
 from zentral.contrib.inventory.utils.full_export import (FULL_EXPORT_QUERIES, FULL_EXPORT_TABLE_NAMES, TempFile,
                                                          export_transaction, iter_tables, save_export_object)
 from zentral.utils.parquet import arrow_schema
@@ -581,6 +582,21 @@ class InventoryExportsTests(TestCase):
                     self.assertEqual(snapshot["os_version"], {'major': 10, 'minor': 11, 'name': 'OS X', 'patch': 1})
                     self.assertEqual(snapshot["extra_facts"], {"un": 1, "deux": "zwei"})
         default_storage.delete(result["filepath"])
+
+    def test_chunked_query_reads_the_read_only_database(self):
+        aliases = []
+
+        class Connections:
+            def __getitem__(self, alias):
+                aliases.append(alias)
+                return connections["default"]
+
+        with patch("zentral.contrib.inventory.utils.db.get_read_only_database", return_value="ro"):
+            with patch("zentral.contrib.inventory.utils.db.connections", Connections()):
+                with chunked_query("select 1 as one", [], 10) as (columns, rows):
+                    self.assertEqual(columns, ["one"])
+                    self.assertEqual(list(rows), [(1,)])
+        self.assertEqual(aliases, ["ro"])
 
     def test_export_machine_snapshots_window_size(self):
         serial_numbers = {self.commit_machine_snapshot() for _ in range(5)}

--- a/tests/inventory/test_exports.py
+++ b/tests/inventory/test_exports.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import csv
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -9,12 +10,14 @@ from pathlib import Path
 import zipfile
 import pyarrow.parquet as pq
 from django.core.files.storage import default_storage
+from django.db import connection
 from django.test import TestCase, TransactionTestCase
 from django.utils.crypto import get_random_string
 from zentral.contrib.inventory.models import MachineSnapshot, MachineSnapshotCommit, MetaBusinessUnit, Source
 from zentral.contrib.inventory.utils import (do_full_export,
                                              export_machine_macos_app_instances,
                                              export_machine_snapshots)
+from zentral.contrib.inventory.utils.app_exports import _export_machine_csv_zip
 from zentral.contrib.inventory.utils.full_export import (FULL_EXPORT_QUERIES, FULL_EXPORT_TABLE_NAMES, TempFile,
                                                          export_transaction, iter_tables, save_export_object)
 from zentral.utils.parquet import arrow_schema
@@ -46,6 +49,29 @@ def sha_256(*parts):
 
 def root_certificate():
     return {"common_name": "Apple Root CA", "sha_256": sha_256("root")}
+
+
+@contextmanager
+def record_fetches():
+    """Record the (window, row count) of every fetch on the chunked cursors of the exports."""
+    fetches = []
+    chunked_cursor = connection.chunked_cursor
+
+    @contextmanager
+    def recording_chunked_cursor():
+        with chunked_cursor() as cursor:
+            fetchmany = cursor.fetchmany
+
+            def recording_fetchmany(size):
+                rows = fetchmany(size)
+                fetches.append((size, len(rows)))
+                return rows
+
+            cursor.fetchmany = recording_fetchmany
+            yield cursor
+
+    with patch.object(connection, "chunked_cursor", recording_chunked_cursor):
+        yield fetches
 
 
 class InventoryExportsTests(TestCase):
@@ -554,6 +580,39 @@ class InventoryExportsTests(TestCase):
                     self.assertEqual(snapshot["serial_number"], serial_number)
                     self.assertEqual(snapshot["os_version"], {'major': 10, 'minor': 11, 'name': 'OS X', 'patch': 1})
                     self.assertEqual(snapshot["extra_facts"], {"un": 1, "deux": "zwei"})
+        default_storage.delete(result["filepath"])
+
+    def test_export_machine_snapshots_window_size(self):
+        serial_numbers = {self.commit_machine_snapshot() for _ in range(5)}
+        with record_fetches() as fetches:
+            result = export_machine_snapshots(source_name="ZENTRAL TESTS", window_size=2)
+        # 5 rows, 2 rows per fetch, then an empty fetch
+        self.assertEqual(fetches, [(2, 2), (2, 2), (2, 1), (2, 0)])
+        with default_storage.open(result["filepath"]) as f:
+            with zipfile.ZipFile(f) as zf:
+                with zf.open("zentral-tests.jsonl") as jl:
+                    content = jl.read().decode("utf-8").splitlines()
+        self.assertEqual({json.loads(line)["serial_number"] for line in content}, serial_numbers)
+        default_storage.delete(result["filepath"])
+
+    def test_export_machine_csv_zip_window_size(self):
+        serial_numbers = {self.commit_machine_snapshot() for _ in range(5)}
+        query = (
+            "select s.name as source_name, cms.serial_number "
+            "from inventory_currentmachinesnapshot as cms "
+            "join inventory_machinesnapshot as ms on ms.id = cms.machine_snapshot_id "
+            "join inventory_source as s on ms.source_id = s.id "
+            "where UPPER(s.name) = %s "
+            "order by s.name, cms.serial_number;"
+        )
+        with record_fetches() as fetches:
+            result = _export_machine_csv_zip(query, "ZENTRAL TESTS", "window_size_export", window_size=2)
+        # 5 rows, 2 rows per fetch, then an empty fetch
+        self.assertEqual(fetches, [(2, 2), (2, 2), (2, 1), (2, 0)])
+        with default_storage.open(result["filepath"]) as f:
+            rows = list(csv.reader(zipfile.Path(f, at="zentral-tests.csv").open(newline="")))
+        self.assertEqual(rows[0], ["source_name", "serial_number"])
+        self.assertEqual({serial_number for _, serial_number in rows[1:]}, serial_numbers)
         default_storage.delete(result["filepath"])
 
     def test_export_machine_macos_app_instances(self):

--- a/zentral/contrib/inventory/utils/app_exports.py
+++ b/zentral/contrib/inventory/utils/app_exports.py
@@ -5,10 +5,11 @@ import tempfile
 import zipfile
 
 from django.core.files.storage import default_storage
-from django.db import connection, transaction
 from django.utils.text import slugify
 
 from zentral.utils.time import naive_utcnow
+
+from .db import chunked_query
 
 __all__ = [
     "export_machine_android_apps",
@@ -23,20 +24,14 @@ logger = logging.getLogger("zentral.contrib.inventory.utils.app_exports")
 
 
 def _export_machine_csv_zip(query, source_name, basename, window_size=5000):
-    columns = None
     csv_files = []
     current_source_name = csv_f = csv_w = csv_p = None
 
-    # iter all rows over a server-side cursor
     query_args = []
     if source_name:
         query_args.append(source_name.upper())
-    with transaction.atomic(), connection.chunked_cursor() as cursor:
-        cursor.itersize = window_size
-        cursor.execute(query, query_args)
-        for row in cursor:
-            if columns is None:
-                columns = [c.name for c in cursor.description]
+    with chunked_query(query, query_args, window_size) as (columns, rows):
+        for row in rows:
             source_name = row[columns.index("source_name")]
             if source_name != current_source_name:
                 if current_source_name:

--- a/zentral/contrib/inventory/utils/db.py
+++ b/zentral/contrib/inventory/utils/db.py
@@ -1,4 +1,6 @@
+from contextlib import contextmanager
 import logging
+from django.db import connection, transaction
 from zentral.contrib.inventory.compliance_checks import jmespath_checks_cache
 from zentral.contrib.inventory.events import (iter_inventory_events)
 from zentral.contrib.inventory.models import MachineSnapshotCommit
@@ -100,3 +102,20 @@ def commit_machine_snapshot_and_yield_events(tree):
         yield from iter_inventory_events(msc.serial_number, inventory_events_from_machine_snapshot_commit(msc))
     # compliance checks
     yield from jmespath_checks_cache.process_tree(tree, last_seen)
+
+
+@contextmanager
+def chunked_query(query, args, window_size):
+    """Run a query on a server-side cursor, and read window_size rows for each round trip."""
+    with transaction.atomic(), connection.chunked_cursor() as cursor:
+        cursor.execute(query, args)
+        # the description of a server-side cursor is only known after the first fetch
+        batch = cursor.fetchmany(window_size)
+        columns = [c.name for c in cursor.description]
+        yield columns, _iter_chunked_rows(cursor, batch, window_size)
+
+
+def _iter_chunked_rows(cursor, batch, window_size):
+    while batch:
+        yield from batch
+        batch = cursor.fetchmany(window_size)

--- a/zentral/contrib/inventory/utils/db.py
+++ b/zentral/contrib/inventory/utils/db.py
@@ -1,9 +1,10 @@
 from contextlib import contextmanager
 import logging
-from django.db import connection, transaction
+from django.db import connections, transaction
 from zentral.contrib.inventory.compliance_checks import jmespath_checks_cache
 from zentral.contrib.inventory.events import (iter_inventory_events)
 from zentral.contrib.inventory.models import MachineSnapshotCommit
+from zentral.utils.db import get_read_only_database
 
 
 __all__ = [
@@ -107,7 +108,8 @@ def commit_machine_snapshot_and_yield_events(tree):
 @contextmanager
 def chunked_query(query, args, window_size):
     """Run a query on a server-side cursor, and read window_size rows for each round trip."""
-    with transaction.atomic(), connection.chunked_cursor() as cursor:
+    connection = connections[get_read_only_database()]
+    with transaction.atomic(using=connection.alias), connection.chunked_cursor() as cursor:
         cursor.execute(query, args)
         # the description of a server-side cursor is only known after the first fetch
         batch = cursor.fetchmany(window_size)

--- a/zentral/contrib/inventory/utils/machine_exports.py
+++ b/zentral/contrib/inventory/utils/machine_exports.py
@@ -6,10 +6,11 @@ import zipfile
 
 from django.core.files.storage import default_storage
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import connection, transaction
 from django.utils.text import slugify
 
 from zentral.utils.time import naive_utcnow
+
+from .db import chunked_query
 
 __all__ = [
     "export_machine_snapshots",
@@ -92,7 +93,6 @@ def export_machine_snapshots(source_name=None, window_size=5000):
         "order by s.name, ms.serial_number"
     )
 
-    columns = None
     json_files = []
     current_source_name = json_f = json_p = None
 
@@ -120,13 +120,8 @@ def export_machine_snapshots(source_name=None, window_size=5000):
                     del row_d[k]
         return row_d
 
-    # iter all rows over a server-side cursor
-    with transaction.atomic(), connection.chunked_cursor() as cursor:
-        cursor.itersize = window_size
-        cursor.execute(query, args)
-        for row in cursor:
-            if columns is None:
-                columns = [c.name for c in cursor.description]
+    with chunked_query(query, args, window_size) as (columns, rows):
+        for row in rows:
             row_d = dict(zip(columns, row))
             source_name = row_d["source"]["name"]
             if source_name != current_source_name:


### PR DESCRIPTION
Two commits.

## 1. Read the export cursors with an explicit fetch

`export_machine_snapshots`, and the machine applications exports through `_export_machine_csv_zip`, set `cursor.itersize = window_size` on a chunked cursor, then iterate the cursor. The assignment does nothing: `django.db.backends.utils.CursorWrapper` has no `__setattr__`, so the value stays on the wrapper, and the psycopg2 named cursor keeps its default window of 2000 rows. The `window_size` parameter of the two functions had no effect.

The two exports share one `chunked_query` helper now, in `zentral/contrib/inventory/utils/db.py`. It opens the transaction a server-side cursor needs, runs the query, and gives the columns and the rows, `cursor.fetchmany(window_size)` rows for each round trip. The exports read 5000 rows for each round trip, the window the code always declared. The archives do not change.

The two call sites also lose their `columns = None` preamble, and the test of it for each row: the helper reads the description after the first fetch, like `iter_tables` does.

#1695 removed the same `itersize` line from the full export, because the new code fetches explicitly. The full export keeps `iter_tables`: it runs many queries in one transaction, and it needs the types of the columns for the Parquet schema.

## 2. Read the machine exports on the read-only database

The two exports are the heaviest scans of the product. They walk the current snapshots and their application tables with a wide `ORDER BY` that spills. They take no lock, and they write nothing: the archive reaches the storage after the cursor is closed. `chunked_query` runs them on the database that `get_read_only_database` names, like the full export.

Where `POSTGRES_RO_HOST` is not set, `get_read_only_database` gives the default database, and nothing changes. Where it is set, note that a long read on a replica can be cancelled when it conflicts with recovery. The three inventory exports have the same behaviour now.

## Tests

- `test_export_machine_snapshots_window_size` and `test_export_machine_csv_zip_window_size` export 5 rows with `window_size=2`, and pin the fetches to `[(2, 2), (2, 2), (2, 1), (2, 0)]`. A recording `chunked_cursor` wraps `fetchmany` on the real cursor.
- `test_chunked_query_reads_the_read_only_database` pins the alias that the helper asks `connections` for.
- Each test was checked against a broken version of the code. The `itersize` assignment records `[]`, because the psycopg2 cursor iterates below the wrapper. A hardcoded window records `[(2000, 5), (2000, 0)]`. `connections["default"]` records `["default"]`.

No CHANGELOG entry: the exports write the same files, and no caller gives a `window_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
